### PR TITLE
ci: fix `stale.yml`

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,7 +4,9 @@ on:
     schedule:
         - cron: "31 22 * * *" # Runs every day at 10:31 PM UTC
 
-permissions: read-all
+permissions:
+    issues: write
+    pull-requests: write
 
 jobs:
     stale:


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Hi,

Currently, the `stale.yml` workflow is not working for the following reasons:

https://github.com/eslint/eslint/actions/runs/16978244500

<img width="1562" height="592" alt="image" src="https://github.com/user-attachments/assets/193ab5ab-0ca3-4814-aca3-ffd11d4335f9" />

---

I think this error is caused by a mismatch between the top-level permissions and the reusable workflow's permissions.

The top-level permissions are set to `read`, but the reusable workflow requests `issues: write` and `pull_requests: write`, which causes a conflict.

Reusable workflow reference: https://github.com/eslint/workflows/blob/main/.github/workflows/stale.yml#L17-L19

---

In my initial PR at https://github.com/eslint/eslint/pull/19994, I left the `permissions: read-all` field as is, since, unlike other ESLint repositories, the `eslint` repository's `trunk` tool showed an error when the `permissions` field was not set for the workflows.

So, I thought it would work fine with `permissions: read-all` set, since the previous workflow worked well with this permission.

https://github.com/eslint/eslint/pull/19994/files

<img width="1867" height="858" alt="image" src="https://github.com/user-attachments/assets/a9bdb723-3f02-4bb6-9ec5-f3c49dec45ea" />

But it didn't work. I'm not sure how the `job`-level workflow permissions override the top-level workflow permissions, but it seems like the reusable workflow's `job`-level permissions are affected by the top-level permissions, which I think is causing the error.

#### Is there anything you'd like reviewers to focus on?

When I tested the reusable workflow in my personal repository, it worked fine.

For your reference, the workflow also failed in my personal repository when `permissions: read-all` was set.

- Succeeded: https://github.com/lumirlumir/test-update-readme/actions/runs/16988260489
- Failed: https://github.com/lumirlumir/test-update-readme/actions/runs/16988283957

<!-- markdownlint-disable-file MD004 -->
