### PR TITLE
fix: [no-empty] allow empty switch statements with comment

### DIFF
--- a/docs/src/rules/no-empty.md
+++ b/docs/src/rules/no-empty.md
@@ -55,6 +55,10 @@ while (foo) {
     /* empty */
 }
 
+switch(foo) {
+	/* empty */
+}
+
 try {
     doSomething();
 } catch (ex) {

--- a/lib/rules/no-empty.js
+++ b/lib/rules/no-empty.js
@@ -104,10 +104,45 @@ module.exports = {
 					typeof node.cases === "undefined" ||
 					node.cases.length === 0
 				) {
+					const switchBlockStartToken = sourceCode.getTokenAfter(
+						node.discriminant,
+						token => token.value === "{",
+					);
+
+					const commentAfterSwitchBlockStart =
+						sourceCode.getCommentsAfter(switchBlockStartToken);
+
+					const hasCommentInsideSwitch =
+						commentAfterSwitchBlockStart.some(
+							comment => comment.range[0] < node.range[1],
+						);
+
+					// block is only allowed to be empty, if it contains a comment
+					if (hasCommentInsideSwitch) {
+						return;
+					}
+
 					context.report({
 						node,
 						messageId: "unexpected",
 						data: { type: "switch" },
+						suggest: [
+							{
+								messageId: "suggestComment",
+								data: { type: "switch" },
+								fix(fixer) {
+									const range = [
+										switchBlockStartToken.range[1],
+										node.range[1] - 1,
+									];
+
+									return fixer.replaceTextRange(
+										range,
+										" /* empty */ ",
+									);
+								},
+							},
+						],
 					});
 				}
 			},

--- a/tests/lib/rules/no-empty.js
+++ b/tests/lib/rules/no-empty.js
@@ -172,7 +172,8 @@ ruleTester.run("no-empty", rule, {
 			],
 		},
 		{
-			code: "switch (/* empty */ foo /* empty */) /* empty */ { }",
+			// comments everywhere except the body of the switch
+			code: "switch /* empty */ (/* empty */ foo /* empty */) /* empty */ { } /* empty */",
 			errors: [
 				{
 					messageId: "unexpected",
@@ -182,7 +183,7 @@ ruleTester.run("no-empty", rule, {
 						{
 							messageId: "suggestComment",
 							data: { type: "switch" },
-							output: "switch (/* empty */ foo /* empty */) /* empty */ { /* empty */ }",
+							output: "switch /* empty */ (/* empty */ foo /* empty */) /* empty */ { /* empty */ } /* empty */",
 						},
 					],
 				},

--- a/tests/lib/rules/no-empty.js
+++ b/tests/lib/rules/no-empty.js
@@ -25,6 +25,8 @@ ruleTester.run("no-empty", rule, {
 		"for (;foo;) { bar() }",
 		"try { foo() } catch (ex) { foo() }",
 		"switch(foo) {case 'foo': break;}",
+		"switch (foo) { /* empty */ }",
+
 		"(function() { }())",
 		{ code: "var foo = () => {};", languageOptions: { ecmaVersion: 6 } },
 		"function foo() { }",
@@ -159,18 +161,30 @@ ruleTester.run("no-empty", rule, {
 					messageId: "unexpected",
 					data: { type: "switch" },
 					type: "SwitchStatement",
-					suggestions: null,
+					suggestions: [
+						{
+							messageId: "suggestComment",
+							data: { type: "switch" },
+							output: "switch(foo) { /* empty */ }",
+						},
+					],
 				},
 			],
 		},
 		{
-			code: "switch (foo) { /* empty */ }",
+			code: "switch (/* empty */ foo /* empty */) /* empty */ { }",
 			errors: [
 				{
 					messageId: "unexpected",
 					data: { type: "switch" },
 					type: "SwitchStatement",
-					suggestions: null,
+					suggestions: [
+						{
+							messageId: "suggestComment",
+							data: { type: "switch" },
+							output: "switch (/* empty */ foo /* empty */) /* empty */ { /* empty */ }",
+						},
+					],
 				},
 			],
 		},


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

fix #20000 

#### What changes did you make? (Give an overview)

Alternative option to #20020. Awaiting response to https://github.com/eslint/eslint/issues/20000#issuecomment-3185645814 to know which PR to go with.

Rather than documenting it, this PR fixes the unexpected behavior and adds comment detection to switch statements in no-empty. Includes corresponding suggestion fixer.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
