### PR TITLE
fix: correct types for `no-restricted-imports` rule

### DIFF
--- a/lib/types/rules.d.ts
+++ b/lib/types/rules.d.ts
@@ -60,25 +60,19 @@ type EitherGroupOrRegEx =
 // Base type for import name specifiers, ensuring mutual exclusivity
 type EitherNameSpecifiers =
 	| {
-			importNames: string[];
+			importNames?: string[];
+			importNamePattern?: string;
 			allowImportNames?: never;
-			importNamePattern?: never;
 			allowImportNamePattern?: never;
 	  }
 	| {
-			importNamePattern: string;
-			allowImportNames?: never;
-			importNames?: never;
-			allowImportNamePattern?: never;
-	  }
-	| {
-			allowImportNames: string[];
+			allowImportNames?: string[];
 			importNames?: never;
 			importNamePattern?: never;
 			allowImportNamePattern?: never;
 	  }
 	| {
-			allowImportNamePattern: string;
+			allowImportNamePattern?: string;
 			importNames?: never;
 			allowImportNames?: never;
 			importNamePattern?: never;
@@ -3441,9 +3435,9 @@ export interface ESLintRules extends Linter.RulesRecord {
 						paths: Array<
 							string | ValidNoRestrictedImportPathOptions
 						>;
-						patterns: Array<
-							string | ValidNoRestrictedImportPatternOptions
-						>;
+						patterns:
+							| Array<string>
+							| Array<ValidNoRestrictedImportPatternOptions>;
 				  }>
 			>,
 		]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

Fixes types for the `patterns` option of the `no-restricted-imports` rule.

#### What changes did you make? (Give an overview)

* A patterns object should be valid without either of `importNames`, `importNamePattern`, `allowImportNames` or `allowImportNamePattern` specified. For example, `"no-restricted-imports": [2, { patterns: [{ group: ["foo"] }] }]` was invalid before this change.
* `importNames` and `importNamePattern` can be specified in the same object. For example, `"no-restricted-imports": [2, { patterns: [{ group: ["foo"], importNames: ["bar"], importNamePattern: "baz" }] }]` was invalid before this change.
* Mixing strings and objects is not allowed. For example, `"no-restricted-imports": [2, { patterns: [{ group: ["foo"], importNames: ["bar"]}, "bar"] }]` was valid before this change.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
