### PR TITLE
docs: add `plugin.configs` to docs around shareable to configs

### DIFF
--- a/docs/src/extend/shareable-configs.md
+++ b/docs/src/extend/shareable-configs.md
@@ -65,6 +65,12 @@ You should declare your dependency on ESLint in the `package.json` using the [pe
 
 If your shareable config depends on a plugin or a custom parser, you should specify these packages as `dependencies` in your `package.json`.
 
+::: tip
+
+If you are publishing a config as part of a _plugin_, be sure to [add it to the `plugin.configs` property](./plugins#configs-in-plugins).
+
+:::
+
 ## Using a Shareable Config
 
 To use a shareable config, import the package inside of an `eslint.config.js` file and add it into the exported array using `extends`, like this:


### PR DESCRIPTION
#### Prerequisites checklist

- [ ] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

fixes https://github.com/eslint/eslint/issues/18095

#### What changes did you make? (Give an overview)

Add tip to inform people publishing a shareable config to add it to `plugin.configs` if they're publishing a config.

#### Is there anything you'd like reviewers to focus on?

