### PR TITLE
fix: default value of accessor-pairs option in rule.d.ts file

### DIFF
--- a/lib/types/rules.d.ts
+++ b/lib/types/rules.d.ts
@@ -117,7 +117,7 @@ export interface ESLintRules extends Linter.RulesRecord {
 				 */
 				enforceForClassMembers: boolean;
 				/**
-				 * @default true
+				 * @default false
 				 */
 				enforceForTSTypes: boolean;
 			}>,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
changed the default value of `enforceForTSTypes` option of `accessor-pairs` rule in `rule.d.ts` file to `false` which is `true` right now.

https://github.com/eslint/eslint/blob/676f4acaaed6e4f6ffe0c2e21272d4702b311a7b/lib/rules/accessor-pairs.js#L149-L156

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
