### PR TITLE
refactor: prefer default options in `grouped-accessor-pairs`

### DIFF
--- a/lib/types/rules.d.ts
+++ b/lib/types/rules.d.ts
@@ -948,7 +948,6 @@ export interface ESLintRules extends Linter.RulesRecord {
 	 * @since 6.7.0
 	 * @see https://eslint.org/docs/latest/rules/grouped-accessor-pairs
 	 */
-
 	"grouped-accessor-pairs": Linter.RuleEntry<
 		[
 			"anyOrder" | "getBeforeSet" | "setBeforeGet",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Hi,

In this PR, I've updated `grouped-accessor-pairs` to use ESLint's default options instead of a custom nullish coalescing logic.

According to the documentation and as I understand it, user-provided options are applied on top of the defaults, so there's no need to use nullish coalescing to set default values.

https://eslint.org/docs/latest/extend/custom-rules#rule-structure

<img width="773" height="70" alt="image" src="https://github.com/user-attachments/assets/490bff7f-308b-4f8b-bd06-e861df9b763f" />

I'm not used to JavaScript codebases, so my conventions might differ from the team's. Please feel free to let me know if anything is out of sync.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
