### PR TITLE
test: resolve flakiness in --mcp flag test

### DIFF
--- a/tests/bin/eslint.js
+++ b/tests/bin/eslint.js
@@ -1343,6 +1343,7 @@ describe("bin/eslint.js", () => {
 	describe("MCP server", () => {
 		it("should start the MCP server when the --mcp flag is used", done => {
 			const child = runESLint(["--mcp"]);
+			let doneCalled = false;
 
 			// should not have anything on std out
 			child.stdout.on("data", data => {
@@ -1350,8 +1351,11 @@ describe("bin/eslint.js", () => {
 			});
 
 			child.stderr.on("data", data => {
-				assert.match(data.toString(), /@eslint\/mcp/u);
-				done();
+				if (!doneCalled) {
+					assert.match(data.toString(), /@eslint\/mcp/u);
+					doneCalled = true;
+					done();
+				}
 			});
 		});
 	});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

This PR resolves a flakiness issue in the test for starting the MCP server with the --mcp flag.

The test failed intermittently with the error `done() called multiple times`. This was because the stderr stream's data event could fire more than once, causing the `done()` callback to be executed for each chunk of data.

#### What changes did you make? (Give an overview)

I introduced a boolean flag, `doneCalled`, to ensure that the `done()` callback is only executed a single time.

#### Is there anything you'd like reviewers to focus on?

See #19951

<!-- markdownlint-disable-file MD004 -->
