### PR TITLE
fix: fix spurious failure in neostandard integration test

### DIFF
--- a/.github/workflows/types-integration.yml
+++ b/.github/workflows/types-integration.yml
@@ -67,7 +67,7 @@ jobs:
             - name: Install Packages (neostandard)
               working-directory: neostandard
               run: |
-                  npm ci && npm install eslint@file:../eslint
+                  npm ci && npm install --no-save ../eslint
 
             - name: Run TSC
               working-directory: neostandard


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

fix #20022

#### What changes did you make? (Give an overview)

`npm i --no-package-lock ../eslint` installs _all_ packages without regard to the package lock, not just eslint (not super obvious from [the docs](https://docs.npmjs.com/cli/v11/commands/npm-install) tbh). This caused neostandard to fail, since they'll have a type error when they upgrade to `typescript-eslint@8.40.0`. 

Instead, this change installs all packages according to package lock, but then adds the local `eslint`, thus only testing whether `eslint` causes a regression.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
