### PR TITLE
feat: add -O,--output option to specify several output formats and files

### DIFF
--- a/docs/src/use/command-line-interface.md
+++ b/docs/src/use/command-line-interface.md
@@ -119,8 +119,9 @@ Handle Warnings:
   --max-warnings Int              Number of warnings to trigger nonzero exit code - default: -1
 
 Output:
+  -O, --output [[{fmt: String, to: Maybe String}]]           Specify multiple output formats and destinations - default: fmt:stylish
   -o, --output-file path::String  Specify file to write report to
-  -f, --format String             Use a specific output format - default: stylish
+  -f, --format String             Use a specific output format
   --color, --no-color             Force enabling/disabling of color
 
 Inline configuration comments:
@@ -609,12 +610,43 @@ When used alongside `--quiet`, this will cause rules marked as warn to still be 
 
 ### Output
 
+#### `-O`, `--output`
+
+Write the output of linting results to a specified file with specified format.
+
+- **Argument Type**: String. Key/value pair separated by colon (`:`). Supported keys are:
+
+    - `fmt` String. **Required**. One of the [built-in formatters](formatters/) or a custom formatter.
+    - `to` String. Path to file.
+
+- **Multiple Arguments**: Yes
+- **Default Value**: fmt:[`stylish`](formatters/#stylish)
+
+::: warning
+This option conflicts with the [`--format`](../use/command-line-interface#-f---format) and [`--output-file`](../use/command-line-interface#-o---output-file) options.
+:::
+
+##### `-O`, `--output` example
+
+Output results to the console in [`stylish`](formatters/#stylish) format, to the `results.json` file in [`json`](formatters/#json) format, and to the `results.html` file in custom HTML format:
+
+{{ npx_tabs ({
+package: "eslint",
+args: ["-O", "fmt:stylish", "-O", "fmt:json,to:results.json", "-O", "fmt:./customformat.js,to:results.html", "file.js"],
+}) }}
+
 #### `-o`, `--output-file`
 
 Write the output of linting results to a specified file.
 
 - **Argument Type**: String. Path to file.
 - **Multiple Arguments**: No
+
+::: warning
+This option conflicts with the [`--output`](../use/command-line-interface#-O---output) option.
+
+This option affects the behavior of the [`--format`](../use/command-line-interface#-f---format) option.
+:::
 
 ##### `-o`, `--output-file` example
 
@@ -629,7 +661,10 @@ This option specifies the output format for the console.
 
 - **Argument Type**: String. One of the [built-in formatters](formatters/) or a custom formatter.
 - **Multiple Arguments**: No
-- **Default Value**: [`stylish`](formatters/#stylish)
+
+::: warning
+This option conflicts with the [`--output`](../use/command-line-interface#-O---output) option.
+:::
 
 If you are using a custom formatter defined in a local file, you can specify the path to the custom formatter file.
 

--- a/docs/src/use/command-line-interface.md
+++ b/docs/src/use/command-line-interface.md
@@ -631,8 +631,8 @@ This option conflicts with the [`--format`](../use/command-line-interface#-f---f
 Output results to the console in [`stylish`](formatters/#stylish) format, to the `results.json` file in [`json`](formatters/#json) format, and to the `results.html` file in custom HTML format:
 
 {{ npx_tabs ({
-package: "eslint",
-args: ["-O", "fmt:stylish", "-O", "fmt:json,to:results.json", "-O", "fmt:./customformat.js,to:results.html", "file.js"],
+	package: "eslint",
+	args: ["-O", "fmt:stylish", "-O", "fmt:json,to:results.json", "-O", "fmt:./customformat.js,to:results.html", "file.js"]
 }) }}
 
 #### `-o`, `--output-file`

--- a/docs/src/use/command-line-interface.md
+++ b/docs/src/use/command-line-interface.md
@@ -643,7 +643,7 @@ Write the output of linting results to a specified file.
 - **Multiple Arguments**: No
 
 ::: warning
-This option conflicts with the [`--output`](../use/command-line-interface#-O---output) option.
+This option conflicts with the [`--output`](../use/command-line-interface#-o---output) option.
 
 This option affects the behavior of the [`--format`](../use/command-line-interface#-f---format) option.
 :::
@@ -663,7 +663,7 @@ This option specifies the output format for the console.
 - **Multiple Arguments**: No
 
 ::: warning
-This option conflicts with the [`--output`](../use/command-line-interface#-O---output) option.
+This option conflicts with the [`--output`](../use/command-line-interface#-o---output) option.
 :::
 
 If you are using a custom formatter defined in a local file, you can specify the path to the custom formatter file.

--- a/docs/src/use/command-line-interface.md
+++ b/docs/src/use/command-line-interface.md
@@ -670,7 +670,7 @@ If you are using a custom formatter defined in a local file, you can specify the
 
 An npm-installed formatter is resolved with or without `eslint-formatter-` prefix.
 
-When specified, the given format is output to the console. If you'd like to save that output into a file, you can do so on the command line like so:
+When specified, the given format is output to the console. If you'd like to save that output into a file, you can specify [`-o` (or `--output-file`)](../use/command-line-interface#-o---output-file) option or redirect console output like so:
 
 {{ npx_tabs ({
     package: "eslint",

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -339,6 +339,27 @@ async function isDirectory(filePath) {
 }
 
 /**
+ * Get outputs from CLI options.
+ * @param {ParsedCLIOptions} options CLI options.
+ * @returns {{format: string, outputFile: string}[]} List of output descriptors.
+ */
+function getOutputs(options) {
+	// options.output is mutually exclusive with options.format and options.outputFile.
+	if (options.format || options.outputFile) {
+		return [
+			{
+				format: options.format || "stylish",
+				outputFile: options.outputFile,
+			},
+		];
+	}
+	return options.output.map(({ fmt, to }) => ({
+		format: fmt,
+		outputFile: to,
+	}));
+}
+
+/**
  * Outputs the results of the linting.
  * @param {ESLint} engine The ESLint instance to use.
  * @param {LintResult[]} results The results to print.
@@ -709,15 +730,21 @@ const cli = {
 				}
 			: {};
 
-		if (
-			await printResults(
+		const outputs = getOutputs(options);
+		let printed = true;
+		for (const { format, outputFile } of outputs) {
+			printed = await printResults(
 				engine,
 				resultsToPrint,
-				options.format,
-				options.outputFile,
+				format,
+				outputFile,
 				resultsMeta,
-			)
-		) {
+			);
+			if (!printed) {
+				break;
+			}
+		}
+		if (printed) {
 			// Errors and warnings from the original unfiltered results should determine the exit code
 			const shouldExitForFatalErrors =
 				options.exitOnFatalError && resultCounts.fatalErrorCount > 0;

--- a/lib/options.js
+++ b/lib/options.js
@@ -43,6 +43,7 @@ const optionator = require("optionator");
  * @property {boolean} init Run config initialization wizard
  * @property {boolean} inlineConfig Prevent comments from changing config or rules
  * @property {number} maxWarnings Number of warnings to trigger nonzero exit code
+ * @property {Object[]} [output] Specify multiple output formats and destinations
  * @property {string} [outputFile] Specify file to write report to
  * @property {string} [parser] Specify the parser to be used
  * @property {Object} [parserOptions] Specify parser options
@@ -230,6 +231,7 @@ module.exports = function (usingFlatConfig) {
 			concatRepeatedArrays: true,
 			mergeRepeatedObjects: true,
 		},
+		mutuallyExclusive: [["output", ["format", "output-file"]]],
 		options: [
 			{
 				heading: "Basic configuration",
@@ -352,6 +354,19 @@ module.exports = function (usingFlatConfig) {
 				heading: "Output",
 			},
 			{
+				option: "output",
+				alias: "O",
+				type: "[{fmt: String, to: Maybe String}]",
+				default: "{fmt:stylish}",
+				description: "Specify multiple output formats and destinations",
+				concatRepeatedArrays: [
+					true,
+					{
+						oneValuePerFlag: true,
+					},
+				],
+			},
+			{
 				option: "output-file",
 				alias: "o",
 				type: "path::String",
@@ -361,7 +376,6 @@ module.exports = function (usingFlatConfig) {
 				option: "format",
 				alias: "f",
 				type: "String",
-				default: "stylish",
 				description: "Use a specific output format",
 			},
 			{

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -392,8 +392,18 @@ describe("cli", () => {
 				});
 
 				describe("when given two valid formatter names, one with output parameter.", () => {
+					const originalCwd = process.cwd;
+
+					beforeEach(() => {
+						process.cwd = () => getFixturePath();
+					});
+
 					afterEach(() => {
-						sh.rm("-rf", "tests/output");
+						sh.rm(
+							"-rf",
+							path.resolve(process.cwd(), "tests/output"),
+						);
+						process.cwd = originalCwd;
 					});
 
 					it(`should execute both without any errors with configType:${configType}`, async () => {
@@ -423,14 +433,13 @@ describe("cli", () => {
 						assert.strictEqual(log.info.callCount, 1);
 						assert.strictEqual(log.info.getCall(0).args[0], cwd);
 
-						assert.isTrue(
-							fs.existsSync("tests/output/eslint-output.txt"),
+						const outFilePath = path.resolve(
+							process.cwd(),
+							"tests/output/eslint-output.txt",
 						);
+						assert.isTrue(fs.existsSync(outFilePath));
 						assert.strictEqual(
-							fs.readFileSync(
-								"tests/output/eslint-output.txt",
-								"utf8",
-							),
+							fs.readFileSync(outFilePath, "utf8"),
 							"from async formatter",
 						);
 					});

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -424,7 +424,13 @@ describe("cli", () => {
 							useFlatConfig,
 						);
 
-						assert.strictEqual(exit, 0);
+						assert.strictEqual(
+							exit,
+							0,
+							log.error.printf("ERR:\n%C") +
+								log.warn.printf("WARN:\n%C") +
+								log.info.printf("INFO:\n%C"),
+						);
 
 						assert.isTrue(
 							log.info.called,

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -64,6 +64,40 @@ describe("options", () => {
 				});
 			});
 
+			describe("--output", () => {
+				it("should return an array with one element for .output when passed a string", () => {
+					const currentOptions = options.parse(
+						"--output fmt:json,to:out.json",
+					);
+
+					assert.isArray(currentOptions.output);
+					assert.deepStrictEqual(currentOptions.output, [
+						{ fmt: "json", to: "out.json" },
+					]);
+				});
+
+				it("should return an array with two items for .output when passed two strings", () => {
+					const currentOptions = options.parse(
+						"--output fmt:json,to:out.json --output fmt:html",
+					);
+
+					assert.isArray(currentOptions.output);
+					assert.deepStrictEqual(currentOptions.output, [
+						{ fmt: "json", to: "out.json" },
+						{ fmt: "html" },
+					]);
+				});
+
+				it("should return single '{fmt: \"stylish\"}' for .output when not passed", () => {
+					const currentOptions = options.parse("");
+
+					assert.isArray(currentOptions.output);
+					assert.deepStrictEqual(currentOptions.output, [
+						{ fmt: "stylish" },
+					]);
+				});
+			});
+
 			describe("--format", () => {
 				it("should return a string for .format when passed a string", () => {
 					const currentOptions = options.parse("--format json");
@@ -72,11 +106,10 @@ describe("options", () => {
 					assert.strictEqual(currentOptions.format, "json");
 				});
 
-				it("should return stylish for .format when not passed", () => {
+				it("should return nothing for .format when not passed", () => {
 					const currentOptions = options.parse("");
 
-					assert.isString(currentOptions.format);
-					assert.strictEqual(currentOptions.format, "stylish");
+					assert.isUndefined(currentOptions.format);
 				});
 			});
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[X] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #8185 #13244 #14260

Refs #10707

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This pull request introduces new CLI option `-O` (`--output`) to specify several output formats and files, for example:
```
$ eslint --output fmt:stylish -O fmt:json,to:results.json -O fmt:./customformat.js,to:results.html ./src
```

This pull request _intentionally_ does not add the ability to customize the output via an eslint configuration file.

The `--output` option cannot be specified alongside with `--format` or `--output-file` options. 

The default behavior is unchanged. If you do not specify the above options, the result will be printed to the console in `stylish` format:
```
$ eslint ./src
```

Specifying the `--format` and `--output-file` options in any combination without specifying the `--output` option also works as before.

#### Is there anything you'd like reviewers to focus on?

My first attempt was to make the `--format` option accepted multiple times, and change it so that it could accept an optional output file parameter, like this:
```
$ eslint --format fmt:stylish -f json=results.json -f ./customformat.js=results.html ./src
```

However, the new `--output` option is easier to parse and validate, and could be extended in the future, for example by adding `append:true` parameter or passing formatting parameters directly to the formatter via the CLI.

<!-- markdownlint-disable-file MD004 -->
