### PR TITLE
feat!: remove eslintrc support from CLI

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -174,8 +174,7 @@ ${getErrorMessage(error)}`;
 	const cli = require("../lib/cli");
 	const exitCode = await cli.execute(
 		process.argv,
-		process.argv.includes("--stdin") ? await readStdin() : null,
-		true,
+		process.argv.includes("--stdin") ? await readStdin() : void 0,
 	);
 
 	/*

--- a/docs/src/use/command-line-interface.md
+++ b/docs/src/use/command-line-interface.md
@@ -46,7 +46,7 @@ Please note that when passing a glob as a parameter, it is expanded by your shel
     args: ["\"lib/**\""]
 }) }}
 
-If you are using a [flat configuration file](./configure/configuration-files) (`eslint.config.js`), you can also omit the file arguments and ESLint will use `.`. For instance, these two lines perform the same operation:
+You can also omit the file arguments and ESLint will use `.`. For instance, these two lines perform the same operation:
 
 {{ npx_tabs ({
     package: "eslint",
@@ -57,8 +57,6 @@ If you are using a [flat configuration file](./configure/configuration-files) (`
     package: "eslint",
     args: []
 }) }}
-
-If you are not using a flat configuration file, running ESLint without file arguments results in an error.
 
 **Note:** You can also use alternative package managers such as [Yarn](https://yarnpkg.com/) or [pnpm](https://pnpm.io/) to run ESLint. For pnpm use `pnpm dlx eslint` and for Yarn use `yarn dlx eslint`.
 
@@ -162,7 +160,7 @@ Miscellaneous:
 
 #### `--no-config-lookup`
 
-**Flat Config Mode Only.** Disables use of configuration from files.
+Disables use of configuration from files.
 
 - **Argument Type**: No argument.
 
@@ -171,19 +169,6 @@ Miscellaneous:
 {{ npx_tabs ({
     package: "eslint",
     args: ["--no-config-lookup", "file.js"]
-}) }}
-
-#### `--no-eslintrc`
-
-**eslintrc Mode Only.** Disables use of configuration from `.eslintrc.*` and `package.json` files. For flat config mode, use [`--no-config-lookup`](#--no-config-lookup) instead.
-
-- **Argument Type**: No argument.
-
-##### `--no-eslintrc` example
-
-{{ npx_tabs ({
-    package: "eslint",
-    args: ["--no-eslintrc", "file.js"]
 }) }}
 
 #### `-c`, `--config`
@@ -204,7 +189,7 @@ This example uses the configuration file at `~/my.eslint.config.js`, which is us
 
 #### `--inspect-config`
 
-**Flat Config Mode Only.** This option runs `npx @eslint/config-inspector@latest` to start the [config inspector](https://github.com/eslint/config-inspector). You can use the config inspector to better understand what your configuration is doing and which files it applies to. When you use this flag, the CLI does not perform linting.
+This option runs `npx @eslint/config-inspector@latest` to start the [config inspector](https://github.com/eslint/config-inspector). You can use the config inspector to better understand what your configuration is doing and which files it applies to. When you use this flag, the CLI does not perform linting.
 
 - **Argument Type**: No argument.
 
@@ -213,27 +198,6 @@ This example uses the configuration file at `~/my.eslint.config.js`, which is us
 {{ npx_tabs ({
     package: "eslint",
     args: ["--inspect-config"]
-}) }}
-
-#### `--env`
-
-**eslintrc Mode Only.** This option enables specific environments.
-
-- **Argument Type**: String. One of the available environments.
-- **Multiple Arguments**: Yes
-
-Details about the global variables defined by each environment are available in the [Specifying Environments](configure/language-options-deprecated#specifying-environments) documentation. This option only enables environments. It does not disable environments set in other configuration files. To specify multiple environments, separate them using commas, or use the option multiple times.
-
-##### `--env` example
-
-{{ npx_tabs ({
-    package: "eslint",
-    args: ["--env", "browser,node", "file.js"]
-}) }}
-
-{{ npx_tabs ({
-    package: "eslint",
-    args: ["--env", "browser", "--env", "node", "file.js"]
 }) }}
 
 #### `--ext`
@@ -324,28 +288,6 @@ This option allows you to specify parser options to be used by ESLint. The avail
     previousCommands: ["echo \'3 ** 4\'"]
 }) }}
 
-#### `--resolve-plugins-relative-to`
-
-**eslintrc Mode Only.** Changes the directory where plugins are resolved from.
-
-- **Argument Type**: String. Path to directory.
-- **Multiple Arguments**: No
-- **Default Value**: By default, plugins are resolved from the directory in which your configuration file is found.
-
-This option should be used when plugins were installed by someone other than the end user. It should be set to the project directory of the project that has a dependency on the necessary plugins.
-
-For example:
-
-- When using a config file that is located outside of the current project (with the `--config` flag), if the config uses plugins which are installed locally to itself, `--resolve-plugins-relative-to` should be set to the directory containing the config file.
-- If an integration has dependencies on ESLint and a set of plugins, and the tool invokes ESLint on behalf of the user with a preset configuration, the tool should set `--resolve-plugins-relative-to` to the top-level directory of the tool.
-
-##### `--resolve-plugins-relative-to` example
-
-{{ npx_tabs ({
-    package: "eslint",
-    args: ["--config", "~/personal-eslintrc.js", "--resolve-plugins-relative-to", "/usr/local/lib/"]
-}) }}
-
 ### Specify Rules and Plugins
 
 #### `--plugin`
@@ -404,29 +346,6 @@ To ignore rules in configuration files and only run rules specified in the comma
     package: "eslint",
     args: ["--rule", "\'quotes: [error, double]\'", "--no-config-lookup"],
     comment: "Only apply rule from the command line"
-}) }}
-
-#### `--rulesdir`
-
-**Deprecated**: Use [rules from custom plugins](https://eslint.org/blog/2022/08/new-config-system-part-2/#from---rulesdir-to-runtime-plugins) instead.
-
-**eslintrc Mode Only.** This option allows you to specify another directory from which to load rules files. This allows you to dynamically load new rules at run time. This is useful when you have custom rules that aren't suitable for being bundled with ESLint.
-
-- **Argument Type**: String. Path to directory. The rules in your custom rules directory must follow the same format as bundled rules to work properly.
-- **Multiple Arguments**: Yes
-
-Note that, as with core rules and plugin rules, you still need to enable the rules in configuration or via the `--rule` CLI option in order to actually run those rules during linting. Specifying a rules directory with `--rulesdir` does not automatically enable the rules within that directory.
-
-##### `--rulesdir` example
-
-{{ npx_tabs ({
-    package: "eslint",
-    args: ["--rulesdir", "my-rules/", "file.js"]
-}) }}
-
-{{ npx_tabs ({
-    package: "eslint",
-    args: ["--rulesdir", "my-rules/", "--rulesdir", "my-other-rules/", "file.js"]
 }) }}
 
 ### Fix Problems
@@ -501,31 +420,9 @@ This option is helpful if you are using another program to format your code, but
 
 ### Ignore Files
 
-#### `--ignore-path`
-
-**eslintrc Mode Only.** This option allows you to specify the file to use as your `.eslintignore`.
-
-- **Argument Type**: String. Path to file.
-- **Multiple Arguments**: No
-- **Default Value**: By default, ESLint looks for `.eslintignore` in the current working directory.
-
-**Note:** `--ignore-path` is only supported when using [deprecated configuration](./configure/configuration-files-deprecated). If you want to include patterns from a `.gitignore` file in your `eslint.config.js` file, please see [including `.gitignore` files](./configure/ignore#including-gitignore-files).
-
-##### `--ignore-path` example
-
-{{ npx_tabs ({
-    package: "eslint",
-    args: ["--ignore-path", "tmp/.eslintignore", "file.js"]
-}) }}
-
-{{ npx_tabs ({
-    package: "eslint",
-    args: ["--ignore-path", ".gitignore", "file.js"]
-}) }}
-
 #### `--no-ignore`
 
-Disables excluding of files from [`--ignore-pattern`](#--ignore-pattern) flags and the `ignores` property in configuration. In eslintrc mode, `.eslintignore` files, [`--ignore-path`](#--ignore-path) flags, and the `ignorePatterns` property in configuration are also disabled.
+Disables excluding of files from [`--ignore-pattern`](#--ignore-pattern) flags and the `ignores` property in configuration.
 
 - **Argument Type**: No argument.
 
@@ -538,9 +435,9 @@ Disables excluding of files from [`--ignore-pattern`](#--ignore-pattern) flags a
 
 #### `--ignore-pattern`
 
-This option allows you to specify patterns of files to ignore. In eslintrc mode, these are in addition to `.eslintignore`.
+This option allows you to specify patterns of files to ignore.
 
-- **Argument Type**: String. The supported syntax is the same as for [`ignores` patterns](configure/configuration-files#excluding-files-with-ignores), which use [minimatch](https://www.npmjs.com/package/minimatch) syntax. In eslintrc mode, the syntax is the same as for [`.eslintignore` files](configure/ignore-deprecated#the-eslintignore-file), which use the same patterns as the [`.gitignore` specification](https://git-scm.com/docs/gitignore). You should quote your patterns in order to avoid shell interpretation of glob patterns.
+- **Argument Type**: String. The supported syntax is the same as for [`ignores` patterns](configure/configuration-files#excluding-files-with-ignores), which use [minimatch](https://www.npmjs.com/package/minimatch) syntax. You should quote your patterns in order to avoid shell interpretation of glob patterns.
 - **Multiple Arguments**: Yes
 
 ##### `--ignore-pattern` example
@@ -989,7 +886,7 @@ This option causes ESLint to exit with exit code 2 if one or more fatal parsing 
 
 #### `--no-warn-ignored`
 
-**Flat Config Mode Only.** This option suppresses both `File ignored by default` and `File ignored because of a matching ignore pattern` warnings when an ignored filename is passed explicitly. It is useful when paired with `--max-warnings 0` as it will prevent exit code 1 due to the aforementioned warning.
+This option suppresses both `File ignored by default` and `File ignored because of a matching ignore pattern` warnings when an ignored filename is passed explicitly. It is useful when paired with `--max-warnings 0` as it will prevent exit code 1 due to the aforementioned warning.
 
 - **Argument Type**: No argument.
 
@@ -1002,7 +899,7 @@ This option causes ESLint to exit with exit code 2 if one or more fatal parsing 
 
 #### `--pass-on-no-patterns`
 
-This option allows ESLint to exit with code 0 when no file or directory patterns are passed. Without this option, ESLint assumes you want to use `.` as the pattern. (When running in legacy eslintrc mode, ESLint will exit with code 1.)
+This option allows ESLint to exit with code 0 when no file or directory patterns are passed. Without this option, ESLint assumes you want to use `.` as the pattern.
 
 - **Argument Type**: No argument.
 

--- a/docs/src/use/configure/configuration-files-deprecated.md
+++ b/docs/src/use/configure/configuration-files-deprecated.md
@@ -432,4 +432,4 @@ If `eslint` could find configuration files in the project, `eslint` ignores `~/.
 
 `~/.eslintrc.*` files load shareable configs and custom parsers from `~/node_modules/` – similarly to `require()` – in the user's home directory. Please note that it doesn't load global-installed packages.
 
-`~/.eslintrc.*` files load plugins from `$CWD/node_modules` by default in order to identify plugins uniquely. If you want to use plugins with `~/.eslintrc.*` files, plugins must be installed locally per project. Alternatively, you can use the [`--resolve-plugins-relative-to` CLI option](../command-line-interface#--resolve-plugins-relative-to) to change the location from which ESLint loads plugins.
+`~/.eslintrc.*` files load plugins from `$CWD/node_modules` by default in order to identify plugins uniquely. If you want to use plugins with `~/.eslintrc.*` files, plugins must be installed locally per project. Alternatively, you can use the `--resolve-plugins-relative-to` CLI option to change the location from which ESLint loads plugins.

--- a/docs/src/use/migrating-to-6.0.0.md
+++ b/docs/src/use/migrating-to-6.0.0.md
@@ -98,7 +98,7 @@ As a rule of thumb: With ESLint v6, plugins should always be installed locally, 
 
 **To address:** If you use a global installation of ESLint (e.g. installed with `npm install eslint --global`) along with plugins, you should install those plugins locally in the projects where you run ESLint. If your config file extends shareable configs and/or parsers, you should ensure that those packages are installed as dependencies of the project containing the config file.
 
-If you use a config file located outside of a local project (with the `--config` flag), consider installing the plugins as dependencies of that config file, and setting the [`--resolve-plugins-relative-to`](./command-line-interface#--resolve-plugins-relative-to) flag to the location of the config file.
+If you use a config file located outside of a local project (with the `--config` flag), consider installing the plugins as dependencies of that config file, and setting the `--resolve-plugins-relative-to` flag to the location of the config file.
 
 **Related issue(s):** [eslint/eslint#10125](https://github.com/eslint/eslint/issues/10125), [eslint/rfcs#7](https://github.com/eslint/rfcs/pull/7)
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -19,12 +19,7 @@ const fs = require("node:fs"),
 	{ mkdir, stat, writeFile } = require("node:fs/promises"),
 	path = require("node:path"),
 	{ pathToFileURL } = require("node:url"),
-	{ LegacyESLint } = require("./eslint"),
-	{
-		ESLint,
-		shouldUseFlatConfig,
-		locateConfigFileToUse,
-	} = require("./eslint/eslint"),
+	{ ESLint, locateConfigFileToUse } = require("./eslint/eslint"),
 	createCLIOptions = require("./options"),
 	log = require("./shared/logging"),
 	RuntimeInfo = require("./shared/runtime-info"),
@@ -76,7 +71,7 @@ function createOptionsModule(options) {
 	).href;
 	const optionsSrc =
 		`import translateOptions from ${JSON.stringify(translateOptionsFileURL)};\n` +
-		`export default await translateOptions(${JSON.stringify(options)}, "flat");\n`;
+		`export default await translateOptions(${JSON.stringify(options)});\n`;
 
 	// Base64 encoding is typically shorter than URL encoding
 	return new URL(
@@ -199,32 +194,14 @@ const cli = {
 	 * Executes the CLI based on an array of arguments that is passed in.
 	 * @param {string|Array|Object} args The arguments to process.
 	 * @param {string} [text] The text to lint (used for TTY).
-	 * @param {boolean} [allowFlatConfig=true] Whether or not to allow flat config.
 	 * @returns {Promise<number>} The exit code for the operation.
 	 */
-	async execute(args, text, allowFlatConfig = true) {
+	async execute(args, text) {
 		if (Array.isArray(args)) {
 			debug("CLI args: %o", args.slice(2));
 		}
 
-		/*
-		 * Before doing anything, we need to see if we are using a
-		 * flat config file. If so, then we need to change the way command
-		 * line args are parsed. This is temporary, and when we fully
-		 * switch to flat config we can remove this logic.
-		 */
-
-		const usingFlatConfig =
-			allowFlatConfig && (await shouldUseFlatConfig());
-
-		debug("Using flat config?", usingFlatConfig);
-
-		if (allowFlatConfig && !usingFlatConfig) {
-			const { WarningService } = require("./services/warning-service");
-			new WarningService().emitESLintRCWarning();
-		}
-
-		const CLIOptions = createCLIOptions(usingFlatConfig);
+		const CLIOptions = createCLIOptions();
 
 		/** @type {ParsedCLIOptions} */
 		let options;
@@ -235,12 +212,9 @@ const cli = {
 		} catch (error) {
 			debug("Error parsing CLI options:", error.message);
 
-			let errorMessage = error.message;
-
-			if (usingFlatConfig) {
-				errorMessage +=
-					"\nYou're using eslint.config.js, some command line flags are no longer available. Please see https://eslint.org/docs/latest/use/command-line-interface for details.";
-			}
+			const errorMessage = `${
+				error.message
+			}\nYou're using eslint.config.js, some command line flags are no longer available. Please see https://eslint.org/docs/latest/use/command-line-interface for details.`;
 
 			log.error(errorMessage);
 			return 2;
@@ -282,9 +256,7 @@ const cli = {
 				return 2;
 			}
 
-			const engine = usingFlatConfig
-				? new ESLint(await translateOptions(options, "flat"))
-				: new LegacyESLint(await translateOptions(options));
+			const engine = new ESLint(await translateOptions(options));
 			const fileConfig = await engine.calculateConfigForFile(
 				options.printConfig,
 			);
@@ -299,7 +271,7 @@ const cli = {
 			);
 
 			try {
-				const flatOptions = await translateOptions(options, "flat");
+				const flatOptions = await translateOptions(options);
 				const spawn = require("cross-spawn");
 				const flags = await cli.calculateInspectConfigFlags(
 					flatOptions.overrideConfigFile,
@@ -349,7 +321,7 @@ const cli = {
 			return 2;
 		}
 
-		if (usingFlatConfig && options.ext) {
+		if (options.ext) {
 			// Passing `--ext ""` results in `options.ext` being an empty array.
 			if (options.ext.length === 0) {
 				log.error("The --ext option value cannot be empty.");
@@ -400,29 +372,21 @@ const cli = {
 			return 2;
 		}
 
-		const ActiveESLint = usingFlatConfig ? ESLint : LegacyESLint;
-
-		/** @type {ESLint|LegacyESLint} */
+		/** @type {ESLint} */
 		let engine;
 
 		if (options.concurrency && options.concurrency !== "off") {
 			const optionsURL = createOptionsModule(options);
 			engine = await ESLint.fromOptionsModule(optionsURL);
 		} else {
-			const eslintOptions = await translateOptions(
-				options,
-				usingFlatConfig ? "flat" : "eslintrc",
-			);
-			engine = new ActiveESLint(eslintOptions);
+			const eslintOptions = await translateOptions(options);
+			engine = new ESLint(eslintOptions);
 		}
 		let results;
 
 		if (useStdin) {
 			results = await engine.lintText(text, {
 				filePath: options.stdinFilename,
-
-				// flatConfig respects CLI flag and constructor warnIgnored, eslintrc forces true for backwards compatibility
-				warnIgnored: usingFlatConfig ? void 0 : true,
 			});
 		} else {
 			results = await engine.lintFiles(files);
@@ -430,7 +394,7 @@ const cli = {
 
 		if (options.fix) {
 			debug("Fix mode enabled - applying fixes");
-			await ActiveESLint.outputFixes(results);
+			await ESLint.outputFixes(results);
 		}
 
 		let unusedSuppressions = {};
@@ -489,7 +453,7 @@ const cli = {
 
 		if (options.quiet) {
 			debug("Quiet mode enabled - filtering out warnings");
-			resultsToPrint = ActiveESLint.getErrorResults(resultsToPrint);
+			resultsToPrint = ESLint.getErrorResults(resultsToPrint);
 		}
 
 		const resultCounts = countErrors(results);

--- a/lib/options.js
+++ b/lib/options.js
@@ -24,12 +24,10 @@ const optionator = require("optionator");
  * @property {"metadata" | "content"} cacheStrategy Strategy to use for detecting changed files in the cache
  * @property {boolean} [color] Force enabling/disabling of color
  * @property {number | "auto" | "off"} [concurrency] Number of linting threads, "auto" to choose automatically, "off" for no multithreading
- * @property {string} [config] Use this configuration, overriding .eslintrc.* config options if present
+ * @property {string} [config] Use this configuration, overriding eslint.config.* config options if present
  * @property {boolean} debug Output debugging information
- * @property {string[]} [env] Specify environments
  * @property {boolean} envInfo Output execution environment information
  * @property {boolean} errorOnUnmatchedPattern Prevent errors when pattern is unmatched
- * @property {boolean} eslintrc Disable use of configuration from .eslintrc.*
  * @property {string[]} [ext] Specify JavaScript file extensions
  * @property {string[]} [flag] Feature flags
  * @property {boolean} fix Automatically fix problems
@@ -39,8 +37,7 @@ const optionator = require("optionator");
  * @property {string[]} [global] Define global variables
  * @property {boolean} [help] Show help
  * @property {boolean} ignore Disable use of ignore files and patterns
- * @property {string} [ignorePath] Specify path of ignore file
- * @property {string[]} [ignorePattern] Patterns of files to ignore. In eslintrc mode, these are in addition to `.eslintignore`
+ * @property {string[]} [ignorePattern] Patterns of files to ignore
  * @property {boolean} init Run config initialization wizard
  * @property {boolean} inlineConfig Prevent comments from changing config or rules
  * @property {number} maxWarnings Number of warnings to trigger nonzero exit code
@@ -56,9 +53,7 @@ const optionator = require("optionator");
  * @property {boolean} quiet Report errors only
  * @property {boolean | undefined} reportUnusedDisableDirectives Adds reported errors for unused eslint-disable and eslint-enable directives
  * @property {string | undefined} reportUnusedDisableDirectivesSeverity A severity string indicating if and how unused disable and enable directives should be tracked and reported.
- * @property {string} [resolvePluginsRelativeTo] A folder where plugins should be resolved from, CWD by default
  * @property {Object} [rule] Specify rules
- * @property {string[]} [rulesdir] Load additional rules from this directory. Deprecated: Use rules from plugins
  * @property {boolean} [stats] Report additional statistics
  * @property {boolean} stdin Lint code provided on <STDIN>
  * @property {string} [stdinFilename] Specify filename to process STDIN as
@@ -78,165 +73,9 @@ const optionator = require("optionator");
 
 /**
  * Creates the CLI options for ESLint.
- * @param {boolean} usingFlatConfig Indicates if flat config is being used.
  * @returns {Object} The optionator instance.
  */
-module.exports = function (usingFlatConfig) {
-	let lookupFlag;
-
-	if (usingFlatConfig) {
-		lookupFlag = {
-			option: "config-lookup",
-			type: "Boolean",
-			default: "true",
-			description: "Disable look up for eslint.config.js",
-		};
-	} else {
-		lookupFlag = {
-			option: "eslintrc",
-			type: "Boolean",
-			default: "true",
-			description: "Disable use of configuration from .eslintrc.*",
-		};
-	}
-
-	let envFlag;
-
-	if (!usingFlatConfig) {
-		envFlag = {
-			option: "env",
-			type: "[String]",
-			description: "Specify environments",
-		};
-	}
-
-	let inspectConfigFlag;
-
-	if (usingFlatConfig) {
-		inspectConfigFlag = {
-			option: "inspect-config",
-			type: "Boolean",
-			description:
-				"Open the config inspector with the current configuration",
-		};
-	}
-
-	let extFlag;
-
-	if (!usingFlatConfig) {
-		extFlag = {
-			option: "ext",
-			type: "[String]",
-			description: "Specify JavaScript file extensions",
-		};
-	} else {
-		extFlag = {
-			option: "ext",
-			type: "[String]",
-			description: "Specify additional file extensions to lint",
-		};
-	}
-
-	let resolvePluginsFlag;
-
-	if (!usingFlatConfig) {
-		resolvePluginsFlag = {
-			option: "resolve-plugins-relative-to",
-			type: "path::String",
-			description:
-				"A folder where plugins should be resolved from, CWD by default",
-		};
-	}
-
-	let rulesDirFlag;
-
-	if (!usingFlatConfig) {
-		rulesDirFlag = {
-			option: "rulesdir",
-			type: "[path::String]",
-			description:
-				"Load additional rules from this directory. Deprecated: Use rules from plugins",
-		};
-	}
-
-	let ignorePathFlag;
-
-	if (!usingFlatConfig) {
-		ignorePathFlag = {
-			option: "ignore-path",
-			type: "path::String",
-			description: "Specify path of ignore file",
-		};
-	}
-
-	let statsFlag;
-
-	if (usingFlatConfig) {
-		statsFlag = {
-			option: "stats",
-			type: "Boolean",
-			default: "false",
-			description: "Add statistics to the lint report",
-		};
-	}
-
-	let warnIgnoredFlag;
-
-	if (usingFlatConfig) {
-		warnIgnoredFlag = {
-			option: "warn-ignored",
-			type: "Boolean",
-			default: "true",
-			description:
-				"Suppress warnings when the file list includes ignored files",
-		};
-	}
-
-	let flagFlag;
-
-	if (usingFlatConfig) {
-		flagFlag = {
-			option: "flag",
-			type: "[String]",
-			description: "Enable a feature flag",
-		};
-	}
-
-	let reportUnusedInlineConfigsFlag;
-
-	if (usingFlatConfig) {
-		reportUnusedInlineConfigsFlag = {
-			option: "report-unused-inline-configs",
-			type: "String",
-			default: void 0,
-			description:
-				"Adds reported errors for unused eslint inline config comments",
-			enum: ["off", "warn", "error", "0", "1", "2"],
-		};
-	}
-
-	let mcpFlag;
-
-	if (usingFlatConfig) {
-		mcpFlag = {
-			option: "mcp",
-			type: "Boolean",
-			description: "Start the ESLint MCP server",
-		};
-	}
-
-	let concurrencyFlag;
-
-	if (usingFlatConfig) {
-		concurrencyFlag = {
-			option: "concurrency",
-			type: "Int|String",
-			default: "off",
-			description:
-				"Number of linting threads, auto to choose automatically, off for no multithreading",
-		};
-	}
-
+module.exports = function () {
 	return optionator({
 		prepend: "eslint [options] file.js [file.js] [dir]",
 		defaults: {
@@ -247,18 +86,30 @@ module.exports = function (usingFlatConfig) {
 			{
 				heading: "Basic configuration",
 			},
-			lookupFlag,
+			{
+				option: "config-lookup",
+				type: "Boolean",
+				default: "true",
+				description: "Disable look up for eslint.config.js",
+			},
 			{
 				option: "config",
 				alias: "c",
 				type: "path::String",
-				description: usingFlatConfig
-					? "Use this configuration instead of eslint.config.js, eslint.config.mjs, or eslint.config.cjs"
-					: "Use this configuration, overriding .eslintrc.* config options if present",
+				description:
+					"Use this configuration instead of eslint.config.js, eslint.config.mjs, or eslint.config.cjs",
 			},
-			inspectConfigFlag,
-			envFlag,
-			extFlag,
+			{
+				option: "inspect-config",
+				type: "Boolean",
+				description:
+					"Open the config inspector with the current configuration",
+			},
+			{
+				option: "ext",
+				type: "[String]",
+				description: "Specify additional file extensions to lint",
+			},
 			{
 				option: "global",
 				type: "[String]",
@@ -274,7 +125,6 @@ module.exports = function (usingFlatConfig) {
 				type: "Object",
 				description: "Specify parser options",
 			},
-			resolvePluginsFlag,
 			{
 				heading: "Specify Rules and Plugins",
 			},
@@ -288,7 +138,6 @@ module.exports = function (usingFlatConfig) {
 				type: "Object",
 				description: "Specify rules",
 			},
-			rulesDirFlag,
 			{
 				heading: "Fix Problems",
 			},
@@ -314,7 +163,6 @@ module.exports = function (usingFlatConfig) {
 			{
 				heading: "Ignore Files",
 			},
-			ignorePathFlag,
 			{
 				option: "ignore",
 				type: "Boolean",
@@ -324,7 +172,7 @@ module.exports = function (usingFlatConfig) {
 			{
 				option: "ignore-pattern",
 				type: "[String]",
-				description: `Patterns of files to ignore${usingFlatConfig ? "" : " (in addition to those in .eslintignore)"}`,
+				description: `Patterns of files to ignore`,
 				concatRepeatedArrays: [
 					true,
 					{
@@ -407,7 +255,14 @@ module.exports = function (usingFlatConfig) {
 					"Chooses severity level for reporting unused eslint-disable and eslint-enable directives",
 				enum: ["off", "warn", "error", "0", "1", "2"],
 			},
-			reportUnusedInlineConfigsFlag,
+			{
+				option: "report-unused-inline-configs",
+				type: "String",
+				default: void 0,
+				description:
+					"Adds reported errors for unused eslint inline config comments",
+				enum: ["off", "warn", "error", "0", "1", "2"],
+			},
 			{
 				heading: "Caching",
 			},
@@ -496,7 +351,13 @@ module.exports = function (usingFlatConfig) {
 				default: "false",
 				description: "Exit with exit code 2 in case of fatal error",
 			},
-			warnIgnoredFlag,
+			{
+				option: "warn-ignored",
+				type: "Boolean",
+				default: "true",
+				description:
+					"Suppress warnings when the file list includes ignored files",
+			},
 			{
 				option: "pass-on-no-patterns",
 				type: "Boolean",
@@ -527,10 +388,29 @@ module.exports = function (usingFlatConfig) {
 				type: "path::String",
 				description: "Print the configuration for the given file",
 			},
-			statsFlag,
-			flagFlag,
-			mcpFlag,
-			concurrencyFlag,
+			{
+				option: "stats",
+				type: "Boolean",
+				default: "false",
+				description: "Add statistics to the lint report",
+			},
+			{
+				option: "flag",
+				type: "[String]",
+				description: "Enable a feature flag",
+			},
+			{
+				option: "mcp",
+				type: "Boolean",
+				description: "Start the ESLint MCP server",
+			},
+			{
+				option: "concurrency",
+				type: "Int|String",
+				default: "off",
+				description:
+					"Number of linting threads, auto to choose automatically, off for no multithreading",
+			},
 		].filter(value => !!value),
 	});
 };

--- a/lib/services/warning-service.js
+++ b/lib/services/warning-service.js
@@ -60,17 +60,6 @@ class WarningService {
 	}
 
 	/**
-	 * Emits a warning when the ESLINT_USE_FLAT_CONFIG environment variable is set to "false".
-	 * @returns {void}
-	 */
-	emitESLintRCWarning() {
-		this.emitWarning(
-			"You are using an eslintrc configuration file, which is deprecated and support will be removed in v10.0.0. Please migrate to an eslint.config.js file. See https://eslint.org/docs/latest/use/configure/migration-guide for details. An eslintrc configuration file is used because you have the ESLINT_USE_FLAT_CONFIG environment variable set to false. If you want to use an eslint.config.js file, remove the environment variable. If you want to find the location of the eslintrc configuration file, use the --debug flag.",
-			"ESLintRCWarning",
-		);
-	}
-
-	/**
 	 * Emits a warning when an inactive flag is used.
 	 * This method is used by the Linter and is safe to call outside Node.js.
 	 * @param {string} flag The name of the flag.

--- a/lib/shared/translate-cli-options.js
+++ b/lib/shared/translate-cli-options.js
@@ -19,7 +19,6 @@ const { ModuleImporter } = require("@humanwhocodes/module-importer");
 //------------------------------------------------------------------------------
 
 /** @typedef {import("../types").ESLint.Options} ESLintOptions */
-/** @typedef {import("../types").ESLint.LegacyOptions} LegacyESLintOptions */
 /** @typedef {import("../types").Linter.LintMessage} LintMessage */
 /** @typedef {import("../options").ParsedCLIOptions} ParsedCLIOptions */
 /** @typedef {import("../types").ESLint.Plugin} Plugin */
@@ -85,195 +84,138 @@ function quietRuleFilter(rule) {
 /**
  * Translates the CLI options into the options expected by the ESLint constructor.
  * @param {ParsedCLIOptions} cliOptions The CLI options to translate.
- * @param {"flat"|"eslintrc"} [configType="eslintrc"] The format of the config to generate.
- * @returns {Promise<ESLintOptions | LegacyESLintOptions>} The options object for the ESLint constructor.
+ * @returns {Promise<ESLintOptions>} The options object for the ESLint constructor.
  */
-async function translateOptions(
-	{
-		cache,
-		cacheFile,
-		cacheLocation,
-		cacheStrategy,
-		concurrency,
-		config,
-		configLookup,
-		env,
-		errorOnUnmatchedPattern,
-		eslintrc,
-		ext,
-		fix,
-		fixDryRun,
-		fixType,
-		flag,
-		global,
-		ignore,
-		ignorePath,
-		ignorePattern,
-		inlineConfig,
-		parser,
-		parserOptions,
-		plugin,
-		quiet,
-		reportUnusedDisableDirectives,
-		reportUnusedDisableDirectivesSeverity,
-		reportUnusedInlineConfigs,
-		resolvePluginsRelativeTo,
-		rule,
-		rulesdir,
-		stats,
-		warnIgnored,
-		passOnNoPatterns,
-		maxWarnings,
-	},
-	configType,
-) {
-	let overrideConfig, overrideConfigFile;
+async function translateOptions({
+	cache,
+	cacheFile,
+	cacheLocation,
+	cacheStrategy,
+	concurrency,
+	config,
+	configLookup,
+	errorOnUnmatchedPattern,
+	ext,
+	fix,
+	fixDryRun,
+	fixType,
+	flag,
+	global,
+	ignore,
+	ignorePattern,
+	inlineConfig,
+	parser,
+	parserOptions,
+	plugin,
+	quiet,
+	reportUnusedDisableDirectives,
+	reportUnusedDisableDirectivesSeverity,
+	reportUnusedInlineConfigs,
+	rule,
+	stats,
+	warnIgnored,
+	passOnNoPatterns,
+	maxWarnings,
+}) {
 	const importer = new ModuleImporter();
 
-	if (configType === "flat") {
-		overrideConfigFile =
-			typeof config === "string" ? config : !configLookup;
-		if (overrideConfigFile === false) {
-			overrideConfigFile = void 0;
-		}
+	let overrideConfigFile =
+		typeof config === "string" ? config : !configLookup;
+	if (overrideConfigFile === false) {
+		overrideConfigFile = void 0;
+	}
 
-		const languageOptions = {};
+	const languageOptions = {};
 
-		if (global) {
-			languageOptions.globals = global.reduce((obj, name) => {
-				if (name.endsWith(":true")) {
-					obj[name.slice(0, -5)] = "writable";
-				} else {
-					obj[name] = "readonly";
-				}
-				return obj;
-			}, {});
-		}
+	if (global) {
+		languageOptions.globals = global.reduce((obj, name) => {
+			if (name.endsWith(":true")) {
+				obj[name.slice(0, -5)] = "writable";
+			} else {
+				obj[name] = "readonly";
+			}
+			return obj;
+		}, {});
+	}
 
-		if (parserOptions) {
-			languageOptions.parserOptions = parserOptions;
-		}
+	if (parserOptions) {
+		languageOptions.parserOptions = parserOptions;
+	}
 
-		if (parser) {
-			languageOptions.parser = await importer.import(parser);
-		}
+	if (parser) {
+		languageOptions.parser = await importer.import(parser);
+	}
 
-		overrideConfig = [
-			{
-				...(Object.keys(languageOptions).length > 0
-					? { languageOptions }
-					: {}),
-				rules: rule ? rule : {},
-			},
-		];
+	const overrideConfig = [
+		{
+			...(Object.keys(languageOptions).length > 0
+				? { languageOptions }
+				: {}),
+			rules: rule ? rule : {},
+		},
+	];
 
-		if (
-			reportUnusedDisableDirectives ||
-			reportUnusedDisableDirectivesSeverity !== void 0
-		) {
-			overrideConfig[0].linterOptions = {
-				reportUnusedDisableDirectives: reportUnusedDisableDirectives
-					? "error"
-					: normalizeSeverityToString(
-							reportUnusedDisableDirectivesSeverity,
-						),
-			};
-		}
-
-		if (reportUnusedInlineConfigs !== void 0) {
-			overrideConfig[0].linterOptions = {
-				...overrideConfig[0].linterOptions,
-				reportUnusedInlineConfigs: normalizeSeverityToString(
-					reportUnusedInlineConfigs,
-				),
-			};
-		}
-
-		if (plugin) {
-			overrideConfig[0].plugins = await loadPlugins(importer, plugin);
-		}
-
-		if (ext) {
-			overrideConfig.push({
-				files: ext.map(
-					extension =>
-						`**/*${extension.startsWith(".") ? "" : "."}${extension}`,
-				),
-			});
-		}
-	} else {
-		overrideConfigFile = config;
-
-		overrideConfig = {
-			env:
-				env &&
-				env.reduce((obj, name) => {
-					obj[name] = true;
-					return obj;
-				}, {}),
-			globals:
-				global &&
-				global.reduce((obj, name) => {
-					if (name.endsWith(":true")) {
-						obj[name.slice(0, -5)] = "writable";
-					} else {
-						obj[name] = "readonly";
-					}
-					return obj;
-				}, {}),
-			ignorePatterns: ignorePattern,
-			parser,
-			parserOptions,
-			plugins: plugin,
-			rules: rule,
+	if (
+		reportUnusedDisableDirectives ||
+		reportUnusedDisableDirectivesSeverity !== void 0
+	) {
+		overrideConfig[0].linterOptions = {
+			reportUnusedDisableDirectives: reportUnusedDisableDirectives
+				? "error"
+				: normalizeSeverityToString(
+						reportUnusedDisableDirectivesSeverity,
+					),
 		};
 	}
+
+	if (reportUnusedInlineConfigs !== void 0) {
+		overrideConfig[0].linterOptions = {
+			...overrideConfig[0].linterOptions,
+			reportUnusedInlineConfigs: normalizeSeverityToString(
+				reportUnusedInlineConfigs,
+			),
+		};
+	}
+
+	if (plugin) {
+		overrideConfig[0].plugins = await loadPlugins(importer, plugin);
+	}
+
+	if (ext) {
+		overrideConfig.push({
+			files: ext.map(
+				extension =>
+					`**/*${extension.startsWith(".") ? "" : "."}${extension}`,
+			),
+		});
+	}
+
+	/*
+	 * For performance reasons rules not marked as 'error' are filtered out in quiet mode. As maxWarnings
+	 * requires rules set to 'warn' to be run, we only filter out 'warn' rules if maxWarnings is not specified.
+	 */
+	const ruleFilter =
+		quiet && maxWarnings === -1 ? quietRuleFilter : () => true;
 
 	const options = {
 		allowInlineConfig: inlineConfig,
 		cache,
 		cacheLocation: cacheLocation || cacheFile,
 		cacheStrategy,
+		concurrency,
 		errorOnUnmatchedPattern,
 		fix: (fix || fixDryRun) && (quiet ? quietFixPredicate : true),
 		fixTypes: fixType,
+		flags: flag,
 		ignore,
+		ignorePatterns: ignorePattern,
 		overrideConfig,
 		overrideConfigFile,
 		passOnNoPatterns,
+		ruleFilter,
+		stats,
+		warnIgnored,
 	};
-
-	if (configType === "flat") {
-		options.concurrency = concurrency;
-		options.flags = flag;
-		options.ignorePatterns = ignorePattern;
-		options.stats = stats;
-		options.warnIgnored = warnIgnored;
-
-		/*
-		 * For performance reasons rules not marked as 'error' are filtered out in quiet mode. As maxWarnings
-		 * requires rules set to 'warn' to be run, we only filter out 'warn' rules if maxWarnings is not specified.
-		 */
-		options.ruleFilter =
-			quiet && maxWarnings === -1 ? quietRuleFilter : () => true;
-	} else {
-		options.resolvePluginsRelativeTo = resolvePluginsRelativeTo;
-		options.rulePaths = rulesdir;
-		options.useEslintrc = eslintrc;
-		options.extensions = ext;
-		options.ignorePath = ignorePath;
-		if (
-			reportUnusedDisableDirectives ||
-			reportUnusedDisableDirectivesSeverity !== void 0
-		) {
-			options.reportUnusedDisableDirectives =
-				reportUnusedDisableDirectives
-					? "error"
-					: normalizeSeverityToString(
-							reportUnusedDisableDirectivesSeverity,
-						);
-		}
-	}
 
 	return options;
 }

--- a/tests/fixtures/configurations/env-nashorn.json
+++ b/tests/fixtures/configurations/env-nashorn.json
@@ -1,8 +1,0 @@
-{
-  "env": {
-    "nashorn": true
-  },
-  "rules": {
-    "no-undef": 2
-  }
-}

--- a/tests/fixtures/configurations/env-webextensions.json
+++ b/tests/fixtures/configurations/env-webextensions.json
@@ -1,8 +1,0 @@
-{
-  "env": {
-    "webextensions": true
-  },
-  "rules": {
-    "no-undef": 2
-  }
-}

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -5,19 +5,13 @@
 
 "use strict";
 
-/*
- * NOTE: If you are adding new tests for cli.js, use verifyESLintOpts(). The
- * test only needs to verify that ESLint receives the correct opts.
- */
-
 //------------------------------------------------------------------------------
 // Requirements
 //------------------------------------------------------------------------------
 
 const assert = require("chai").assert,
 	stdAssert = require("node:assert"),
-	{ ESLint, LegacyESLint } = require("../../lib/eslint"),
-	BuiltinRules = require("../../lib/rules"),
+	{ ESLint } = require("../../lib/eslint"),
 	path = require("node:path"),
 	sinon = require("sinon"),
 	fs = require("node:fs"),
@@ -86,44 +80,6 @@ describe("cli", () => {
 		});
 
 		/**
-		 * Verify that ESLint class receives correct opts via await cli.execute().
-		 * @param {string} cmd CLI command.
-		 * @param {Object} opts Options hash that should match that received by ESLint class.
-		 * @param {string} configType The config type to work with.
-		 * @returns {void}
-		 */
-		async function verifyESLintOpts(cmd, opts, configType) {
-			const ActiveESLint = configType === "flat" ? ESLint : LegacyESLint;
-
-			// create a fake ESLint class to test with
-			const fakeESLint = sinon.mock().withExactArgs(sinon.match(opts));
-
-			Object.defineProperties(
-				fakeESLint.prototype,
-				Object.getOwnPropertyDescriptors(ActiveESLint.prototype),
-			);
-			sinon.stub(fakeESLint.prototype, "lintFiles").returns([]);
-			sinon
-				.stub(fakeESLint.prototype, "loadFormatter")
-				.returns({ format: sinon.spy() });
-
-			const localCLI = proxyquire("../../lib/cli", {
-				"./eslint": { LegacyESLint: fakeESLint },
-				"./eslint/eslint": {
-					ESLint: fakeESLint,
-					shouldUseFlatConfig: () =>
-						Promise.resolve(configType === "flat"),
-				},
-				"./shared/logging": log,
-			});
-
-			await localCLI.execute(cmd, null, configType === "flat");
-			sinon.verifyAndRestore();
-		}
-
-		// verifyESLintOpts
-
-		/**
 		 * Returns the path inside of the fixture directory.
 		 * @param {...string} args file path segments.
 		 * @returns {string} The path inside the fixture directory.
@@ -133,7 +89,7 @@ describe("cli", () => {
 			return path.join(fixtureDir, ...args);
 		}
 
-		// copy into clean area so as not to get "infected" by this project's .eslintrc files
+		// copy into clean area so as not to get "infected" by this project's config files
 		before(function () {
 			/*
 			 * GitHub Actions Windows and macOS runners occasionally exhibit
@@ -163,133 +119,113 @@ describe("cli", () => {
 			sh.rm("-r", fixtureDir);
 		});
 
-		["eslintrc", "flat"].forEach(configType => {
-			const useFlatConfig = configType === "flat";
-			const ActiveESLint = configType === "flat" ? ESLint : LegacyESLint;
+		describe("execute()", () => {
+			it(`should return error when text with incorrect quotes is passed as argument`, async () => {
+				const configFile = getFixturePath(
+					"configurations",
+					"quotes-error.js",
+				);
+				const result = await cli.execute(
+					`--no-config-lookup -c ${configFile} --stdin --stdin-filename foo.js`,
+					"var foo = 'bar';",
+				);
 
-			describe("execute()", () => {
-				it(`should return error when text with incorrect quotes is passed as argument with configType:${configType}`, async () => {
-					const flag = useFlatConfig
-						? "--no-config-lookup"
-						: "--no-eslintrc";
-					const configFile = getFixturePath(
-						"configurations",
-						"quotes-error.js",
-					);
-					const result = await cli.execute(
-						`${flag} -c ${configFile} --stdin --stdin-filename foo.js`,
-						"var foo = 'bar';",
-						useFlatConfig,
-					);
+				assert.strictEqual(result, 1);
+			});
 
-					assert.strictEqual(result, 1);
+			it(`should not print debug info when passed the empty string as text`, async () => {
+				const result = await cli.execute(
+					[
+						"argv0",
+						"argv1",
+						"--stdin",
+						"--no-config-lookup",
+						"--stdin-filename",
+						"foo.js",
+					],
+					"",
+				);
+
+				assert.strictEqual(result, 0);
+				assert.isTrue(log.info.notCalled);
+			});
+
+			it(`should exit with console error when passed unsupported arguments`, async () => {
+				const filePath = getFixturePath("files");
+				const result = await cli.execute(
+					`--blah --another ${filePath}`,
+				);
+
+				assert.strictEqual(result, 2);
+			});
+		});
+
+		describe("when given a config with rules with options and severity level set to error", () => {
+			const originalCwd = process.cwd;
+
+			beforeEach(() => {
+				process.cwd = () => getFixturePath();
+			});
+
+			afterEach(() => {
+				process.cwd = originalCwd;
+			});
+
+			it(`should exit with an error status (1)`, async () => {
+				const configPath = getFixturePath(
+					"configurations",
+					"quotes-error.js",
+				);
+				const filePath = getFixturePath("single-quoted.js");
+				const code = `--no-ignore --config ${configPath} ${filePath}`;
+
+				const exitStatus = await cli.execute(code);
+
+				assert.strictEqual(exitStatus, 1);
+			});
+		});
+
+		describe("when there is a local config file", () => {
+			const originalCwd = process.cwd;
+
+			beforeEach(() => {
+				process.cwd = () => getFixturePath();
+			});
+
+			afterEach(() => {
+				process.cwd = originalCwd;
+			});
+
+			it(`should load the local config file`, async () => {
+				await cli.execute("cli/passing.js --no-ignore");
+			});
+
+			it(`should load the local config file with glob pattern`, async () => {
+				await cli.execute("cli/pass*.js --no-ignore");
+			});
+
+			// only works on Windows
+			if (os.platform() === "win32") {
+				it(`should load the local config file with Windows slashes glob pattern`, async () => {
+					await cli.execute("cli\\pass*.js --no-ignore");
 				});
+			}
+		});
 
-				it(`should not print debug info when passed the empty string as text with configType:${configType}`, async () => {
-					const flag = useFlatConfig
-						? "--no-config-lookup"
-						: "--no-eslintrc";
-					const result = await cli.execute(
-						[
-							"argv0",
-							"argv1",
-							"--stdin",
-							flag,
-							"--stdin-filename",
-							"foo.js",
-						],
-						"",
-						useFlatConfig,
-					);
-
-					assert.strictEqual(result, 0);
-					assert.isTrue(log.info.notCalled);
-				});
-
-				it(`should exit with console error when passed unsupported arguments with configType:${configType}`, async () => {
-					const filePath = getFixturePath("files");
-					const result = await cli.execute(
-						`--blah --another ${filePath}`,
+		describe("Formatters", () => {
+			describe("when given a valid built-in formatter name", () => {
+				it(`should execute without any errors`, async () => {
+					const filePath = getFixturePath("passing.js");
+					const exit = await cli.execute(
+						`--no-config-lookup -f json ${filePath}`,
 						null,
-						useFlatConfig,
 					);
 
-					assert.strictEqual(result, 2);
+					assert.strictEqual(exit, 0);
 				});
 			});
 
-			describe("flat config", () => {
-				const originalEnv = process.env;
-				const originalCwd = process.cwd;
-
-				let emitESLintRCWarningStub;
-
-				beforeEach(() => {
-					sinon.restore();
-					emitESLintRCWarningStub = sinon.stub(
-						WarningService.prototype,
-						"emitESLintRCWarning",
-					);
-					process.env = { ...originalEnv };
-				});
-
-				afterEach(() => {
-					emitESLintRCWarningStub.restore();
-					process.env = originalEnv;
-					process.cwd = originalCwd;
-				});
-
-				it(`should use it when an eslint.config.js is present and useFlatConfig is true:${configType}`, async () => {
-					process.cwd = getFixturePath;
-
-					const exitCode = await cli.execute(
-						`--no-ignore --env es2024 ${getFixturePath("files")}`,
-						null,
-						useFlatConfig,
-					);
-
-					// When flat config is used, we get an exit code of 2 because the --env option is unrecognized.
-					assert.strictEqual(exitCode, useFlatConfig ? 2 : 0);
-				});
-
-				it(`should not use it when ESLINT_USE_FLAT_CONFIG=false even if an eslint.config.js is present:${configType}`, async () => {
-					process.env.ESLINT_USE_FLAT_CONFIG = "false";
-					process.cwd = getFixturePath;
-
-					const exitCode = await cli.execute(
-						`--no-ignore --env es2024 ${getFixturePath("files")}`,
-						null,
-						useFlatConfig,
-					);
-
-					assert.strictEqual(exitCode, 0);
-
-					if (useFlatConfig) {
-						assert(
-							emitESLintRCWarningStub.calledOnce,
-							"calls `warningService.emitESLintRCWarning()` once",
-						);
-					}
-				});
-
-				it(`should use it when ESLINT_USE_FLAT_CONFIG=true and useFlatConfig is true even if an eslint.config.js is not present:${configType}`, async () => {
-					process.env.ESLINT_USE_FLAT_CONFIG = "true";
-
-					// Set the CWD to outside the fixtures/ directory so that no eslint.config.js is found
-					process.cwd = () => getFixturePath("..");
-
-					const exitCode = await cli.execute(
-						`--no-ignore --env es2024 ${getFixturePath("files")}`,
-						null,
-						useFlatConfig,
-					);
-
-					// When flat config is used, we get an exit code of 2 because the --env option is unrecognized.
-					assert.strictEqual(exitCode, useFlatConfig ? 2 : 0);
-				});
-			});
-
-			describe("when given a config with rules with options and severity level set to error", () => {
+			describe("when given a valid built-in formatter name that uses rules meta.", () => {
 				const originalCwd = process.cwd;
 
 				beforeEach(() => {
@@ -300,2106 +236,1655 @@ describe("cli", () => {
 					process.cwd = originalCwd;
 				});
 
-				it(`should exit with an error status (1) with configType:${configType}`, async () => {
+				it(`should execute without any errors`, async () => {
+					const filePath = getFixturePath("passing.js");
+					const exit = await cli.execute(
+						`--no-ignore -f json-with-metadata ${filePath} --no-config-lookup`,
+						null,
+					);
+
+					assert.strictEqual(exit, 0);
+
+					/*
+					 * rulesMeta only contains meta data for the rules that triggered messages in the
+					 * results.
+					 */
+
+					// Check metadata.
+					const { metadata } = JSON.parse(log.info.args[0][0]);
+					const expectedMetadata = {
+						cwd: process.cwd(),
+						rulesMeta: {},
+					};
+
+					assert.deepStrictEqual(metadata, expectedMetadata);
+				});
+			});
+
+			describe("when the --max-warnings option is passed", () => {
+				describe("and there are too many warnings", () => {
+					it(`should provide \`maxWarningsExceeded\` metadata to the formatter`, async () => {
+						const exit = await cli.execute(
+							`--no-ignore -f json-with-metadata --max-warnings 1 --rule 'quotes: warn' --no-config-lookup`,
+							"'hello' + 'world';",
+						);
+
+						assert.strictEqual(exit, 1);
+
+						const { metadata } = JSON.parse(log.info.args[0][0]);
+
+						assert.deepStrictEqual(metadata.maxWarningsExceeded, {
+							maxWarnings: 1,
+							foundWarnings: 2,
+						});
+					});
+				});
+
+				describe("and warnings do not exceed the limit", () => {
+					it(`should omit \`maxWarningsExceeded\` metadata from the formatter`, async () => {
+						const exit = await cli.execute(
+							`--no-ignore -f json-with-metadata --max-warnings 1 --rule 'quotes: warn' --no-config-lookup`,
+							"'hello world';",
+						);
+
+						assert.strictEqual(exit, 0);
+
+						const { metadata } = JSON.parse(log.info.args[0][0]);
+
+						assert.notProperty(metadata, "maxWarningsExceeded");
+					});
+				});
+			});
+
+			describe("when given an invalid built-in formatter name", () => {
+				const originalCwd = process.cwd;
+
+				beforeEach(() => {
+					process.cwd = () => getFixturePath();
+				});
+
+				afterEach(() => {
+					process.cwd = originalCwd;
+				});
+
+				it(`should execute with error:`, async () => {
+					const filePath = getFixturePath("passing.js");
+					const exit = await cli.execute(
+						`-f fakeformatter ${filePath} --no-config-lookup`,
+						null,
+					);
+
+					assert.strictEqual(exit, 2);
+				});
+			});
+
+			describe("when given a valid formatter path", () => {
+				const originalCwd = process.cwd;
+
+				beforeEach(() => {
+					process.cwd = () => getFixturePath();
+				});
+
+				afterEach(() => {
+					process.cwd = originalCwd;
+				});
+
+				it(`should execute without any errors`, async () => {
+					const formatterPath = getFixturePath(
+						"formatters",
+						"simple.js",
+					);
+					const filePath = getFixturePath("passing.js");
+					const exit = await cli.execute(
+						`-f ${formatterPath} ${filePath} --no-config-lookup`,
+						null,
+					);
+
+					assert.strictEqual(exit, 0);
+				});
+			});
+
+			describe("when given an invalid formatter path", () => {
+				const originalCwd = process.cwd;
+
+				beforeEach(() => {
+					process.cwd = () => getFixturePath();
+				});
+
+				afterEach(() => {
+					process.cwd = originalCwd;
+				});
+
+				it(`should execute with error`, async () => {
+					const formatterPath = getFixturePath(
+						"formatters",
+						"file-does-not-exist.js",
+					);
+					const filePath = getFixturePath("passing.js");
+					const exit = await cli.execute(
+						`--no-ignore -f ${formatterPath} ${filePath}`,
+						null,
+					);
+
+					assert.strictEqual(exit, 2);
+				});
+			});
+
+			describe("when given an async formatter path", () => {
+				const originalCwd = process.cwd;
+
+				beforeEach(() => {
+					process.cwd = () => getFixturePath();
+				});
+
+				afterEach(() => {
+					process.cwd = originalCwd;
+				});
+
+				it(`should execute without any errors`, async () => {
+					const formatterPath = getFixturePath(
+						"formatters",
+						"async.js",
+					);
+					const filePath = getFixturePath("passing.js");
+					const exit = await cli.execute(
+						`-f ${formatterPath} ${filePath} --no-config-lookup`,
+						null,
+					);
+
+					assert.strictEqual(
+						log.info.getCall(0).args[0],
+						"from async formatter",
+					);
+					assert.strictEqual(exit, 0);
+				});
+			});
+		});
+
+		describe("Exit Codes", () => {
+			const originalCwd = process.cwd;
+
+			beforeEach(() => {
+				process.cwd = () => getFixturePath();
+			});
+
+			afterEach(() => {
+				process.cwd = originalCwd;
+			});
+
+			describe("when executing a file with a lint error", () => {
+				it(`should exit with error`, async () => {
+					const filePath = getFixturePath("undef.js");
+					const code = `--no-ignore --rule no-undef:2 ${filePath}`;
+
+					const exit = await cli.execute(code);
+
+					assert.strictEqual(exit, 1);
+				});
+			});
+
+			describe("when using --fix-type without --fix or --fix-dry-run", () => {
+				it(`should exit with error`, async () => {
+					const filePath = getFixturePath("passing.js");
+					const code = `--fix-type suggestion ${filePath}`;
+
+					const exit = await cli.execute(code);
+
+					assert.strictEqual(exit, 2);
+				});
+			});
+
+			describe("when executing a file with a syntax error", () => {
+				it(`should exit with error`, async () => {
+					const filePath = getFixturePath("syntax-error.js");
+					const exit = await cli.execute(
+						`--no-ignore ${filePath}`,
+						null,
+					);
+
+					assert.strictEqual(exit, 1);
+				});
+			});
+		});
+
+		describe("when calling execute more than once", () => {
+			const originalCwd = process.cwd;
+
+			beforeEach(() => {
+				process.cwd = () => getFixturePath();
+			});
+
+			afterEach(() => {
+				process.cwd = originalCwd;
+			});
+
+			it(`should not print the results from previous execution`, async () => {
+				const filePath = getFixturePath("missing-semicolon.js");
+				const passingPath = getFixturePath("passing.js");
+
+				await cli.execute(
+					`--no-ignore --rule semi:2 ${filePath}`,
+					null,
+				);
+
+				assert.isTrue(log.info.called, "Log should have been called.");
+
+				log.info.resetHistory();
+
+				await cli.execute(
+					`--no-ignore --rule semi:2 ${passingPath}`,
+					null,
+				);
+				assert.isTrue(log.info.notCalled);
+			});
+		});
+
+		describe("when executing with version flag", () => {
+			it(`should print out current version`, async () => {
+				assert.strictEqual(await cli.execute("-v"), 0);
+				assert.strictEqual(log.info.callCount, 1);
+			});
+		});
+
+		describe("when executing with env-info flag", () => {
+			it(`should print out environment information`, async () => {
+				assert.strictEqual(await cli.execute("--env-info"), 0);
+				assert.strictEqual(log.info.callCount, 1);
+			});
+
+			describe("With error condition", () => {
+				beforeEach(() => {
+					RuntimeInfo.environment = sinon
+						.stub()
+						.throws("There was an error!");
+				});
+
+				afterEach(() => {
+					RuntimeInfo.environment = sinon.stub();
+				});
+
+				it(`should print error message and return error code`, async () => {
+					assert.strictEqual(await cli.execute("--env-info"), 2);
+					assert.strictEqual(log.error.callCount, 1);
+				});
+			});
+		});
+
+		describe("when executing with help flag", () => {
+			it(`should print out help`, async () => {
+				assert.strictEqual(await cli.execute("-h"), 0);
+				assert.strictEqual(log.info.callCount, 1);
+			});
+		});
+
+		describe("when executing a file with a shebang", () => {
+			it(`should execute without error`, async () => {
+				const filePath = getFixturePath("shebang.js");
+				const exit = await cli.execute(
+					`--no-config-lookup --no-ignore ${filePath}`,
+					null,
+				);
+
+				assert.strictEqual(exit, 0);
+			});
+		});
+
+		describe("FixtureDir Dependent Tests", () => {
+			const originalCwd = process.cwd;
+
+			beforeEach(() => {
+				process.cwd = () => getFixturePath();
+			});
+
+			afterEach(() => {
+				process.cwd = originalCwd;
+			});
+
+			describe("when given a config file and a directory of files", () => {
+				it(`should load and execute without error`, async () => {
 					const configPath = getFixturePath(
 						"configurations",
-						"quotes-error.js",
+						"semi-error.js",
 					);
-					const filePath = getFixturePath("single-quoted.js");
+					const filePath = getFixturePath("formatters");
 					const code = `--no-ignore --config ${configPath} ${filePath}`;
+					const exitStatus = await cli.execute(code);
 
-					const exitStatus = await cli.execute(
-						code,
+					assert.strictEqual(exitStatus, 0);
+				});
+			});
+
+			describe("when executing with global flag", () => {
+				it(`should default defined variables to read-only`, async () => {
+					const filePath = getFixturePath("undef.js");
+					const exit = await cli.execute(
+						`--global baz,bat --no-ignore --rule no-global-assign:2 ${filePath}`,
 						null,
-						useFlatConfig,
 					);
+
+					assert.isTrue(log.info.calledOnce);
+					assert.strictEqual(exit, 1);
+				});
+
+				it(`should allow defining writable global variables`, async () => {
+					const filePath = getFixturePath("undef.js");
+					const exit = await cli.execute(
+						`--global baz:false,bat:true --no-ignore ${filePath}`,
+						null,
+					);
+
+					assert.isTrue(log.info.notCalled);
+					assert.strictEqual(exit, 0);
+				});
+
+				it(`should allow defining variables with multiple flags`, async () => {
+					const filePath = getFixturePath("undef.js");
+					const exit = await cli.execute(
+						`--global baz --global bat:true --no-ignore ${filePath}`,
+						null,
+					);
+
+					assert.isTrue(log.info.notCalled);
+					assert.strictEqual(exit, 0);
+				});
+			});
+
+			describe("when supplied with rule flag and severity level set to error", () => {
+				it(`should exit with an error status (2)`, async () => {
+					const filePath = getFixturePath("single-quoted.js");
+					const code = `--no-ignore --rule 'quotes: [2, double]' ${filePath}`;
+					const exitStatus = await cli.execute(code);
 
 					assert.strictEqual(exitStatus, 1);
 				});
 			});
 
-			describe("when there is a local config file", () => {
-				const originalCwd = process.cwd;
+			describe("when the quiet option is enabled", () => {
+				it(`should only print error`, async () => {
+					const filePath = getFixturePath("single-quoted.js");
+					const cliArgs = `--no-ignore --quiet -f stylish --rule 'quotes: [2, double]' --rule 'no-undef: 1' ${filePath}`;
 
-				beforeEach(() => {
-					process.cwd = () => getFixturePath();
+					await cli.execute(cliArgs);
+
+					sinon.assert.calledOnce(log.info);
+
+					const formattedOutput = log.info.firstCall.args[0];
+
+					assert.include(formattedOutput, "(1 error, 0 warnings)");
 				});
 
-				afterEach(() => {
-					process.cwd = originalCwd;
+				it(`should print nothing if there are no errors`, async () => {
+					const filePath = getFixturePath("single-quoted.js");
+					const cliArgs = `--no-ignore --quiet -f stylish --rule 'quotes: [1, double]' --rule 'no-undef: 1' ${filePath}`;
+
+					await cli.execute(cliArgs);
+
+					sinon.assert.notCalled(log.info);
 				});
 
-				it(`should load the local config file with configType:${configType}`, async () => {
-					await cli.execute(
-						"cli/passing.js --no-ignore",
-						null,
-						useFlatConfig,
+				it(`should not run rules set to 'warn'`, async () => {
+					const filePath = getFixturePath("single-quoted.js");
+					const configPath = getFixturePath(
+						"eslint.config-rule-throws.js",
 					);
-				});
+					const cliArgs = `--quiet --config ${configPath}' ${filePath}`;
 
-				if (useFlatConfig) {
-					it(`should load the local config file with glob pattern and configType:${configType}`, async () => {
-						await cli.execute(
-							"cli/pass*.js --no-ignore",
-							null,
-							useFlatConfig,
-						);
-					});
-				}
-
-				// only works on Windows
-				if (os.platform() === "win32") {
-					it(`should load the local config file with Windows slashes glob pattern and configType:${configType}`, async () => {
-						await cli.execute(
-							"cli\\pass*.js --no-ignore",
-							null,
-							useFlatConfig,
-						);
-					});
-				}
-			});
-
-			describe("Formatters", () => {
-				const flag = useFlatConfig
-					? "--no-config-lookup"
-					: "--no-eslintrc";
-
-				describe("when given a valid built-in formatter name", () => {
-					it(`should execute without any errors with configType:${configType}`, async () => {
-						const filePath = getFixturePath("passing.js");
-						const exit = await cli.execute(
-							`${flag} -f json ${filePath}`,
-							null,
-							useFlatConfig,
-						);
-
-						assert.strictEqual(exit, 0);
-					});
-				});
-
-				describe("when given a valid built-in formatter name that uses rules meta.", () => {
-					const originalCwd = process.cwd;
-
-					beforeEach(() => {
-						process.cwd = () => getFixturePath();
-					});
-
-					afterEach(() => {
-						process.cwd = originalCwd;
-					});
-
-					it(`should execute without any errors with configType:${configType}`, async () => {
-						const filePath = getFixturePath("passing.js");
-						const exit = await cli.execute(
-							`--no-ignore -f json-with-metadata ${filePath} ${flag}`,
-							null,
-							useFlatConfig,
-						);
-
-						assert.strictEqual(exit, 0);
-
-						/*
-						 * Note: There is a behavior difference between eslintrc and flat config
-						 * when using formatters. For eslintrc, rulesMeta always contains every
-						 * rule that was loaded during the last run; for flat config, rulesMeta
-						 * only contains meta data for the rules that triggered messages in the
-						 * results. (Flat config uses ESLint#getRulesMetaForResults().)
-						 */
-
-						// Check metadata.
-						const { metadata } = JSON.parse(log.info.args[0][0]);
-						const expectedMetadata = {
-							cwd: process.cwd(),
-							rulesMeta: useFlatConfig
-								? {}
-								: Array.from(BuiltinRules).reduce(
-										(obj, [ruleId, rule]) => {
-											obj[ruleId] = rule.meta;
-											return obj;
-										},
-										{},
-									),
-						};
-
-						assert.deepStrictEqual(metadata, expectedMetadata);
-					});
-				});
-
-				describe("when the --max-warnings option is passed", () => {
-					describe("and there are too many warnings", () => {
-						it(`should provide \`maxWarningsExceeded\` metadata to the formatter with configType:${configType}`, async () => {
-							const exit = await cli.execute(
-								`--no-ignore -f json-with-metadata --max-warnings 1 --rule 'quotes: warn' ${flag}`,
-								"'hello' + 'world';",
-								useFlatConfig,
-							);
-
-							assert.strictEqual(exit, 1);
-
-							const { metadata } = JSON.parse(
-								log.info.args[0][0],
-							);
-
-							assert.deepStrictEqual(
-								metadata.maxWarningsExceeded,
-								{ maxWarnings: 1, foundWarnings: 2 },
-							);
-						});
-					});
-
-					describe("and warnings do not exceed the limit", () => {
-						it(`should omit \`maxWarningsExceeded\` metadata from the formatter with configType:${configType}`, async () => {
-							const exit = await cli.execute(
-								`--no-ignore -f json-with-metadata --max-warnings 1 --rule 'quotes: warn' ${flag}`,
-								"'hello world';",
-								useFlatConfig,
-							);
-
-							assert.strictEqual(exit, 0);
-
-							const { metadata } = JSON.parse(
-								log.info.args[0][0],
-							);
-
-							assert.notProperty(metadata, "maxWarningsExceeded");
-						});
-					});
-				});
-
-				describe("when given an invalid built-in formatter name", () => {
-					const originalCwd = process.cwd;
-
-					beforeEach(() => {
-						process.cwd = () => getFixturePath();
-					});
-
-					afterEach(() => {
-						process.cwd = originalCwd;
-					});
-
-					it(`should execute with error: with configType:${configType}`, async () => {
-						const filePath = getFixturePath("passing.js");
-						const exit = await cli.execute(
-							`-f fakeformatter ${filePath} ${flag}`,
-							null,
-							useFlatConfig,
-						);
-
-						assert.strictEqual(exit, 2);
-					});
-				});
-
-				describe("when given a valid formatter path", () => {
-					const originalCwd = process.cwd;
-
-					beforeEach(() => {
-						process.cwd = () => getFixturePath();
-					});
-
-					afterEach(() => {
-						process.cwd = originalCwd;
-					});
-
-					it(`should execute without any errors with configType:${configType}`, async () => {
-						const formatterPath = getFixturePath(
-							"formatters",
-							"simple.js",
-						);
-						const filePath = getFixturePath("passing.js");
-						const exit = await cli.execute(
-							`-f ${formatterPath} ${filePath} ${flag}`,
-							null,
-							useFlatConfig,
-						);
-
-						assert.strictEqual(exit, 0);
-					});
-				});
-
-				describe("when given an invalid formatter path", () => {
-					const originalCwd = process.cwd;
-
-					beforeEach(() => {
-						process.cwd = () => getFixturePath();
-					});
-
-					afterEach(() => {
-						process.cwd = originalCwd;
-					});
-
-					it(`should execute with error with configType:${configType}`, async () => {
-						const formatterPath = getFixturePath(
-							"formatters",
-							"file-does-not-exist.js",
-						);
-						const filePath = getFixturePath("passing.js");
-						const exit = await cli.execute(
-							`--no-ignore -f ${formatterPath} ${filePath}`,
-							null,
-							useFlatConfig,
-						);
-
-						assert.strictEqual(exit, 2);
-					});
-				});
-
-				describe("when given an async formatter path", () => {
-					const originalCwd = process.cwd;
-
-					beforeEach(() => {
-						process.cwd = () => getFixturePath();
-					});
-
-					afterEach(() => {
-						process.cwd = originalCwd;
-					});
-
-					it(`should execute without any errors with configType:${configType}`, async () => {
-						const formatterPath = getFixturePath(
-							"formatters",
-							"async.js",
-						);
-						const filePath = getFixturePath("passing.js");
-						const exit = await cli.execute(
-							`-f ${formatterPath} ${filePath} ${flag}`,
-							null,
-							useFlatConfig,
-						);
-
-						assert.strictEqual(
-							log.info.getCall(0).args[0],
-							"from async formatter",
-						);
-						assert.strictEqual(exit, 0);
-					});
-				});
-			});
-
-			describe("Exit Codes", () => {
-				const originalCwd = process.cwd;
-
-				beforeEach(() => {
-					process.cwd = () => getFixturePath();
-				});
-
-				afterEach(() => {
-					process.cwd = originalCwd;
-				});
-
-				describe("when executing a file with a lint error", () => {
-					it(`should exit with error with configType:${configType}`, async () => {
-						const filePath = getFixturePath("undef.js");
-						const code = `--no-ignore --rule no-undef:2 ${filePath}`;
-
-						const exit = await cli.execute(
-							code,
-							null,
-							useFlatConfig,
-						);
-
-						assert.strictEqual(exit, 1);
-					});
-				});
-
-				describe("when using --fix-type without --fix or --fix-dry-run", () => {
-					it(`should exit with error with configType:${configType}`, async () => {
-						const filePath = getFixturePath("passing.js");
-						const code = `--fix-type suggestion ${filePath}`;
-
-						const exit = await cli.execute(
-							code,
-							null,
-							useFlatConfig,
-						);
-
-						assert.strictEqual(exit, 2);
-					});
-				});
-
-				describe("when executing a file with a syntax error", () => {
-					it(`should exit with error with configType:${configType}`, async () => {
-						const filePath = getFixturePath("syntax-error.js");
-						const exit = await cli.execute(
-							`--no-ignore ${filePath}`,
-							null,
-							useFlatConfig,
-						);
-
-						assert.strictEqual(exit, 1);
-					});
-				});
-			});
-
-			describe("when calling execute more than once", () => {
-				const originalCwd = process.cwd;
-
-				beforeEach(() => {
-					process.cwd = () => getFixturePath();
-				});
-
-				afterEach(() => {
-					process.cwd = originalCwd;
-				});
-
-				it(`should not print the results from previous execution with configType:${configType}`, async () => {
-					const filePath = getFixturePath("missing-semicolon.js");
-					const passingPath = getFixturePath("passing.js");
-
-					await cli.execute(
-						`--no-ignore --rule semi:2 ${filePath}`,
-						null,
-						useFlatConfig,
-					);
-
-					assert.isTrue(
-						log.info.called,
-						"Log should have been called.",
-					);
-
-					log.info.resetHistory();
-
-					await cli.execute(
-						`--no-ignore --rule semi:2 ${passingPath}`,
-						null,
-						useFlatConfig,
-					);
-					assert.isTrue(log.info.notCalled);
-				});
-			});
-
-			describe("when executing with version flag", () => {
-				it(`should print out current version with configType:${configType}`, async () => {
-					assert.strictEqual(
-						await cli.execute("-v", null, useFlatConfig),
-						0,
-					);
-					assert.strictEqual(log.info.callCount, 1);
-				});
-			});
-
-			describe("when executing with env-info flag", () => {
-				it(`should print out environment information with configType:${configType}`, async () => {
-					assert.strictEqual(
-						await cli.execute("--env-info", null, useFlatConfig),
-						0,
-					);
-					assert.strictEqual(log.info.callCount, 1);
-				});
-
-				describe("With error condition", () => {
-					beforeEach(() => {
-						RuntimeInfo.environment = sinon
-							.stub()
-							.throws("There was an error!");
-					});
-
-					afterEach(() => {
-						RuntimeInfo.environment = sinon.stub();
-					});
-
-					it(`should print error message and return error code with configType:${configType}`, async () => {
-						assert.strictEqual(
-							await cli.execute(
-								"--env-info",
-								null,
-								useFlatConfig,
-							),
-							2,
-						);
-						assert.strictEqual(log.error.callCount, 1);
-					});
-				});
-			});
-
-			describe("when executing with help flag", () => {
-				it(`should print out help with configType:${configType}`, async () => {
-					assert.strictEqual(
-						await cli.execute("-h", null, useFlatConfig),
-						0,
-					);
-					assert.strictEqual(log.info.callCount, 1);
-				});
-			});
-
-			describe("when executing a file with a shebang", () => {
-				it(`should execute without error with configType:${configType}`, async () => {
-					const filePath = getFixturePath("shebang.js");
-					const flag = useFlatConfig
-						? "--no-config-lookup"
-						: "--no-eslintrc";
-					const exit = await cli.execute(
-						`${flag} --no-ignore ${filePath}`,
-						null,
-						useFlatConfig,
-					);
+					const exit = await cli.execute(cliArgs);
 
 					assert.strictEqual(exit, 0);
 				});
+
+				it(`should run rules set to 'warn' while maxWarnings is set`, async () => {
+					const filePath = getFixturePath("single-quoted.js");
+					const configPath = getFixturePath(
+						"eslint.config-rule-throws.js",
+					);
+					const cliArgs = `--quiet --max-warnings=1 --config ${configPath}' ${filePath}`;
+
+					await stdAssert.rejects(async () => {
+						await cli.execute(cliArgs);
+					});
+				});
 			});
 
-			describe("FixtureDir Dependent Tests", () => {
-				const originalCwd = process.cwd;
+			describe("no-error-on-unmatched-pattern flag", () => {
+				describe("when executing without no-error-on-unmatched-pattern flag", () => {
+					it(`should throw an error on unmatched glob pattern`, async () => {
+						let filePath = getFixturePath("unmatched-patterns");
+						const globPattern = "unmatched*.js";
 
-				beforeEach(() => {
-					process.cwd = () => getFixturePath();
+						filePath = filePath.replace(/\\/gu, "/");
+
+						await stdAssert.rejects(
+							async () => {
+								await cli.execute(
+									`"${filePath}/${globPattern}"`,
+									null,
+								);
+							},
+							new Error(
+								`No files matching '${filePath}/${globPattern}' were found.`,
+							),
+						);
+					});
 				});
 
-				afterEach(() => {
-					process.cwd = originalCwd;
+				describe("when executing with no-error-on-unmatched-pattern flag", () => {
+					it(`should not throw an error on unmatched node glob syntax patterns`, async () => {
+						const filePath = getFixturePath("unmatched-patterns");
+						const exit = await cli.execute(
+							`--no-error-on-unmatched-pattern "${filePath}/unmatched*.js"`,
+							null,
+						);
+
+						assert.strictEqual(exit, 0);
+					});
 				});
 
-				describe("when given a config file and a directory of files", () => {
-					it(`should load and execute without error with configType:${configType}`, async () => {
+				describe("when executing with no-error-on-unmatched-pattern flag and multiple patterns", () => {
+					it(`should not throw an error on multiple unmatched node glob syntax patterns`, async () => {
+						const filePath = getFixturePath(
+							"unmatched-patterns/js3",
+						);
+						const exit = await cli.execute(
+							`--no-error-on-unmatched-pattern ${filePath}/unmatched1*.js ${filePath}/unmatched2*.js`,
+							null,
+						);
+
+						assert.strictEqual(exit, 0);
+					});
+
+					it(`should still throw an error on when a matched pattern has lint errors`, async () => {
+						const filePath = getFixturePath("unmatched-patterns");
+						const exit = await cli.execute(
+							`--no-ignore --no-error-on-unmatched-pattern ${filePath}/unmatched1*.js ${filePath}/failing.js`,
+							null,
+						);
+
+						assert.strictEqual(exit, 1);
+					});
+				});
+			});
+
+			describe("Parser Options", () => {
+				describe("when given parser options", () => {
+					it(`should exit with error if parser options are invalid`, async () => {
+						const filePath = getFixturePath("passing.js");
+						const exit = await cli.execute(
+							`--no-ignore --parser-options test111 ${filePath}`,
+							null,
+						);
+
+						assert.strictEqual(exit, 2);
+					});
+
+					it(`should exit with no error if parser is valid`, async () => {
+						const filePath = getFixturePath("passing.js");
+						const exit = await cli.execute(
+							`--no-ignore --parser-options=ecmaVersion:6 ${filePath}`,
+							null,
+						);
+
+						assert.strictEqual(exit, 0);
+					});
+
+					it(`should exit with an error on ecmaVersion 7 feature in ecmaVersion 6`, async () => {
+						const filePath = getFixturePath("passing-es7.js");
+						const exit = await cli.execute(
+							`--no-ignore --parser-options=ecmaVersion:6 ${filePath}`,
+							null,
+						);
+
+						assert.strictEqual(exit, 1);
+					});
+
+					it(`should exit with no error on ecmaVersion 7 feature in ecmaVersion 7`, async () => {
+						const filePath = getFixturePath("passing-es7.js");
+						const exit = await cli.execute(
+							`--no-ignore --parser-options=ecmaVersion:7 ${filePath}`,
+							null,
+						);
+
+						assert.strictEqual(exit, 0);
+					});
+
+					it(`should exit with no error on ecmaVersion 7 feature with config ecmaVersion 6 and command line ecmaVersion 7`, async () => {
 						const configPath = getFixturePath(
 							"configurations",
-							"semi-error.js",
+							"es6.js",
 						);
-						const filePath = getFixturePath("formatters");
-						const code = `--no-ignore --config ${configPath} ${filePath}`;
-						const exitStatus = await cli.execute(
-							code,
-							null,
-							useFlatConfig,
-						);
-
-						assert.strictEqual(exitStatus, 0);
-					});
-				});
-
-				describe("when executing with global flag", () => {
-					it(`should default defined variables to read-only with configType:${configType}`, async () => {
-						const filePath = getFixturePath("undef.js");
+						const filePath = getFixturePath("passing-es7.js");
 						const exit = await cli.execute(
-							`--global baz,bat --no-ignore --rule no-global-assign:2 ${filePath}`,
+							`--no-ignore --config ${configPath} --parser-options=ecmaVersion:7 ${filePath}`,
 							null,
-							useFlatConfig,
 						);
 
-						assert.isTrue(log.info.calledOnce);
-						assert.strictEqual(exit, 1);
-					});
-
-					it(`should allow defining writable global variables with configType:${configType}`, async () => {
-						const filePath = getFixturePath("undef.js");
-						const exit = await cli.execute(
-							`--global baz:false,bat:true --no-ignore ${filePath}`,
-							null,
-							useFlatConfig,
-						);
-
-						assert.isTrue(log.info.notCalled);
 						assert.strictEqual(exit, 0);
-					});
-
-					it(`should allow defining variables with multiple flags with configType:${configType}`, async () => {
-						const filePath = getFixturePath("undef.js");
-						const exit = await cli.execute(
-							`--global baz --global bat:true --no-ignore ${filePath}`,
-							null,
-							useFlatConfig,
-						);
-
-						assert.isTrue(log.info.notCalled);
-						assert.strictEqual(exit, 0);
-					});
-				});
-
-				describe("when supplied with rule flag and severity level set to error", () => {
-					it(`should exit with an error status (2) with configType:${configType}`, async () => {
-						const filePath = getFixturePath("single-quoted.js");
-						const code = `--no-ignore --rule 'quotes: [2, double]' ${filePath}`;
-						const exitStatus = await cli.execute(
-							code,
-							null,
-							useFlatConfig,
-						);
-
-						assert.strictEqual(exitStatus, 1);
-					});
-				});
-
-				describe("when the quiet option is enabled", () => {
-					it(`should only print error with configType:${configType}`, async () => {
-						const filePath = getFixturePath("single-quoted.js");
-						const cliArgs = `--no-ignore --quiet -f stylish --rule 'quotes: [2, double]' --rule 'no-undef: 1' ${filePath}`;
-
-						await cli.execute(cliArgs, null, useFlatConfig);
-
-						sinon.assert.calledOnce(log.info);
-
-						const formattedOutput = log.info.firstCall.args[0];
-
-						assert.include(
-							formattedOutput,
-							"(1 error, 0 warnings)",
-						);
-					});
-
-					it(`should print nothing if there are no errors with configType:${configType}`, async () => {
-						const filePath = getFixturePath("single-quoted.js");
-						const cliArgs = `--no-ignore --quiet -f stylish --rule 'quotes: [1, double]' --rule 'no-undef: 1' ${filePath}`;
-
-						await cli.execute(cliArgs, null, useFlatConfig);
-
-						sinon.assert.notCalled(log.info);
-					});
-
-					if (useFlatConfig) {
-						it(`should not run rules set to 'warn' with configType:${configType}`, async () => {
-							const filePath = getFixturePath("single-quoted.js");
-							const configPath = getFixturePath(
-								"eslint.config-rule-throws.js",
-							);
-							const cliArgs = `--quiet --config ${configPath}' ${filePath}`;
-
-							const exit = await cli.execute(
-								cliArgs,
-								null,
-								useFlatConfig,
-							);
-
-							assert.strictEqual(exit, 0);
-						});
-
-						it(`should run rules set to 'warn' while maxWarnings is set with configType:${configType}`, async () => {
-							const filePath = getFixturePath("single-quoted.js");
-							const configPath = getFixturePath(
-								"eslint.config-rule-throws.js",
-							);
-							const cliArgs = `--quiet --max-warnings=1 --config ${configPath}' ${filePath}`;
-
-							await stdAssert.rejects(async () => {
-								await cli.execute(cliArgs, null, useFlatConfig);
-							});
-						});
-					}
-				});
-
-				describe("no-error-on-unmatched-pattern flag", () => {
-					describe("when executing without no-error-on-unmatched-pattern flag", () => {
-						it(`should throw an error on unmatched glob pattern with configType:${configType}`, async () => {
-							let filePath = getFixturePath("unmatched-patterns");
-							const globPattern = "unmatched*.js";
-
-							if (useFlatConfig) {
-								filePath = filePath.replace(/\\/gu, "/");
-							}
-
-							await stdAssert.rejects(
-								async () => {
-									await cli.execute(
-										`"${filePath}/${globPattern}"`,
-										null,
-										useFlatConfig,
-									);
-								},
-								new Error(
-									`No files matching '${filePath}/${globPattern}' were found.`,
-								),
-							);
-						});
-					});
-
-					describe("when executing with no-error-on-unmatched-pattern flag", () => {
-						it(`should not throw an error on unmatched node glob syntax patterns with configType:${configType}`, async () => {
-							const filePath =
-								getFixturePath("unmatched-patterns");
-							const exit = await cli.execute(
-								`--no-error-on-unmatched-pattern "${filePath}/unmatched*.js"`,
-								null,
-								useFlatConfig,
-							);
-
-							assert.strictEqual(exit, 0);
-						});
-					});
-
-					describe("when executing with no-error-on-unmatched-pattern flag and multiple patterns", () => {
-						it(`should not throw an error on multiple unmatched node glob syntax patterns with configType:${configType}`, async () => {
-							const filePath = getFixturePath(
-								"unmatched-patterns/js3",
-							);
-							const exit = await cli.execute(
-								`--no-error-on-unmatched-pattern ${filePath}/unmatched1*.js ${filePath}/unmatched2*.js`,
-								null,
-								useFlatConfig,
-							);
-
-							assert.strictEqual(exit, 0);
-						});
-
-						it(`should still throw an error on when a matched pattern has lint errors with configType:${configType}`, async () => {
-							const filePath =
-								getFixturePath("unmatched-patterns");
-							const exit = await cli.execute(
-								`--no-ignore --no-error-on-unmatched-pattern ${filePath}/unmatched1*.js ${filePath}/failing.js`,
-								null,
-								useFlatConfig,
-							);
-
-							assert.strictEqual(exit, 1);
-						});
-					});
-				});
-
-				describe("Parser Options", () => {
-					describe("when given parser options", () => {
-						it(`should exit with error if parser options are invalid with configType:${configType}`, async () => {
-							const filePath = getFixturePath("passing.js");
-							const exit = await cli.execute(
-								`--no-ignore --parser-options test111 ${filePath}`,
-								null,
-								useFlatConfig,
-							);
-
-							assert.strictEqual(exit, 2);
-						});
-
-						it(`should exit with no error if parser is valid with configType:${configType}`, async () => {
-							const filePath = getFixturePath("passing.js");
-							const exit = await cli.execute(
-								`--no-ignore --parser-options=ecmaVersion:6 ${filePath}`,
-								null,
-								useFlatConfig,
-							);
-
-							assert.strictEqual(exit, 0);
-						});
-
-						it(`should exit with an error on ecmaVersion 7 feature in ecmaVersion 6 with configType:${configType}`, async () => {
-							const filePath = getFixturePath("passing-es7.js");
-							const exit = await cli.execute(
-								`--no-ignore --parser-options=ecmaVersion:6 ${filePath}`,
-								null,
-								useFlatConfig,
-							);
-
-							assert.strictEqual(exit, 1);
-						});
-
-						it(`should exit with no error on ecmaVersion 7 feature in ecmaVersion 7 with configType:${configType}`, async () => {
-							const filePath = getFixturePath("passing-es7.js");
-							const exit = await cli.execute(
-								`--no-ignore --parser-options=ecmaVersion:7 ${filePath}`,
-								null,
-								useFlatConfig,
-							);
-
-							assert.strictEqual(exit, 0);
-						});
-
-						it(`should exit with no error on ecmaVersion 7 feature with config ecmaVersion 6 and command line ecmaVersion 7 with configType:${configType}`, async () => {
-							const configPath = useFlatConfig
-								? getFixturePath("configurations", "es6.js")
-								: getFixturePath("configurations", "es6.json");
-							const filePath = getFixturePath("passing-es7.js");
-							const exit = await cli.execute(
-								`--no-ignore --config ${configPath} --parser-options=ecmaVersion:7 ${filePath}`,
-								null,
-								useFlatConfig,
-							);
-
-							assert.strictEqual(exit, 0);
-						});
-					});
-				});
-
-				describe("when given the max-warnings flag", () => {
-					let filePath, configFilePath;
-
-					before(() => {
-						filePath = getFixturePath(
-							"max-warnings/six-warnings.js",
-						);
-						configFilePath = getFixturePath(
-							useFlatConfig
-								? "max-warnings/eslint.config.js"
-								: "max-warnings/.eslintrc",
-						);
-					});
-
-					it(`should not change exit code if warning count under threshold with configType:${configType}`, async () => {
-						const exitCode = await cli.execute(
-							`--no-ignore --max-warnings 10 ${filePath} -c ${configFilePath}`,
-							null,
-							useFlatConfig,
-						);
-
-						assert.strictEqual(exitCode, 0);
-					});
-
-					it(`should exit with exit code 1 if warning count exceeds threshold with configType:${configType}`, async () => {
-						const exitCode = await cli.execute(
-							`--no-ignore --max-warnings 5 ${filePath} -c ${configFilePath}`,
-							null,
-							useFlatConfig,
-						);
-
-						assert.strictEqual(exitCode, 1);
-						assert.ok(log.error.calledOnce);
-						assert.include(
-							log.error.getCall(0).args[0],
-							"ESLint found too many warnings",
-						);
-					});
-
-					it(`should exit with exit code 1 without printing warnings if the quiet option is enabled and warning count exceeds threshold with configType:${configType}`, async () => {
-						const exitCode = await cli.execute(
-							`--no-ignore --quiet --max-warnings 5 ${filePath} -c ${configFilePath}`,
-							null,
-							useFlatConfig,
-						);
-
-						assert.strictEqual(exitCode, 1);
-						assert.ok(log.error.calledOnce);
-						assert.include(
-							log.error.getCall(0).args[0],
-							"ESLint found too many warnings",
-						);
-						assert.ok(log.info.notCalled); // didn't print warnings
-					});
-
-					it(`should not change exit code if warning count equals threshold with configType:${configType}`, async () => {
-						const exitCode = await cli.execute(
-							`--no-ignore --max-warnings 6 ${filePath} -c ${configFilePath}`,
-							null,
-							useFlatConfig,
-						);
-
-						assert.strictEqual(exitCode, 0);
-					});
-
-					it(`should not change exit code if flag is not specified and there are warnings with configType:${configType}`, async () => {
-						const exitCode = await cli.execute(
-							`-c ${configFilePath} ${filePath}`,
-							null,
-							useFlatConfig,
-						);
-
-						assert.strictEqual(exitCode, 0);
-					});
-				});
-
-				describe("when given the exit-on-fatal-error flag", () => {
-					it(`should not change exit code if no fatal errors are reported with configType:${configType}`, async () => {
-						const filePath = getFixturePath(
-							"exit-on-fatal-error",
-							"no-fatal-error.js",
-						);
-						const exitCode = await cli.execute(
-							`--no-ignore --exit-on-fatal-error ${filePath}`,
-							null,
-							useFlatConfig,
-						);
-
-						assert.strictEqual(exitCode, 0);
-					});
-
-					it(`should exit with exit code 1 if no fatal errors are found, but rule violations are found with configType:${configType}`, async () => {
-						const filePath = getFixturePath(
-							"exit-on-fatal-error",
-							"no-fatal-error-rule-violation.js",
-						);
-						const exitCode = await cli.execute(
-							`--no-ignore --exit-on-fatal-error ${filePath}`,
-							null,
-							useFlatConfig,
-						);
-
-						assert.strictEqual(exitCode, 1);
-					});
-
-					it(`should exit with exit code 2 if fatal error is found with configType:${configType}`, async () => {
-						const filePath = getFixturePath(
-							"exit-on-fatal-error",
-							"fatal-error.js",
-						);
-						const exitCode = await cli.execute(
-							`--no-ignore --exit-on-fatal-error ${filePath}`,
-							null,
-							useFlatConfig,
-						);
-
-						assert.strictEqual(exitCode, 2);
-					});
-
-					it(`should exit with exit code 2 if fatal error is found in any file with configType:${configType}`, async () => {
-						const filePath = getFixturePath("exit-on-fatal-error");
-						const exitCode = await cli.execute(
-							`--no-ignore --exit-on-fatal-error ${filePath}`,
-							null,
-							useFlatConfig,
-						);
-
-						assert.strictEqual(exitCode, 2);
-					});
-				});
-
-				describe("Ignores", () => {
-					describe("when given a directory with eslint excluded files in the directory", () => {
-						it(`should throw an error and not process any files with configType:${configType}`, async () => {
-							const options = useFlatConfig
-								? `--config ${getFixturePath("eslint.config-with-ignores.js")}`
-								: `--ignore-path ${getFixturePath(".eslintignore")}`;
-							const filePath = getFixturePath("cli");
-							const expectedMessage = useFlatConfig
-								? `All files matched by '${filePath.replace(/\\/gu, "/")}' are ignored.`
-								: `All files matched by '${filePath}' are ignored.`;
-
-							await stdAssert.rejects(async () => {
-								await cli.execute(
-									`${options} ${filePath}`,
-									null,
-									useFlatConfig,
-								);
-							}, new Error(expectedMessage));
-						});
-					});
-
-					describe("when given a file in excluded files list", () => {
-						it(`should not process the file with configType:${configType}`, async () => {
-							const options = useFlatConfig
-								? `--config ${getFixturePath("eslint.config-with-ignores.js")}`
-								: `--ignore-path ${getFixturePath(".eslintignore")}`;
-							const filePath = getFixturePath("passing.js");
-							const exit = await cli.execute(
-								`${options} ${filePath}`,
-								null,
-								useFlatConfig,
-							);
-
-							// a warning about the ignored file
-							assert.isTrue(log.info.called);
-							assert.strictEqual(exit, 0);
-						});
-
-						it(`should process the file when forced with configType:${configType}`, async () => {
-							const options = useFlatConfig
-								? `--config ${getFixturePath("eslint.config-with-ignores.js")}`
-								: `--ignore-path ${getFixturePath(".eslintignore")}`;
-							const filePath = getFixturePath("passing.js");
-							const exit = await cli.execute(
-								`${options} --no-ignore ${filePath}`,
-								null,
-								useFlatConfig,
-							);
-
-							// no warnings
-							assert.isFalse(log.info.called);
-							assert.strictEqual(exit, 0);
-						});
-
-						it(`should suppress the warning if --no-warn-ignored is passed with configType:${configType}`, async () => {
-							const options = useFlatConfig
-								? `--config ${getFixturePath("eslint.config-with-ignores.js")}`
-								: `--ignore-path ${getFixturePath(".eslintignore")}`;
-							const filePath = getFixturePath("passing.js");
-							const exit = await cli.execute(
-								`${options} --no-warn-ignored ${filePath}`,
-								null,
-								useFlatConfig,
-							);
-
-							assert.isFalse(log.info.called);
-
-							// When eslintrc is used, we get an exit code of 2 because the --no-warn-ignored option is unrecognized.
-							assert.strictEqual(exit, useFlatConfig ? 0 : 2);
-						});
-
-						it(`should not lint anything when no files are passed if --pass-on-no-patterns is passed with configType:${configType}`, async () => {
-							const exit = await cli.execute(
-								"--pass-on-no-patterns",
-								null,
-								useFlatConfig,
-							);
-
-							assert.isFalse(log.info.called);
-							assert.strictEqual(exit, 0);
-						});
-
-						it(`should suppress the warning if --no-warn-ignored is passed and an ignored file is passed via stdin with configType:${configType}`, async () => {
-							const options = useFlatConfig
-								? `--config ${getFixturePath("eslint.config-with-ignores.js")}`
-								: `--ignore-path ${getFixturePath(".eslintignore")}`;
-							const filePath = getFixturePath("passing.js");
-							const exit = await cli.execute(
-								`${options} --no-warn-ignored --stdin --stdin-filename ${filePath}`,
-								"foo",
-								useFlatConfig,
-							);
-
-							assert.isFalse(log.info.called);
-
-							// When eslintrc is used, we get an exit code of 2 because the --no-warn-ignored option is unrecognized.
-							assert.strictEqual(exit, useFlatConfig ? 0 : 2);
-						});
-					});
-
-					describe("when given a pattern to ignore", () => {
-						it(`should not process any files with configType:${configType}`, async () => {
-							const ignoredFile = getFixturePath(
-								"cli/syntax-error.js",
-							);
-							const ignorePathOption = useFlatConfig
-								? ""
-								: "--ignore-path .eslintignore_empty";
-							const filePath = getFixturePath("cli/passing.js");
-							const ignorePattern = useFlatConfig
-								? "cli/**"
-								: "cli/";
-							const exit = await cli.execute(
-								`--ignore-pattern ${ignorePattern} ${ignorePathOption} ${ignoredFile} ${filePath}`,
-								null,
-								useFlatConfig,
-							);
-
-							// warnings about the ignored files
-							assert.isTrue(log.info.called);
-							assert.strictEqual(exit, 0);
-						});
-
-						it(`should interpret pattern that contains a slash as relative to cwd with configType:${configType}`, async () => {
-							process.cwd = () =>
-								getFixturePath(
-									"cli/ignore-pattern-relative/subdir",
-								);
-
-							/*
-							 * The config file is in `cli/ignore-pattern-relative`, so this would fail
-							 * if `subdir/**` ignore pattern is interpreted as relative to the config base path.
-							 */
-							const exit = await cli.execute(
-								"**/*.js --ignore-pattern subdir/**",
-								null,
-								useFlatConfig,
-							);
-
-							assert.strictEqual(exit, 0);
-
-							await stdAssert.rejects(
-								async () =>
-									await cli.execute(
-										"**/*.js --ignore-pattern subsubdir/*.js",
-										null,
-										useFlatConfig,
-									),
-								/All files matched by '\*\*\/\*\.js' are ignored/u,
-							);
-						});
-
-						it(`should interpret pattern that doesn't contain a slash as relative to cwd with configType:${configType}`, async () => {
-							process.cwd = () =>
-								getFixturePath(
-									"cli/ignore-pattern-relative/subdir/subsubdir",
-								);
-
-							await stdAssert.rejects(
-								async () =>
-									await cli.execute(
-										"**/*.js --ignore-pattern *.js",
-										null,
-										useFlatConfig,
-									),
-								/All files matched by '\*\*\/\*\.js' are ignored/u,
-							);
-						});
-
-						if (useFlatConfig) {
-							it("should ignore files if the pattern is a path to a directory (with trailing slash)", async () => {
-								const filePath = getFixturePath(
-									"cli/syntax-error.js",
-								);
-								const exit = await cli.execute(
-									`--ignore-pattern cli/ ${filePath}`,
-									null,
-									true,
-								);
-
-								// parsing error causes exit code 1
-								assert.isTrue(log.info.called);
-								assert.strictEqual(exit, 0);
-							});
-
-							it("should ignore files if the pattern is a path to a directory (without trailing slash)", async () => {
-								const filePath = getFixturePath(
-									"cli/syntax-error.js",
-								);
-								const exit = await cli.execute(
-									`--ignore-pattern cli ${filePath}`,
-									null,
-									true,
-								);
-
-								// parsing error causes exit code 1
-								assert.isTrue(log.info.called);
-								assert.strictEqual(exit, 0);
-							});
-						}
 					});
 				});
 			});
 
-			describe("when given a parser name", () => {
-				it(`should exit with a fatal error if parser is invalid with configType:${configType}`, async () => {
-					const filePath = getFixturePath("passing.js");
+			describe("when given the max-warnings flag", () => {
+				let filePath, configFilePath;
 
-					await stdAssert.rejects(
-						async () =>
-							await cli.execute(
-								`--no-ignore --parser test111 ${filePath}`,
-								null,
-								useFlatConfig,
-							),
-						"Cannot find module 'test111'",
+				before(() => {
+					filePath = getFixturePath("max-warnings/six-warnings.js");
+					configFilePath = getFixturePath(
+						"max-warnings/eslint.config.js",
 					);
 				});
 
-				it(`should exit with no error if parser is valid with configType:${configType}`, async () => {
-					const filePath = getFixturePath("passing.js");
-					const flag = useFlatConfig
-						? "--no-config-lookup"
-						: "--no-eslintrc";
-					const exit = await cli.execute(
-						`${flag} --no-ignore --parser espree ${filePath}`,
+				it(`should not change exit code if warning count under threshold`, async () => {
+					const exitCode = await cli.execute(
+						`--no-ignore --max-warnings 10 ${filePath} -c ${configFilePath}`,
 						null,
-						useFlatConfig,
 					);
 
-					assert.strictEqual(exit, 0);
-				});
-			});
-
-			describe("when supplied with report output file path", () => {
-				const flag = useFlatConfig
-					? "--no-config-lookup"
-					: "--no-eslintrc";
-
-				afterEach(() => {
-					sh.rm("-rf", "tests/output");
+					assert.strictEqual(exitCode, 0);
 				});
 
-				it(`should write the file and create dirs if they don't exist with configType:${configType}`, async () => {
-					const filePath = getFixturePath("single-quoted.js");
-					const code = `${flag} --rule 'quotes: [1, double]' --o tests/output/eslint-output.txt ${filePath}`;
+				it(`should exit with exit code 1 if warning count exceeds threshold`, async () => {
+					const exitCode = await cli.execute(
+						`--no-ignore --max-warnings 5 ${filePath} -c ${configFilePath}`,
+						null,
+					);
 
-					await cli.execute(code, null, useFlatConfig);
-
+					assert.strictEqual(exitCode, 1);
+					assert.ok(log.error.calledOnce);
 					assert.include(
-						fs.readFileSync(
-							"tests/output/eslint-output.txt",
-							"utf8",
-						),
-						filePath,
+						log.error.getCall(0).args[0],
+						"ESLint found too many warnings",
 					);
-					assert.isTrue(log.info.notCalled);
 				});
 
-				// https://github.com/eslint/eslint/issues/17660
-				it(`should write the file and create dirs if they don't exist even when output is empty with configType:${configType}`, async () => {
-					const filePath = getFixturePath("single-quoted.js");
-					const code = `${flag} --rule 'quotes: [1, single]' --o tests/output/eslint-output.txt ${filePath}`;
-
-					// TODO: fix this test to: await cli.execute(code, null, useFlatConfig);
-					await cli.execute(code, "var a = 'b'", useFlatConfig);
-
-					assert.isTrue(
-						fs.existsSync("tests/output/eslint-output.txt"),
-					);
-					assert.strictEqual(
-						fs.readFileSync(
-							"tests/output/eslint-output.txt",
-							"utf8",
-						),
-						"",
-					);
-					assert.isTrue(log.info.notCalled);
-				});
-
-				it(`should return an error if the path is a directory with configType:${configType}`, async () => {
-					const filePath = getFixturePath("single-quoted.js");
-					const code = `${flag} --rule 'quotes: [1, double]' --o tests/output ${filePath}`;
-
-					fs.mkdirSync("tests/output");
-
-					const exit = await cli.execute(code, null, useFlatConfig);
-
-					assert.strictEqual(exit, 2);
-					assert.isTrue(log.info.notCalled);
-					assert.isTrue(log.error.calledOnce);
-				});
-
-				it(`should return an error if the path could not be written to with configType:${configType}`, async () => {
-					const filePath = getFixturePath("single-quoted.js");
-					const code = `${flag} --rule 'quotes: [1, double]' --o tests/output/eslint-output.txt ${filePath}`;
-
-					fs.writeFileSync("tests/output", "foo");
-
-					const exit = await cli.execute(code, null, useFlatConfig);
-
-					assert.strictEqual(exit, 2);
-					assert.isTrue(log.info.notCalled);
-					assert.isTrue(log.error.calledOnce);
-				});
-			});
-
-			describe("when passed --no-inline-config", () => {
-				let localCLI;
-
-				afterEach(() => {
-					sinon.verifyAndRestore();
-				});
-
-				it(`should pass allowInlineConfig:false to ESLint when --no-inline-config is used with configType:${configType}`, async () => {
-					// create a fake ESLint class to test with
-					const fakeESLint = sinon
-						.mock()
-						.withExactArgs(
-							sinon.match({ allowInlineConfig: false }),
-						);
-
-					Object.defineProperties(
-						fakeESLint.prototype,
-						Object.getOwnPropertyDescriptors(
-							ActiveESLint.prototype,
-						),
-					);
-					sinon.stub(fakeESLint.prototype, "lintFiles").returns([
-						{
-							filePath: "./foo.js",
-							output: "bar",
-							messages: [
-								{
-									severity: 2,
-									message: "Fake message",
-								},
-							],
-							errorCount: 1,
-							warningCount: 0,
-						},
-					]);
-					sinon
-						.stub(fakeESLint.prototype, "loadFormatter")
-						.returns({ format: () => "done" });
-					fakeESLint.outputFixes = sinon.stub();
-
-					localCLI = proxyquire("../../lib/cli", {
-						"./eslint": { LegacyESLint: fakeESLint },
-						"./eslint/eslint": {
-							ESLint: fakeESLint,
-							shouldUseFlatConfig: () =>
-								Promise.resolve(useFlatConfig),
-						},
-						"./shared/logging": log,
-					});
-
-					await localCLI.execute(
-						"--no-inline-config .",
+				it(`should exit with exit code 1 without printing warnings if the quiet option is enabled and warning count exceeds threshold`, async () => {
+					const exitCode = await cli.execute(
+						`--no-ignore --quiet --max-warnings 5 ${filePath} -c ${configFilePath}`,
 						null,
-						useFlatConfig,
 					);
+
+					assert.strictEqual(exitCode, 1);
+					assert.ok(log.error.calledOnce);
+					assert.include(
+						log.error.getCall(0).args[0],
+						"ESLint found too many warnings",
+					);
+					assert.ok(log.info.notCalled); // didn't print warnings
 				});
 
-				it(`should not error and allowInlineConfig should be true by default with configType:${configType}`, async () => {
-					// create a fake ESLint class to test with
-					const fakeESLint = sinon
-						.mock()
-						.withExactArgs(
-							sinon.match({ allowInlineConfig: true }),
-						);
-
-					Object.defineProperties(
-						fakeESLint.prototype,
-						Object.getOwnPropertyDescriptors(
-							ActiveESLint.prototype,
-						),
-					);
-					sinon.stub(fakeESLint.prototype, "lintFiles").returns([]);
-					sinon
-						.stub(fakeESLint.prototype, "loadFormatter")
-						.returns({ format: () => "done" });
-					fakeESLint.outputFixes = sinon.stub();
-
-					localCLI = proxyquire("../../lib/cli", {
-						"./eslint": { LegacyESLint: fakeESLint },
-						"./eslint/eslint": {
-							ESLint: fakeESLint,
-							shouldUseFlatConfig: () =>
-								Promise.resolve(useFlatConfig),
-						},
-						"./shared/logging": log,
-					});
-
-					const exitCode = await localCLI.execute(
-						".",
+				it(`should not change exit code if warning count equals threshold`, async () => {
+					const exitCode = await cli.execute(
+						`--no-ignore --max-warnings 6 ${filePath} -c ${configFilePath}`,
 						null,
-						useFlatConfig,
+					);
+
+					assert.strictEqual(exitCode, 0);
+				});
+
+				it(`should not change exit code if flag is not specified and there are warnings`, async () => {
+					const exitCode = await cli.execute(
+						`-c ${configFilePath} ${filePath}`,
+						null,
 					);
 
 					assert.strictEqual(exitCode, 0);
 				});
 			});
 
-			describe("when passed --fix", () => {
-				let localCLI;
-
-				afterEach(() => {
-					sinon.verifyAndRestore();
-				});
-
-				it(`should pass fix:true to ESLint when executing on files with configType:${configType}`, async () => {
-					// create a fake ESLint class to test with
-					const fakeESLint = sinon
-						.mock()
-						.withExactArgs(sinon.match({ fix: true }));
-
-					Object.defineProperties(
-						fakeESLint.prototype,
-						Object.getOwnPropertyDescriptors(
-							ActiveESLint.prototype,
-						),
+			describe("when given the exit-on-fatal-error flag", () => {
+				it(`should not change exit code if no fatal errors are reported`, async () => {
+					const filePath = getFixturePath(
+						"exit-on-fatal-error",
+						"no-fatal-error.js",
 					);
-					sinon.stub(fakeESLint.prototype, "lintFiles").returns([]);
-					sinon
-						.stub(fakeESLint.prototype, "loadFormatter")
-						.returns({ format: () => "done" });
-					fakeESLint.outputFixes = sinon.mock().once();
-
-					localCLI = proxyquire("../../lib/cli", {
-						"./eslint": { LegacyESLint: fakeESLint },
-						"./eslint/eslint": {
-							ESLint: fakeESLint,
-							shouldUseFlatConfig: () =>
-								Promise.resolve(useFlatConfig),
-						},
-						"./shared/logging": log,
-					});
-
-					const exitCode = await localCLI.execute(
-						"--fix .",
+					const exitCode = await cli.execute(
+						`--no-ignore --exit-on-fatal-error ${filePath}`,
 						null,
-						useFlatConfig,
 					);
 
 					assert.strictEqual(exitCode, 0);
 				});
 
-				it(`should rewrite files when in fix mode with configType:${configType}`, async () => {
-					const report = [
-						{
-							filePath: "./foo.js",
-							output: "bar",
-							messages: [
-								{
-									severity: 2,
-									message: "Fake message",
-								},
-							],
-							errorCount: 1,
-							warningCount: 0,
-						},
-					];
-
-					// create a fake ESLint class to test with
-					const fakeESLint = sinon
-						.mock()
-						.withExactArgs(sinon.match({ fix: true }));
-
-					Object.defineProperties(
-						fakeESLint.prototype,
-						Object.getOwnPropertyDescriptors(
-							ActiveESLint.prototype,
-						),
+				it(`should exit with exit code 1 if no fatal errors are found, but rule violations are found`, async () => {
+					const filePath = getFixturePath(
+						"exit-on-fatal-error",
+						"no-fatal-error-rule-violation.js",
 					);
-					sinon
-						.stub(fakeESLint.prototype, "lintFiles")
-						.returns(report);
-					sinon
-						.stub(fakeESLint.prototype, "loadFormatter")
-						.returns({ format: () => "done" });
-					fakeESLint.outputFixes = sinon.mock().withExactArgs(report);
-
-					localCLI = proxyquire("../../lib/cli", {
-						"./eslint": { LegacyESLint: fakeESLint },
-						"./eslint/eslint": {
-							ESLint: fakeESLint,
-							shouldUseFlatConfig: () =>
-								Promise.resolve(useFlatConfig),
-						},
-						"./shared/logging": log,
-					});
-
-					const exitCode = await localCLI.execute(
-						"--fix .",
+					const exitCode = await cli.execute(
+						`--no-ignore --exit-on-fatal-error ${filePath}`,
 						null,
-						useFlatConfig,
 					);
 
 					assert.strictEqual(exitCode, 1);
 				});
 
-				it(`should provide fix predicate and rewrite files when in fix mode and quiet mode with configType:${configType}`, async () => {
-					const report = [
-						{
-							filePath: "./foo.js",
-							output: "bar",
-							messages: [
-								{
-									severity: 1,
-									message: "Fake message",
-								},
-							],
-							errorCount: 0,
-							warningCount: 1,
-						},
-					];
-
-					// create a fake ESLint class to test with
-					const fakeESLint = sinon
-						.mock()
-						.withExactArgs(sinon.match({ fix: sinon.match.func }));
-
-					Object.defineProperties(
-						fakeESLint.prototype,
-						Object.getOwnPropertyDescriptors(
-							ActiveESLint.prototype,
-						),
+				it(`should exit with exit code 2 if fatal error is found`, async () => {
+					const filePath = getFixturePath(
+						"exit-on-fatal-error",
+						"fatal-error.js",
 					);
-					sinon
-						.stub(fakeESLint.prototype, "lintFiles")
-						.returns(report);
-					sinon
-						.stub(fakeESLint.prototype, "loadFormatter")
-						.returns({ format: () => "done" });
-					fakeESLint.getErrorResults = sinon.stub().returns([]);
-					fakeESLint.outputFixes = sinon.mock().withExactArgs(report);
-
-					localCLI = proxyquire("../../lib/cli", {
-						"./eslint": { LegacyESLint: fakeESLint },
-						"./eslint/eslint": {
-							ESLint: fakeESLint,
-							shouldUseFlatConfig: () =>
-								Promise.resolve(useFlatConfig),
-						},
-						"./shared/logging": log,
-					});
-
-					const exitCode = await localCLI.execute(
-						"--fix --quiet .",
+					const exitCode = await cli.execute(
+						`--no-ignore --exit-on-fatal-error ${filePath}`,
 						null,
-						useFlatConfig,
 					);
 
-					assert.strictEqual(exitCode, 0);
+					assert.strictEqual(exitCode, 2);
 				});
 
-				it(`should not call ESLint and return 2 when executing on text with configType:${configType}`, async () => {
-					// create a fake ESLint class to test with
-					const fakeESLint = sinon.mock().never();
-
-					localCLI = proxyquire("../../lib/cli", {
-						"./eslint": { LegacyESLint: fakeESLint },
-						"./eslint/eslint": {
-							ESLint: fakeESLint,
-							shouldUseFlatConfig: () =>
-								Promise.resolve(useFlatConfig),
-						},
-						"./shared/logging": log,
-					});
-
-					const exitCode = await localCLI.execute(
-						"--fix .",
-						"foo = bar;",
-						useFlatConfig,
+				it(`should exit with exit code 2 if fatal error is found in any file`, async () => {
+					const filePath = getFixturePath("exit-on-fatal-error");
+					const exitCode = await cli.execute(
+						`--no-ignore --exit-on-fatal-error ${filePath}`,
+						null,
 					);
 
 					assert.strictEqual(exitCode, 2);
 				});
 			});
 
-			describe("when passed --fix-dry-run", () => {
-				let localCLI;
+			describe("Ignores", () => {
+				describe("when given a directory with eslint excluded files in the directory", () => {
+					it(`should throw an error and not process any files`, async () => {
+						const options = `--config ${getFixturePath("eslint.config-with-ignores.js")}`;
+						const filePath = getFixturePath("cli");
+						const expectedMessage = `All files matched by '${filePath.replace(/\\/gu, "/")}' are ignored.`;
 
-				afterEach(() => {
-					sinon.verifyAndRestore();
+						await stdAssert.rejects(async () => {
+							await cli.execute(`${options} ${filePath}`);
+						}, new Error(expectedMessage));
+					});
 				});
 
-				it(`should pass fix:true to ESLint when executing on files with configType:${configType}`, async () => {
-					// create a fake ESLint class to test with
-					const fakeESLint = sinon
-						.mock()
-						.withExactArgs(sinon.match({ fix: true }));
-
-					Object.defineProperties(
-						fakeESLint.prototype,
-						Object.getOwnPropertyDescriptors(
-							ActiveESLint.prototype,
-						),
-					);
-					sinon.stub(fakeESLint.prototype, "lintFiles").returns([]);
-					sinon
-						.stub(fakeESLint.prototype, "loadFormatter")
-						.returns({ format: () => "done" });
-					fakeESLint.outputFixes = sinon.mock().never();
-
-					localCLI = proxyquire("../../lib/cli", {
-						"./eslint": { LegacyESLint: fakeESLint },
-						"./eslint/eslint": {
-							ESLint: fakeESLint,
-							shouldUseFlatConfig: () =>
-								Promise.resolve(useFlatConfig),
-						},
-
-						"./shared/logging": log,
-					});
-
-					const exitCode = await localCLI.execute(
-						"--fix-dry-run .",
-						null,
-						useFlatConfig,
-					);
-
-					assert.strictEqual(exitCode, 0);
-				});
-
-				it(`should pass fixTypes to ESLint when --fix-type is passed with configType:${configType}`, async () => {
-					const expectedESLintOptions = {
-						fix: true,
-						fixTypes: ["suggestion"],
-					};
-
-					// create a fake ESLint class to test with
-					const fakeESLint = sinon
-						.mock()
-						.withExactArgs(sinon.match(expectedESLintOptions));
-
-					Object.defineProperties(
-						fakeESLint.prototype,
-						Object.getOwnPropertyDescriptors(
-							ActiveESLint.prototype,
-						),
-					);
-					sinon.stub(fakeESLint.prototype, "lintFiles").returns([]);
-					sinon
-						.stub(fakeESLint.prototype, "loadFormatter")
-						.returns({ format: () => "done" });
-					fakeESLint.outputFixes = sinon.stub();
-
-					localCLI = proxyquire("../../lib/cli", {
-						"./eslint": { LegacyESLint: fakeESLint },
-						"./eslint/eslint": {
-							ESLint: fakeESLint,
-							shouldUseFlatConfig: () =>
-								Promise.resolve(useFlatConfig),
-						},
-
-						"./shared/logging": log,
-					});
-
-					const exitCode = await localCLI.execute(
-						"--fix-dry-run --fix-type suggestion .",
-						null,
-						useFlatConfig,
-					);
-
-					assert.strictEqual(exitCode, 0);
-				});
-
-				it(`should not rewrite files when in fix-dry-run mode with configType:${configType}`, async () => {
-					const report = [
-						{
-							filePath: "./foo.js",
-							output: "bar",
-							messages: [
-								{
-									severity: 2,
-									message: "Fake message",
-								},
-							],
-							errorCount: 1,
-							warningCount: 0,
-						},
-					];
-
-					// create a fake ESLint class to test with
-					const fakeESLint = sinon
-						.mock()
-						.withExactArgs(sinon.match({ fix: true }));
-
-					Object.defineProperties(
-						fakeESLint.prototype,
-						Object.getOwnPropertyDescriptors(
-							ActiveESLint.prototype,
-						),
-					);
-					sinon
-						.stub(fakeESLint.prototype, "lintFiles")
-						.returns(report);
-					sinon
-						.stub(fakeESLint.prototype, "loadFormatter")
-						.returns({ format: () => "done" });
-					fakeESLint.outputFixes = sinon.mock().never();
-
-					localCLI = proxyquire("../../lib/cli", {
-						"./eslint": { LegacyESLint: fakeESLint },
-						"./eslint/eslint": {
-							ESLint: fakeESLint,
-							shouldUseFlatConfig: () =>
-								Promise.resolve(useFlatConfig),
-						},
-
-						"./shared/logging": log,
-					});
-
-					const exitCode = await localCLI.execute(
-						"--fix-dry-run .",
-						null,
-						useFlatConfig,
-					);
-
-					assert.strictEqual(exitCode, 1);
-				});
-
-				it(`should provide fix predicate when in fix-dry-run mode and quiet mode with configType:${configType}`, async () => {
-					const report = [
-						{
-							filePath: "./foo.js",
-							output: "bar",
-							messages: [
-								{
-									severity: 1,
-									message: "Fake message",
-								},
-							],
-							errorCount: 0,
-							warningCount: 1,
-						},
-					];
-
-					// create a fake ESLint class to test with
-					const fakeESLint = sinon
-						.mock()
-						.withExactArgs(sinon.match({ fix: sinon.match.func }));
-
-					Object.defineProperties(
-						fakeESLint.prototype,
-						Object.getOwnPropertyDescriptors(
-							ActiveESLint.prototype,
-						),
-					);
-					sinon
-						.stub(fakeESLint.prototype, "lintFiles")
-						.returns(report);
-					sinon
-						.stub(fakeESLint.prototype, "loadFormatter")
-						.returns({ format: () => "done" });
-					fakeESLint.getErrorResults = sinon.stub().returns([]);
-					fakeESLint.outputFixes = sinon.mock().never();
-
-					localCLI = proxyquire("../../lib/cli", {
-						"./eslint": { LegacyESLint: fakeESLint },
-						"./eslint/eslint": {
-							ESLint: fakeESLint,
-							shouldUseFlatConfig: () =>
-								Promise.resolve(useFlatConfig),
-						},
-
-						"./shared/logging": log,
-					});
-
-					const exitCode = await localCLI.execute(
-						"--fix-dry-run --quiet .",
-						null,
-						useFlatConfig,
-					);
-
-					assert.strictEqual(exitCode, 0);
-				});
-
-				it(`should allow executing on text with configType:${configType}`, async () => {
-					const report = [
-						{
-							filePath: "./foo.js",
-							output: "bar",
-							messages: [
-								{
-									severity: 2,
-									message: "Fake message",
-								},
-							],
-							errorCount: 1,
-							warningCount: 0,
-						},
-					];
-
-					// create a fake ESLint class to test with
-					const fakeESLint = sinon
-						.mock()
-						.withExactArgs(sinon.match({ fix: true }));
-
-					Object.defineProperties(
-						fakeESLint.prototype,
-						Object.getOwnPropertyDescriptors(
-							ActiveESLint.prototype,
-						),
-					);
-					sinon
-						.stub(fakeESLint.prototype, "lintText")
-						.returns(report);
-					sinon
-						.stub(fakeESLint.prototype, "loadFormatter")
-						.returns({ format: () => "done" });
-					fakeESLint.outputFixes = sinon.mock().never();
-
-					localCLI = proxyquire("../../lib/cli", {
-						"./eslint": { LegacyESLint: fakeESLint },
-						"./eslint/eslint": {
-							ESLint: fakeESLint,
-							shouldUseFlatConfig: () =>
-								Promise.resolve(useFlatConfig),
-						},
-
-						"./shared/logging": log,
-					});
-
-					const exitCode = await localCLI.execute(
-						"--fix-dry-run .",
-						"foo = bar;",
-						useFlatConfig,
-					);
-
-					assert.strictEqual(exitCode, 1);
-				});
-
-				it(`should not call ESLint and return 2 when used with --fix with configType:${configType}`, async () => {
-					// create a fake ESLint class to test with
-					const fakeESLint = sinon.mock().never();
-
-					localCLI = proxyquire("../../lib/cli", {
-						"./eslint": { LegacyESLint: fakeESLint },
-						"./eslint/eslint": {
-							ESLint: fakeESLint,
-							shouldUseFlatConfig: () =>
-								Promise.resolve(useFlatConfig),
-						},
-						"./shared/logging": log,
-					});
-
-					const exitCode = await localCLI.execute(
-						"--fix --fix-dry-run .",
-						"foo = bar;",
-						useFlatConfig,
-					);
-
-					assert.strictEqual(exitCode, 2);
-				});
-			});
-
-			describe("when passing --print-config", () => {
-				const originalCwd = process.cwd;
-
-				beforeEach(() => {
-					process.cwd = () => getFixturePath();
-				});
-
-				afterEach(() => {
-					process.cwd = originalCwd;
-				});
-
-				it(`should print out the configuration with configType:${configType}`, async () => {
-					const filePath = getFixturePath("xxx.js");
-
-					const exitCode = await cli.execute(
-						`--print-config ${filePath}`,
-						null,
-						useFlatConfig,
-					);
-
-					assert.isTrue(log.info.calledOnce);
-					assert.strictEqual(exitCode, 0);
-				});
-
-				it(`should error if any positional file arguments are passed with configType:${configType}`, async () => {
-					const filePath1 = getFixturePath("files", "bar.js");
-					const filePath2 = getFixturePath("files", "foo.js");
-
-					const exitCode = await cli.execute(
-						`--print-config ${filePath1} ${filePath2}`,
-						null,
-						useFlatConfig,
-					);
-
-					assert.isTrue(log.info.notCalled);
-					assert.isTrue(log.error.calledOnce);
-					assert.strictEqual(exitCode, 2);
-				});
-
-				it(`should error out when executing on text with configType:${configType}`, async () => {
-					const exitCode = await cli.execute(
-						"--print-config=myFile.js",
-						"foo = bar;",
-						useFlatConfig,
-					);
-
-					assert.isTrue(log.info.notCalled);
-					assert.isTrue(log.error.calledOnce);
-					assert.strictEqual(exitCode, 2);
-				});
-			});
-
-			describe("when passing --report-unused-disable-directives", () => {
-				describe(`config type: ${configType}`, () => {
-					it("errors when --report-unused-disable-directives", async () => {
-						const exitCode = await cli.execute(
-							`${useFlatConfig ? "--no-config-lookup" : "--no-eslintrc"} --report-unused-disable-directives --rule "'no-console': 'error'"`,
-							"foo(); // eslint-disable-line no-console",
-							useFlatConfig,
-						);
-
-						assert.strictEqual(
-							log.error.callCount,
-							0,
-							"log.error should not be called",
-						);
-						assert.strictEqual(
-							log.info.callCount,
-							1,
-							"log.info is called once",
-						);
-						assert.ok(
-							log.info.firstCall.args[0].includes(
-								"Unused eslint-disable directive (no problems were reported from 'no-console')",
-							),
-							"has correct message about unused directives",
-						);
-						assert.ok(
-							log.info.firstCall.args[0].includes(
-								"1 error and 0 warning",
-							),
-							"has correct error and warning count",
-						);
-						assert.strictEqual(
-							exitCode,
-							1,
-							"exit code should be 1",
-						);
-					});
-
-					it("errors when --report-unused-disable-directives-severity error", async () => {
-						const exitCode = await cli.execute(
-							`${useFlatConfig ? "--no-config-lookup" : "--no-eslintrc"} --report-unused-disable-directives-severity error --rule "'no-console': 'error'"`,
-							"foo(); // eslint-disable-line no-console",
-							useFlatConfig,
-						);
-
-						assert.strictEqual(
-							log.error.callCount,
-							0,
-							"log.error should not be called",
-						);
-						assert.strictEqual(
-							log.info.callCount,
-							1,
-							"log.info is called once",
-						);
-						assert.ok(
-							log.info.firstCall.args[0].includes(
-								"Unused eslint-disable directive (no problems were reported from 'no-console')",
-							),
-							"has correct message about unused directives",
-						);
-						assert.ok(
-							log.info.firstCall.args[0].includes(
-								"1 error and 0 warning",
-							),
-							"has correct error and warning count",
-						);
-						assert.strictEqual(
-							exitCode,
-							1,
-							"exit code should be 1",
-						);
-					});
-
-					it("errors when --report-unused-disable-directives-severity 2", async () => {
-						const exitCode = await cli.execute(
-							`${useFlatConfig ? "--no-config-lookup" : "--no-eslintrc"} --report-unused-disable-directives-severity 2 --rule "'no-console': 'error'"`,
-							"foo(); // eslint-disable-line no-console",
-							useFlatConfig,
-						);
-
-						assert.strictEqual(
-							log.error.callCount,
-							0,
-							"log.error should not be called",
-						);
-						assert.strictEqual(
-							log.info.callCount,
-							1,
-							"log.info is called once",
-						);
-						assert.ok(
-							log.info.firstCall.args[0].includes(
-								"Unused eslint-disable directive (no problems were reported from 'no-console')",
-							),
-							"has correct message about unused directives",
-						);
-						assert.ok(
-							log.info.firstCall.args[0].includes(
-								"1 error and 0 warning",
-							),
-							"has correct error and warning count",
-						);
-						assert.strictEqual(
-							exitCode,
-							1,
-							"exit code should be 1",
-						);
-					});
-
-					it("warns when --report-unused-disable-directives-severity warn", async () => {
-						const exitCode = await cli.execute(
-							`${useFlatConfig ? "--no-config-lookup" : "--no-eslintrc"} --report-unused-disable-directives-severity warn --rule "'no-console': 'error'""`,
-							"foo(); // eslint-disable-line no-console",
-							useFlatConfig,
-						);
-
-						assert.strictEqual(
-							log.error.callCount,
-							0,
-							"log.error should not be called",
-						);
-						assert.strictEqual(
-							log.info.callCount,
-							1,
-							"log.info is called once",
-						);
-						assert.ok(
-							log.info.firstCall.args[0].includes(
-								"Unused eslint-disable directive (no problems were reported from 'no-console')",
-							),
-							"has correct message about unused directives",
-						);
-						assert.ok(
-							log.info.firstCall.args[0].includes(
-								"0 errors and 1 warning",
-							),
-							"has correct error and warning count",
-						);
-						assert.strictEqual(
-							exitCode,
-							0,
-							"exit code should be 0",
-						);
-					});
-
-					it("warns when --report-unused-disable-directives-severity 1", async () => {
-						const exitCode = await cli.execute(
-							`${useFlatConfig ? "--no-config-lookup" : "--no-eslintrc"} --report-unused-disable-directives-severity 1 --rule "'no-console': 'error'"`,
-							"foo(); // eslint-disable-line no-console",
-							useFlatConfig,
-						);
-
-						assert.strictEqual(
-							log.error.callCount,
-							0,
-							"log.error should not be called",
-						);
-						assert.strictEqual(
-							log.info.callCount,
-							1,
-							"log.info is called once",
-						);
-						assert.ok(
-							log.info.firstCall.args[0].includes(
-								"Unused eslint-disable directive (no problems were reported from 'no-console')",
-							),
-							"has correct message about unused directives",
-						);
-						assert.ok(
-							log.info.firstCall.args[0].includes(
-								"0 errors and 1 warning",
-							),
-							"has correct error and warning count",
-						);
-						assert.strictEqual(
-							exitCode,
-							0,
-							"exit code should be 0",
-						);
-					});
-
-					it("does not report when --report-unused-disable-directives-severity off", async () => {
-						const exitCode = await cli.execute(
-							`${useFlatConfig ? "--no-config-lookup" : "--no-eslintrc"} --report-unused-disable-directives-severity off --rule "'no-console': 'error'"`,
-							"foo(); // eslint-disable-line no-console",
-							useFlatConfig,
-						);
-
-						assert.strictEqual(
-							log.error.callCount,
-							0,
-							"log.error should not be called",
-						);
-						assert.strictEqual(
-							log.info.callCount,
-							0,
-							"log.info should not be called",
-						);
-						assert.strictEqual(
-							exitCode,
-							0,
-							"exit code should be 0",
-						);
-					});
-
-					it("does not report when --report-unused-disable-directives-severity 0", async () => {
-						const exitCode = await cli.execute(
-							`${useFlatConfig ? "--no-config-lookup" : "--no-eslintrc"} --report-unused-disable-directives-severity 0 --rule "'no-console': 'error'"`,
-							"foo(); // eslint-disable-line no-console",
-							useFlatConfig,
-						);
-
-						assert.strictEqual(
-							log.error.callCount,
-							0,
-							"log.error should not be called",
-						);
-						assert.strictEqual(
-							log.info.callCount,
-							0,
-							"log.info should not be called",
-						);
-						assert.strictEqual(
-							exitCode,
-							0,
-							"exit code should be 0",
-						);
-					});
-
-					it("fails when passing invalid string for --report-unused-disable-directives-severity", async () => {
-						const exitCode = await cli.execute(
-							`${useFlatConfig ? "--no-config-lookup" : "--no-eslintrc"} --report-unused-disable-directives-severity foo`,
+				describe("when given a file in excluded files list", () => {
+					it(`should not process the file`, async () => {
+						const options = `--config ${getFixturePath("eslint.config-with-ignores.js")}`;
+						const filePath = getFixturePath("passing.js");
+						const exit = await cli.execute(
+							`${options} ${filePath}`,
 							null,
-							useFlatConfig,
 						);
 
-						assert.strictEqual(
-							log.info.callCount,
-							0,
-							"log.info should not be called",
-						);
-						assert.strictEqual(
-							log.error.callCount,
-							1,
-							"log.error should be called once",
-						);
-
-						const lines = [
-							"Option report-unused-disable-directives-severity: 'foo' not one of off, warn, error, 0, 1, or 2.",
-						];
-
-						if (useFlatConfig) {
-							lines.push(
-								"You're using eslint.config.js, some command line flags are no longer available. Please see https://eslint.org/docs/latest/use/command-line-interface for details.",
-							);
-						}
-						assert.deepStrictEqual(
-							log.error.firstCall.args,
-							[lines.join("\n")],
-							"has the right text to log.error",
-						);
-						assert.strictEqual(
-							exitCode,
-							2,
-							"exit code should be 2",
-						);
+						// a warning about the ignored file
+						assert.isTrue(log.info.called);
+						assert.strictEqual(exit, 0);
 					});
 
-					it("fails when passing both --report-unused-disable-directives and --report-unused-disable-directives-severity", async () => {
-						const exitCode = await cli.execute(
-							`${useFlatConfig ? "--no-config-lookup" : "--no-eslintrc"} --report-unused-disable-directives --report-unused-disable-directives-severity warn`,
+					it(`should process the file when forced`, async () => {
+						const options = `--config ${getFixturePath("eslint.config-with-ignores.js")}`;
+						const filePath = getFixturePath("passing.js");
+						const exit = await cli.execute(
+							`${options} --no-ignore ${filePath}`,
 							null,
-							useFlatConfig,
 						);
 
-						assert.strictEqual(
-							log.info.callCount,
-							0,
-							"log.info should not be called",
-						);
-						assert.strictEqual(
-							log.error.callCount,
-							1,
-							"log.error should be called once",
-						);
-						assert.deepStrictEqual(
-							log.error.firstCall.args,
-							[
-								"The --report-unused-disable-directives option and the --report-unused-disable-directives-severity option cannot be used together.",
-							],
-							"has the right text to log.error",
-						);
-						assert.strictEqual(
-							exitCode,
-							2,
-							"exit code should be 2",
-						);
+						// no warnings
+						assert.isFalse(log.info.called);
+						assert.strictEqual(exit, 0);
 					});
 
-					it("warns by default in flat config only", async () => {
-						const exitCode = await cli.execute(
-							`${useFlatConfig ? "--no-config-lookup" : "--no-eslintrc"} --rule "'no-console': 'error'"`,
-							"foo(); // eslint-disable-line no-console",
-							useFlatConfig,
+					it(`should suppress the warning if --no-warn-ignored is passed`, async () => {
+						const options = `--config ${getFixturePath("eslint.config-with-ignores.js")}`;
+						const filePath = getFixturePath("passing.js");
+						const exit = await cli.execute(
+							`${options} --no-warn-ignored ${filePath}`,
+							null,
 						);
 
-						if (useFlatConfig) {
-							assert.strictEqual(
-								log.error.callCount,
-								0,
-								"log.error should not be called",
-							);
-							assert.strictEqual(
-								log.info.callCount,
-								1,
-								"log.info is called once",
-							);
-							assert.ok(
-								log.info.firstCall.args[0].includes(
-									"Unused eslint-disable directive (no problems were reported from 'no-console')",
-								),
-								"has correct message about unused directives",
-							);
-							assert.ok(
-								log.info.firstCall.args[0].includes(
-									"0 errors and 1 warning",
-								),
-								"has correct error and warning count",
-							);
-							assert.strictEqual(
-								exitCode,
-								0,
-								"exit code should be 0",
-							);
-						} else {
-							assert.strictEqual(
-								log.error.callCount,
-								0,
-								"log.error should not be called",
-							);
-							assert.strictEqual(
-								log.info.callCount,
-								0,
-								"log.info should not be called",
-							);
-							assert.strictEqual(
-								exitCode,
-								0,
-								"exit code should be 0",
-							);
-						}
+						assert.isFalse(log.info.called);
+						assert.strictEqual(exit, 0);
+					});
+
+					it(`should not lint anything when no files are passed if --pass-on-no-patterns is passed`, async () => {
+						const exit = await cli.execute(
+							"--pass-on-no-patterns",
+							null,
+						);
+
+						assert.isFalse(log.info.called);
+						assert.strictEqual(exit, 0);
+					});
+
+					it(`should suppress the warning if --no-warn-ignored is passed and an ignored file is passed via stdin`, async () => {
+						const options = `--config ${getFixturePath("eslint.config-with-ignores.js")}`;
+						const filePath = getFixturePath("passing.js");
+						const exit = await cli.execute(
+							`${options} --no-warn-ignored --stdin --stdin-filename ${filePath}`,
+							"foo",
+						);
+
+						assert.isFalse(log.info.called);
+						assert.strictEqual(exit, 0);
 					});
 				});
+
+				describe("when given a pattern to ignore", () => {
+					it(`should not process any files`, async () => {
+						const ignoredFile = getFixturePath(
+							"cli/syntax-error.js",
+						);
+						const filePath = getFixturePath("cli/passing.js");
+						const exit = await cli.execute(
+							`--ignore-pattern cli/** ${ignoredFile} ${filePath}`,
+							null,
+						);
+
+						// warnings about the ignored files
+						assert.isTrue(log.info.called);
+						assert.strictEqual(exit, 0);
+					});
+
+					it(`should interpret pattern that contains a slash as relative to cwd`, async () => {
+						process.cwd = () =>
+							getFixturePath(
+								"cli/ignore-pattern-relative/subdir",
+							);
+
+						/*
+						 * The config file is in `cli/ignore-pattern-relative`, so this would fail
+						 * if `subdir/**` ignore pattern is interpreted as relative to the config base path.
+						 */
+						const exit = await cli.execute(
+							"**/*.js --ignore-pattern subdir/**",
+							null,
+						);
+
+						assert.strictEqual(exit, 0);
+
+						await stdAssert.rejects(
+							async () =>
+								await cli.execute(
+									"**/*.js --ignore-pattern subsubdir/*.js",
+									null,
+								),
+							/All files matched by '\*\*\/\*\.js' are ignored/u,
+						);
+					});
+
+					it(`should interpret pattern that doesn't contain a slash as relative to cwd`, async () => {
+						process.cwd = () =>
+							getFixturePath(
+								"cli/ignore-pattern-relative/subdir/subsubdir",
+							);
+
+						await stdAssert.rejects(
+							async () =>
+								await cli.execute(
+									"**/*.js --ignore-pattern *.js",
+									null,
+								),
+							/All files matched by '\*\*\/\*\.js' are ignored/u,
+						);
+					});
+
+					it("should ignore files if the pattern is a path to a directory (with trailing slash)", async () => {
+						const filePath = getFixturePath("cli/syntax-error.js");
+						const exit = await cli.execute(
+							`--ignore-pattern cli/ ${filePath}`,
+							null,
+						);
+
+						// parsing error causes exit code 1
+						assert.isTrue(log.info.called);
+						assert.strictEqual(exit, 0);
+					});
+
+					it("should ignore files if the pattern is a path to a directory (without trailing slash)", async () => {
+						const filePath = getFixturePath("cli/syntax-error.js");
+						const exit = await cli.execute(
+							`--ignore-pattern cli ${filePath}`,
+							null,
+						);
+
+						// parsing error causes exit code 1
+						assert.isTrue(log.info.called);
+						assert.strictEqual(exit, 0);
+					});
+				});
+			});
+		});
+
+		describe("when given a parser name", () => {
+			it(`should exit with a fatal error if parser is invalid`, async () => {
+				const filePath = getFixturePath("passing.js");
+
+				await stdAssert.rejects(
+					async () =>
+						await cli.execute(
+							`--no-ignore --parser test111 ${filePath}`,
+							null,
+						),
+					"Cannot find module 'test111'",
+				);
+			});
+
+			it(`should exit with no error if parser is valid`, async () => {
+				const filePath = getFixturePath("passing.js");
+				const exit = await cli.execute(
+					`--no-config-lookup --no-ignore --parser espree ${filePath}`,
+					null,
+				);
+
+				assert.strictEqual(exit, 0);
+			});
+		});
+
+		describe("when supplied with report output file path", () => {
+			afterEach(() => {
+				sh.rm("-rf", "tests/output");
+			});
+
+			it(`should write the file and create dirs if they don't exist`, async () => {
+				const filePath = getFixturePath("single-quoted.js");
+				const code = `--no-config-lookup --rule 'quotes: [1, double]' --o tests/output/eslint-output.txt ${filePath}`;
+
+				await cli.execute(code);
+
+				assert.include(
+					fs.readFileSync("tests/output/eslint-output.txt", "utf8"),
+					filePath,
+				);
+				assert.isTrue(log.info.notCalled);
+			});
+
+			// https://github.com/eslint/eslint/issues/17660
+			it(`should write the file and create dirs if they don't exist even when output is empty`, async () => {
+				const filePath = getFixturePath("single-quoted.js");
+				const code = `--no-config-lookup --rule 'quotes: [1, single]' --o tests/output/eslint-output.txt ${filePath}`;
+
+				// TODO: fix this test to: await cli.execute(code);
+				await cli.execute(code, "var a = 'b'");
+
+				assert.isTrue(fs.existsSync("tests/output/eslint-output.txt"));
+				assert.strictEqual(
+					fs.readFileSync("tests/output/eslint-output.txt", "utf8"),
+					"",
+				);
+				assert.isTrue(log.info.notCalled);
+			});
+
+			it(`should return an error if the path is a directory`, async () => {
+				const filePath = getFixturePath("single-quoted.js");
+				const code = `--no-config-lookup --rule 'quotes: [1, double]' --o tests/output ${filePath}`;
+
+				fs.mkdirSync("tests/output");
+
+				const exit = await cli.execute(code);
+
+				assert.strictEqual(exit, 2);
+				assert.isTrue(log.info.notCalled);
+				assert.isTrue(log.error.calledOnce);
+			});
+
+			it(`should return an error if the path could not be written to`, async () => {
+				const filePath = getFixturePath("single-quoted.js");
+				const code = `--no-config-lookup --rule 'quotes: [1, double]' --o tests/output/eslint-output.txt ${filePath}`;
+
+				fs.writeFileSync("tests/output", "foo");
+
+				const exit = await cli.execute(code);
+
+				assert.strictEqual(exit, 2);
+				assert.isTrue(log.info.notCalled);
+				assert.isTrue(log.error.calledOnce);
+			});
+		});
+
+		describe("when passed --no-inline-config", () => {
+			let localCLI;
+
+			afterEach(() => {
+				sinon.verifyAndRestore();
+			});
+
+			it(`should pass allowInlineConfig:false to ESLint when --no-inline-config is used`, async () => {
+				// create a fake ESLint class to test with
+				const fakeESLint = sinon
+					.mock()
+					.withExactArgs(sinon.match({ allowInlineConfig: false }));
+
+				Object.defineProperties(
+					fakeESLint.prototype,
+					Object.getOwnPropertyDescriptors(ESLint.prototype),
+				);
+				sinon.stub(fakeESLint.prototype, "lintFiles").returns([
+					{
+						filePath: "./foo.js",
+						output: "bar",
+						messages: [
+							{
+								severity: 2,
+								message: "Fake message",
+							},
+						],
+						errorCount: 1,
+						warningCount: 0,
+					},
+				]);
+				sinon
+					.stub(fakeESLint.prototype, "loadFormatter")
+					.returns({ format: () => "done" });
+				fakeESLint.outputFixes = sinon.stub();
+
+				localCLI = proxyquire("../../lib/cli", {
+					"./eslint/eslint": { ESLint: fakeESLint },
+					"./shared/logging": log,
+				});
+
+				await localCLI.execute("--no-inline-config .");
+			});
+
+			it(`should not error and allowInlineConfig should be true by default`, async () => {
+				// create a fake ESLint class to test with
+				const fakeESLint = sinon
+					.mock()
+					.withExactArgs(sinon.match({ allowInlineConfig: true }));
+
+				Object.defineProperties(
+					fakeESLint.prototype,
+					Object.getOwnPropertyDescriptors(ESLint.prototype),
+				);
+				sinon.stub(fakeESLint.prototype, "lintFiles").returns([]);
+				sinon
+					.stub(fakeESLint.prototype, "loadFormatter")
+					.returns({ format: () => "done" });
+				fakeESLint.outputFixes = sinon.stub();
+
+				localCLI = proxyquire("../../lib/cli", {
+					"./eslint/eslint": { ESLint: fakeESLint },
+					"./shared/logging": log,
+				});
+
+				const exitCode = await localCLI.execute(".");
+
+				assert.strictEqual(exitCode, 0);
+			});
+		});
+
+		describe("when passed --fix", () => {
+			let localCLI;
+
+			afterEach(() => {
+				sinon.verifyAndRestore();
+			});
+
+			it(`should pass fix:true to ESLint when executing on files`, async () => {
+				// create a fake ESLint class to test with
+				const fakeESLint = sinon
+					.mock()
+					.withExactArgs(sinon.match({ fix: true }));
+
+				Object.defineProperties(
+					fakeESLint.prototype,
+					Object.getOwnPropertyDescriptors(ESLint.prototype),
+				);
+				sinon.stub(fakeESLint.prototype, "lintFiles").returns([]);
+				sinon
+					.stub(fakeESLint.prototype, "loadFormatter")
+					.returns({ format: () => "done" });
+				fakeESLint.outputFixes = sinon.mock().once();
+
+				localCLI = proxyquire("../../lib/cli", {
+					"./eslint/eslint": { ESLint: fakeESLint },
+					"./shared/logging": log,
+				});
+
+				const exitCode = await localCLI.execute("--fix .");
+
+				assert.strictEqual(exitCode, 0);
+			});
+
+			it(`should rewrite files when in fix mode`, async () => {
+				const report = [
+					{
+						filePath: "./foo.js",
+						output: "bar",
+						messages: [
+							{
+								severity: 2,
+								message: "Fake message",
+							},
+						],
+						errorCount: 1,
+						warningCount: 0,
+					},
+				];
+
+				// create a fake ESLint class to test with
+				const fakeESLint = sinon
+					.mock()
+					.withExactArgs(sinon.match({ fix: true }));
+
+				Object.defineProperties(
+					fakeESLint.prototype,
+					Object.getOwnPropertyDescriptors(ESLint.prototype),
+				);
+				sinon.stub(fakeESLint.prototype, "lintFiles").returns(report);
+				sinon
+					.stub(fakeESLint.prototype, "loadFormatter")
+					.returns({ format: () => "done" });
+				fakeESLint.outputFixes = sinon.mock().withExactArgs(report);
+
+				localCLI = proxyquire("../../lib/cli", {
+					"./eslint/eslint": { ESLint: fakeESLint },
+					"./shared/logging": log,
+				});
+
+				const exitCode = await localCLI.execute("--fix .");
+
+				assert.strictEqual(exitCode, 1);
+			});
+
+			it(`should provide fix predicate and rewrite files when in fix mode and quiet mode`, async () => {
+				const report = [
+					{
+						filePath: "./foo.js",
+						output: "bar",
+						messages: [
+							{
+								severity: 1,
+								message: "Fake message",
+							},
+						],
+						errorCount: 0,
+						warningCount: 1,
+					},
+				];
+
+				// create a fake ESLint class to test with
+				const fakeESLint = sinon
+					.mock()
+					.withExactArgs(sinon.match({ fix: sinon.match.func }));
+
+				Object.defineProperties(
+					fakeESLint.prototype,
+					Object.getOwnPropertyDescriptors(ESLint.prototype),
+				);
+				sinon.stub(fakeESLint.prototype, "lintFiles").returns(report);
+				sinon
+					.stub(fakeESLint.prototype, "loadFormatter")
+					.returns({ format: () => "done" });
+				fakeESLint.getErrorResults = sinon.stub().returns([]);
+				fakeESLint.outputFixes = sinon.mock().withExactArgs(report);
+
+				localCLI = proxyquire("../../lib/cli", {
+					"./eslint/eslint": { ESLint: fakeESLint },
+					"./shared/logging": log,
+				});
+
+				const exitCode = await localCLI.execute(
+					"--fix --quiet .",
+					null,
+				);
+
+				assert.strictEqual(exitCode, 0);
+			});
+
+			it(`should not call ESLint and return 2 when executing on text`, async () => {
+				// create a fake ESLint class to test with
+				const fakeESLint = sinon.mock().never();
+
+				localCLI = proxyquire("../../lib/cli", {
+					"./eslint/eslint": { ESLint: fakeESLint },
+					"./shared/logging": log,
+				});
+
+				const exitCode = await localCLI.execute(
+					"--fix .",
+					"foo = bar;",
+				);
+
+				assert.strictEqual(exitCode, 2);
+			});
+		});
+
+		describe("when passed --fix-dry-run", () => {
+			let localCLI;
+
+			afterEach(() => {
+				sinon.verifyAndRestore();
+			});
+
+			it(`should pass fix:true to ESLint when executing on files`, async () => {
+				// create a fake ESLint class to test with
+				const fakeESLint = sinon
+					.mock()
+					.withExactArgs(sinon.match({ fix: true }));
+
+				Object.defineProperties(
+					fakeESLint.prototype,
+					Object.getOwnPropertyDescriptors(ESLint.prototype),
+				);
+				sinon.stub(fakeESLint.prototype, "lintFiles").returns([]);
+				sinon
+					.stub(fakeESLint.prototype, "loadFormatter")
+					.returns({ format: () => "done" });
+				fakeESLint.outputFixes = sinon.mock().never();
+
+				localCLI = proxyquire("../../lib/cli", {
+					"./eslint/eslint": { ESLint: fakeESLint },
+					"./shared/logging": log,
+				});
+
+				const exitCode = await localCLI.execute(
+					"--fix-dry-run .",
+					null,
+				);
+
+				assert.strictEqual(exitCode, 0);
+			});
+
+			it(`should pass fixTypes to ESLint when --fix-type is passed`, async () => {
+				const expectedESLintOptions = {
+					fix: true,
+					fixTypes: ["suggestion"],
+				};
+
+				// create a fake ESLint class to test with
+				const fakeESLint = sinon
+					.mock()
+					.withExactArgs(sinon.match(expectedESLintOptions));
+
+				Object.defineProperties(
+					fakeESLint.prototype,
+					Object.getOwnPropertyDescriptors(ESLint.prototype),
+				);
+				sinon.stub(fakeESLint.prototype, "lintFiles").returns([]);
+				sinon
+					.stub(fakeESLint.prototype, "loadFormatter")
+					.returns({ format: () => "done" });
+				fakeESLint.outputFixes = sinon.stub();
+
+				localCLI = proxyquire("../../lib/cli", {
+					"./eslint/eslint": { ESLint: fakeESLint },
+					"./shared/logging": log,
+				});
+
+				const exitCode = await localCLI.execute(
+					"--fix-dry-run --fix-type suggestion .",
+					null,
+				);
+
+				assert.strictEqual(exitCode, 0);
+			});
+
+			it(`should not rewrite files when in fix-dry-run mode`, async () => {
+				const report = [
+					{
+						filePath: "./foo.js",
+						output: "bar",
+						messages: [
+							{
+								severity: 2,
+								message: "Fake message",
+							},
+						],
+						errorCount: 1,
+						warningCount: 0,
+					},
+				];
+
+				// create a fake ESLint class to test with
+				const fakeESLint = sinon
+					.mock()
+					.withExactArgs(sinon.match({ fix: true }));
+
+				Object.defineProperties(
+					fakeESLint.prototype,
+					Object.getOwnPropertyDescriptors(ESLint.prototype),
+				);
+				sinon.stub(fakeESLint.prototype, "lintFiles").returns(report);
+				sinon
+					.stub(fakeESLint.prototype, "loadFormatter")
+					.returns({ format: () => "done" });
+				fakeESLint.outputFixes = sinon.mock().never();
+
+				localCLI = proxyquire("../../lib/cli", {
+					"./eslint/eslint": { ESLint: fakeESLint },
+					"./shared/logging": log,
+				});
+
+				const exitCode = await localCLI.execute(
+					"--fix-dry-run .",
+					null,
+				);
+
+				assert.strictEqual(exitCode, 1);
+			});
+
+			it(`should provide fix predicate when in fix-dry-run mode and quiet mode`, async () => {
+				const report = [
+					{
+						filePath: "./foo.js",
+						output: "bar",
+						messages: [
+							{
+								severity: 1,
+								message: "Fake message",
+							},
+						],
+						errorCount: 0,
+						warningCount: 1,
+					},
+				];
+
+				// create a fake ESLint class to test with
+				const fakeESLint = sinon
+					.mock()
+					.withExactArgs(sinon.match({ fix: sinon.match.func }));
+
+				Object.defineProperties(
+					fakeESLint.prototype,
+					Object.getOwnPropertyDescriptors(ESLint.prototype),
+				);
+				sinon.stub(fakeESLint.prototype, "lintFiles").returns(report);
+				sinon
+					.stub(fakeESLint.prototype, "loadFormatter")
+					.returns({ format: () => "done" });
+				fakeESLint.getErrorResults = sinon.stub().returns([]);
+				fakeESLint.outputFixes = sinon.mock().never();
+
+				localCLI = proxyquire("../../lib/cli", {
+					"./eslint/eslint": { ESLint: fakeESLint },
+					"./shared/logging": log,
+				});
+
+				const exitCode = await localCLI.execute(
+					"--fix-dry-run --quiet .",
+					null,
+				);
+
+				assert.strictEqual(exitCode, 0);
+			});
+
+			it(`should allow executing on text`, async () => {
+				const report = [
+					{
+						filePath: "./foo.js",
+						output: "bar",
+						messages: [
+							{
+								severity: 2,
+								message: "Fake message",
+							},
+						],
+						errorCount: 1,
+						warningCount: 0,
+					},
+				];
+
+				// create a fake ESLint class to test with
+				const fakeESLint = sinon
+					.mock()
+					.withExactArgs(sinon.match({ fix: true }));
+
+				Object.defineProperties(
+					fakeESLint.prototype,
+					Object.getOwnPropertyDescriptors(ESLint.prototype),
+				);
+				sinon.stub(fakeESLint.prototype, "lintText").returns(report);
+				sinon
+					.stub(fakeESLint.prototype, "loadFormatter")
+					.returns({ format: () => "done" });
+				fakeESLint.outputFixes = sinon.mock().never();
+
+				localCLI = proxyquire("../../lib/cli", {
+					"./eslint/eslint": { ESLint: fakeESLint },
+					"./shared/logging": log,
+				});
+
+				const exitCode = await localCLI.execute(
+					"--fix-dry-run .",
+					"foo = bar;",
+				);
+
+				assert.strictEqual(exitCode, 1);
+			});
+
+			it(`should not call ESLint and return 2 when used with --fix`, async () => {
+				// create a fake ESLint class to test with
+				const fakeESLint = sinon.mock().never();
+
+				localCLI = proxyquire("../../lib/cli", {
+					"./eslint/eslint": { ESLint: fakeESLint },
+					"./shared/logging": log,
+				});
+
+				const exitCode = await localCLI.execute(
+					"--fix --fix-dry-run .",
+					"foo = bar;",
+				);
+
+				assert.strictEqual(exitCode, 2);
+			});
+		});
+
+		describe("when passing --print-config", () => {
+			const originalCwd = process.cwd;
+
+			beforeEach(() => {
+				process.cwd = () => getFixturePath();
+			});
+
+			afterEach(() => {
+				process.cwd = originalCwd;
+			});
+
+			it(`should print out the configuration`, async () => {
+				const filePath = getFixturePath("xxx.js");
+
+				const exitCode = await cli.execute(
+					`--print-config ${filePath}`,
+					null,
+				);
+
+				assert.isTrue(log.info.calledOnce);
+				assert.strictEqual(exitCode, 0);
+			});
+
+			it(`should error if any positional file arguments are passed`, async () => {
+				const filePath1 = getFixturePath("files", "bar.js");
+				const filePath2 = getFixturePath("files", "foo.js");
+
+				const exitCode = await cli.execute(
+					`--print-config ${filePath1} ${filePath2}`,
+					null,
+				);
+
+				assert.isTrue(log.info.notCalled);
+				assert.isTrue(log.error.calledOnce);
+				assert.strictEqual(exitCode, 2);
+			});
+
+			it(`should error out when executing on text`, async () => {
+				const exitCode = await cli.execute(
+					"--print-config=myFile.js",
+					"foo = bar;",
+				);
+
+				assert.isTrue(log.info.notCalled);
+				assert.isTrue(log.error.calledOnce);
+				assert.strictEqual(exitCode, 2);
+			});
+		});
+
+		describe("when passing --report-unused-disable-directives", () => {
+			it("errors when --report-unused-disable-directives", async () => {
+				const exitCode = await cli.execute(
+					`--no-config-lookup --report-unused-disable-directives --rule "'no-console': 'error'"`,
+					"foo(); // eslint-disable-line no-console",
+				);
+
+				assert.strictEqual(
+					log.error.callCount,
+					0,
+					"log.error should not be called",
+				);
+				assert.strictEqual(
+					log.info.callCount,
+					1,
+					"log.info is called once",
+				);
+				assert.ok(
+					log.info.firstCall.args[0].includes(
+						"Unused eslint-disable directive (no problems were reported from 'no-console')",
+					),
+					"has correct message about unused directives",
+				);
+				assert.ok(
+					log.info.firstCall.args[0].includes(
+						"1 error and 0 warning",
+					),
+					"has correct error and warning count",
+				);
+				assert.strictEqual(exitCode, 1, "exit code should be 1");
+			});
+
+			it("errors when --report-unused-disable-directives-severity error", async () => {
+				const exitCode = await cli.execute(
+					`--no-config-lookup --report-unused-disable-directives-severity error --rule "'no-console': 'error'"`,
+					"foo(); // eslint-disable-line no-console",
+				);
+
+				assert.strictEqual(
+					log.error.callCount,
+					0,
+					"log.error should not be called",
+				);
+				assert.strictEqual(
+					log.info.callCount,
+					1,
+					"log.info is called once",
+				);
+				assert.ok(
+					log.info.firstCall.args[0].includes(
+						"Unused eslint-disable directive (no problems were reported from 'no-console')",
+					),
+					"has correct message about unused directives",
+				);
+				assert.ok(
+					log.info.firstCall.args[0].includes(
+						"1 error and 0 warning",
+					),
+					"has correct error and warning count",
+				);
+				assert.strictEqual(exitCode, 1, "exit code should be 1");
+			});
+
+			it("errors when --report-unused-disable-directives-severity 2", async () => {
+				const exitCode = await cli.execute(
+					`--no-config-lookup --report-unused-disable-directives-severity 2 --rule "'no-console': 'error'"`,
+					"foo(); // eslint-disable-line no-console",
+				);
+
+				assert.strictEqual(
+					log.error.callCount,
+					0,
+					"log.error should not be called",
+				);
+				assert.strictEqual(
+					log.info.callCount,
+					1,
+					"log.info is called once",
+				);
+				assert.ok(
+					log.info.firstCall.args[0].includes(
+						"Unused eslint-disable directive (no problems were reported from 'no-console')",
+					),
+					"has correct message about unused directives",
+				);
+				assert.ok(
+					log.info.firstCall.args[0].includes(
+						"1 error and 0 warning",
+					),
+					"has correct error and warning count",
+				);
+				assert.strictEqual(exitCode, 1, "exit code should be 1");
+			});
+
+			it("warns when --report-unused-disable-directives-severity warn", async () => {
+				const exitCode = await cli.execute(
+					`--no-config-lookup --report-unused-disable-directives-severity warn --rule "'no-console': 'error'""`,
+					"foo(); // eslint-disable-line no-console",
+				);
+
+				assert.strictEqual(
+					log.error.callCount,
+					0,
+					"log.error should not be called",
+				);
+				assert.strictEqual(
+					log.info.callCount,
+					1,
+					"log.info is called once",
+				);
+				assert.ok(
+					log.info.firstCall.args[0].includes(
+						"Unused eslint-disable directive (no problems were reported from 'no-console')",
+					),
+					"has correct message about unused directives",
+				);
+				assert.ok(
+					log.info.firstCall.args[0].includes(
+						"0 errors and 1 warning",
+					),
+					"has correct error and warning count",
+				);
+				assert.strictEqual(exitCode, 0, "exit code should be 0");
+			});
+
+			it("warns when --report-unused-disable-directives-severity 1", async () => {
+				const exitCode = await cli.execute(
+					`--no-config-lookup --report-unused-disable-directives-severity 1 --rule "'no-console': 'error'"`,
+					"foo(); // eslint-disable-line no-console",
+				);
+
+				assert.strictEqual(
+					log.error.callCount,
+					0,
+					"log.error should not be called",
+				);
+				assert.strictEqual(
+					log.info.callCount,
+					1,
+					"log.info is called once",
+				);
+				assert.ok(
+					log.info.firstCall.args[0].includes(
+						"Unused eslint-disable directive (no problems were reported from 'no-console')",
+					),
+					"has correct message about unused directives",
+				);
+				assert.ok(
+					log.info.firstCall.args[0].includes(
+						"0 errors and 1 warning",
+					),
+					"has correct error and warning count",
+				);
+				assert.strictEqual(exitCode, 0, "exit code should be 0");
+			});
+
+			it("does not report when --report-unused-disable-directives-severity off", async () => {
+				const exitCode = await cli.execute(
+					`--no-config-lookup --report-unused-disable-directives-severity off --rule "'no-console': 'error'"`,
+					"foo(); // eslint-disable-line no-console",
+				);
+
+				assert.strictEqual(
+					log.error.callCount,
+					0,
+					"log.error should not be called",
+				);
+				assert.strictEqual(
+					log.info.callCount,
+					0,
+					"log.info should not be called",
+				);
+				assert.strictEqual(exitCode, 0, "exit code should be 0");
+			});
+
+			it("does not report when --report-unused-disable-directives-severity 0", async () => {
+				const exitCode = await cli.execute(
+					`--no-config-lookup --report-unused-disable-directives-severity 0 --rule "'no-console': 'error'"`,
+					"foo(); // eslint-disable-line no-console",
+				);
+
+				assert.strictEqual(
+					log.error.callCount,
+					0,
+					"log.error should not be called",
+				);
+				assert.strictEqual(
+					log.info.callCount,
+					0,
+					"log.info should not be called",
+				);
+				assert.strictEqual(exitCode, 0, "exit code should be 0");
+			});
+
+			it("fails when passing invalid string for --report-unused-disable-directives-severity", async () => {
+				const exitCode = await cli.execute(
+					`--no-config-lookup --report-unused-disable-directives-severity foo`,
+					null,
+				);
+
+				assert.strictEqual(
+					log.info.callCount,
+					0,
+					"log.info should not be called",
+				);
+				assert.strictEqual(
+					log.error.callCount,
+					1,
+					"log.error should be called once",
+				);
+
+				const lines = [
+					"Option report-unused-disable-directives-severity: 'foo' not one of off, warn, error, 0, 1, or 2.",
+					"You're using eslint.config.js, some command line flags are no longer available. Please see https://eslint.org/docs/latest/use/command-line-interface for details.",
+				];
+				assert.deepStrictEqual(
+					log.error.firstCall.args,
+					[lines.join("\n")],
+					"has the right text to log.error",
+				);
+				assert.strictEqual(exitCode, 2, "exit code should be 2");
+			});
+
+			it("fails when passing both --report-unused-disable-directives and --report-unused-disable-directives-severity", async () => {
+				const exitCode = await cli.execute(
+					`--no-config-lookup --report-unused-disable-directives --report-unused-disable-directives-severity warn`,
+					null,
+				);
+
+				assert.strictEqual(
+					log.info.callCount,
+					0,
+					"log.info should not be called",
+				);
+				assert.strictEqual(
+					log.error.callCount,
+					1,
+					"log.error should be called once",
+				);
+				assert.deepStrictEqual(
+					log.error.firstCall.args,
+					[
+						"The --report-unused-disable-directives option and the --report-unused-disable-directives-severity option cannot be used together.",
+					],
+					"has the right text to log.error",
+				);
+				assert.strictEqual(exitCode, 2, "exit code should be 2");
+			});
+
+			it("warns by default", async () => {
+				const exitCode = await cli.execute(
+					`--no-config-lookup --rule "'no-console': 'error'"`,
+					"foo(); // eslint-disable-line no-console",
+				);
+
+				assert.strictEqual(
+					log.error.callCount,
+					0,
+					"log.error should not be called",
+				);
+				assert.strictEqual(
+					log.info.callCount,
+					1,
+					"log.info is called once",
+				);
+				assert.ok(
+					log.info.firstCall.args[0].includes(
+						"Unused eslint-disable directive (no problems were reported from 'no-console')",
+					),
+					"has correct message about unused directives",
+				);
+				assert.ok(
+					log.info.firstCall.args[0].includes(
+						"0 errors and 1 warning",
+					),
+					"has correct error and warning count",
+				);
+				assert.strictEqual(exitCode, 0, "exit code should be 0");
 			});
 		});
 
@@ -2412,876 +1897,600 @@ describe("cli", () => {
 			});
 		});
 
-		describe("eslintrc Only", () => {
-			describe("Environments", () => {
-				describe("when given a config with environment set to browser", () => {
-					it("should execute without any errors", async () => {
-						const configPath = getFixturePath(
-							"configurations",
-							"env-browser.json",
-						);
-						const filePath = getFixturePath("globals-browser.js");
-						const code = `--config ${configPath} ${filePath}`;
+		describe("`--plugin` option", () => {
+			let originalCwd;
 
-						const exit = await cli.execute(code, null, false);
+			beforeEach(() => {
+				originalCwd = process.cwd();
+				process.chdir(getFixturePath("plugins"));
+			});
 
-						assert.strictEqual(exit, 0);
-					});
-				});
+			afterEach(() => {
+				process.chdir(originalCwd);
+				originalCwd = void 0;
+			});
 
-				describe("when given a config with environment set to Node.js", () => {
-					it("should execute without any errors", async () => {
-						const configPath = getFixturePath(
-							"configurations",
-							"env-node.json",
-						);
-						const filePath = getFixturePath("globals-node.js");
-						const code = `--config ${configPath} ${filePath}`;
+			it("should load a plugin from a CommonJS package", async () => {
+				const code =
+					"--plugin hello-cjs --rule 'hello-cjs/hello: error' ../files/*.js";
 
-						const exit = await cli.execute(code, null, false);
+				const exitCode = await cli.execute(code);
 
-						assert.strictEqual(exit, 0);
-					});
-				});
+				assert.strictEqual(exitCode, 1);
+				assert.ok(log.info.calledOnce);
+				assert.include(log.info.firstCall.firstArg, "Hello CommonJS!");
+			});
 
-				describe("when given a config with environment set to Nashorn", () => {
-					it("should execute without any errors", async () => {
-						const configPath = getFixturePath(
-							"configurations",
-							"env-nashorn.json",
-						);
-						const filePath = getFixturePath("globals-nashorn.js");
-						const code = `--config ${configPath} ${filePath}`;
+			it("should load a plugin from an ESM package", async () => {
+				const code =
+					"--plugin hello-esm --rule 'hello-esm/hello: error' ../files/*.js";
 
-						const exit = await cli.execute(code, null, false);
+				const exitCode = await cli.execute(code);
 
-						assert.strictEqual(exit, 0);
-					});
-				});
+				assert.strictEqual(exitCode, 1);
+				assert.ok(log.info.calledOnce);
+				assert.include(log.info.firstCall.firstArg, "Hello ESM!");
+			});
 
-				describe("when given a config with environment set to WebExtensions", () => {
-					it("should execute without any errors", async () => {
-						const configPath = getFixturePath(
-							"configurations",
-							"env-webextensions.json",
-						);
-						const filePath = getFixturePath(
-							"globals-webextensions.js",
-						);
-						const code = `--config ${configPath} ${filePath}`;
+			it("should load multiple plugins", async () => {
+				const code =
+					"--plugin 'hello-cjs, hello-esm' --rule 'hello-cjs/hello: warn, hello-esm/hello: error' ../files/*.js";
 
-						const exit = await cli.execute(code, null, false);
+				const exitCode = await cli.execute(code);
 
-						assert.strictEqual(exit, 0);
-					});
+				assert.strictEqual(exitCode, 1);
+				assert.ok(log.info.calledOnce);
+				assert.include(log.info.firstCall.firstArg, "Hello CommonJS!");
+				assert.include(log.info.firstCall.firstArg, "Hello ESM!");
+			});
+
+			it("should resolve plugins specified with 'eslint-plugin-'", async () => {
+				const code =
+					"--plugin 'eslint-plugin-schema-array, @scope/eslint-plugin-example' --rule 'schema-array/rule1: warn, @scope/example/test: warn' ../passing.js";
+
+				const exitCode = await cli.execute(code);
+
+				assert.strictEqual(exitCode, 0);
+			});
+
+			it("should resolve plugins in the parent directory's node_module subdirectory", async () => {
+				process.chdir("subdir");
+				const code = "--plugin 'example, @scope/example' file.js";
+
+				const exitCode = await cli.execute(code);
+
+				assert.strictEqual(exitCode, 0);
+			});
+
+			it("should fail if a plugin is not found", async () => {
+				const code = "--plugin 'example, no-such-plugin' ../passing.js";
+
+				await stdAssert.rejects(cli.execute(code), ({ message }) => {
+					assert(
+						message.startsWith(
+							"Cannot find module 'eslint-plugin-no-such-plugin'\n",
+						),
+						`Unexpected error message:\n${message}`,
+					);
+					return true;
 				});
 			});
 
-			describe("when loading a custom rule", () => {
-				it("should return an error when rule isn't found", async () => {
-					const rulesPath = getFixturePath("rules", "wrong");
-					const configPath = getFixturePath("rules", "eslint.json");
-					const filePath = getFixturePath(
-						"rules",
-						"test",
-						"test-custom-rule.js",
-					);
-					const code = `--rulesdir ${rulesPath} --config ${configPath} --no-ignore ${filePath}`;
+			it("should fail if a plugin throws an error while loading", async () => {
+				const code = "--plugin 'example, throws-on-load' ../passing.js";
 
-					await stdAssert.rejects(async () => {
-						const exit = await cli.execute(code, null, false);
-
-						assert.strictEqual(exit, 2);
-					}, /Error while loading rule 'custom-rule': Boom!/u);
-				});
-
-				it("should return a warning when rule is matched", async () => {
-					const rulesPath = getFixturePath("rules");
-					const configPath = getFixturePath("rules", "eslint.json");
-					const filePath = getFixturePath(
-						"rules",
-						"test",
-						"test-custom-rule.js",
-					);
-					const code = `--rulesdir ${rulesPath} --config ${configPath} --no-ignore ${filePath}`;
-
-					await cli.execute(code, null, false);
-
-					assert.isTrue(log.info.calledOnce);
-					assert.isTrue(log.info.neverCalledWith(""));
-				});
-
-				it("should return warnings from multiple rules in different directories", async () => {
-					const rulesPath = getFixturePath("rules", "dir1");
-					const rulesPath2 = getFixturePath("rules", "dir2");
-					const configPath = getFixturePath(
-						"rules",
-						"multi-rulesdirs.json",
-					);
-					const filePath = getFixturePath(
-						"rules",
-						"test-multi-rulesdirs.js",
-					);
-					const code = `--rulesdir ${rulesPath} --rulesdir ${rulesPath2} --config ${configPath} --no-ignore ${filePath}`;
-					const exit = await cli.execute(code, null, false);
-
-					const call = log.info.getCall(0);
-
-					assert.isTrue(log.info.calledOnce);
-					assert.isTrue(call.args[0].includes("String!"));
-					assert.isTrue(call.args[0].includes("Literal!"));
-					assert.isTrue(call.args[0].includes("2 problems"));
-					assert.isTrue(log.info.neverCalledWith(""));
-					assert.strictEqual(exit, 1);
+				await stdAssert.rejects(cli.execute(code), {
+					message: "error thrown while loading this module",
 				});
 			});
 
-			describe("when executing with no-eslintrc flag", () => {
-				it("should ignore a local config file", async () => {
-					const filePath = getFixturePath("eslintrc", "quotes.js");
-					const exit = await cli.execute(
-						`--no-eslintrc --no-ignore ${filePath}`,
-						null,
-						false,
-					);
+			it("should fail to load a plugin from a package without a default export", async () => {
+				const code =
+					"--plugin 'example, no-default-export' ../passing.js";
 
-					assert.isTrue(log.info.notCalled);
-					assert.strictEqual(exit, 0);
-				});
-			});
-
-			describe("when executing without no-eslintrc flag", () => {
-				it("should load a local config file", async () => {
-					const filePath = getFixturePath("eslintrc", "quotes.js");
-					const exit = await cli.execute(
-						`--no-ignore ${filePath}`,
-						null,
-						false,
-					);
-
-					assert.isTrue(log.info.calledOnce);
-					assert.strictEqual(exit, 1);
-				});
-			});
-
-			describe("when executing without env flag", () => {
-				it("should not define environment-specific globals", async () => {
-					const files = [
-						getFixturePath("globals-browser.js"),
-						getFixturePath("globals-node.js"),
-					];
-
-					await cli.execute(
-						`--no-eslintrc --config ./tests/fixtures/config-file/js/.eslintrc.js --no-ignore ${files.join(" ")}`,
-						null,
-						false,
-					);
-
-					assert.strictEqual(
-						log.info.args[0][0].split("\n").length,
-						10,
-					);
-				});
-			});
-
-			describe("when supplied with a plugin", () => {
-				it("should pass plugins to ESLint", async () => {
-					const examplePluginName = "eslint-plugin-example";
-
-					await verifyESLintOpts(
-						`--no-ignore --plugin ${examplePluginName} foo.js`,
-						{
-							overrideConfig: {
-								plugins: [examplePluginName],
-							},
-						},
-					);
-				});
-			});
-
-			describe("when supplied with a plugin-loading path", () => {
-				it("should pass the option to ESLint", async () => {
-					const examplePluginDirPath = "foo/bar";
-
-					await verifyESLintOpts(
-						`--resolve-plugins-relative-to ${examplePluginDirPath} foo.js`,
-						{
-							resolvePluginsRelativeTo: examplePluginDirPath,
-						},
-					);
+				await stdAssert.rejects(cli.execute(code), {
+					message:
+						'"eslint-plugin-no-default-export" cannot be used with the `--plugin` option because its default module does not provide a `default` export',
 				});
 			});
 		});
 
-		describe("flat Only", () => {
-			describe("`--plugin` option", () => {
-				let originalCwd;
+		describe("--flag option", () => {
+			let processStub;
 
-				beforeEach(() => {
-					originalCwd = process.cwd();
-					process.chdir(getFixturePath("plugins"));
-				});
-
-				afterEach(() => {
-					process.chdir(originalCwd);
-					originalCwd = void 0;
-				});
-
-				it("should load a plugin from a CommonJS package", async () => {
-					const code =
-						"--plugin hello-cjs --rule 'hello-cjs/hello: error' ../files/*.js";
-
-					const exitCode = await cli.execute(code, null, true);
-
-					assert.strictEqual(exitCode, 1);
-					assert.ok(log.info.calledOnce);
-					assert.include(
-						log.info.firstCall.firstArg,
-						"Hello CommonJS!",
-					);
-				});
-
-				it("should load a plugin from an ESM package", async () => {
-					const code =
-						"--plugin hello-esm --rule 'hello-esm/hello: error' ../files/*.js";
-
-					const exitCode = await cli.execute(code, null, true);
-
-					assert.strictEqual(exitCode, 1);
-					assert.ok(log.info.calledOnce);
-					assert.include(log.info.firstCall.firstArg, "Hello ESM!");
-				});
-
-				it("should load multiple plugins", async () => {
-					const code =
-						"--plugin 'hello-cjs, hello-esm' --rule 'hello-cjs/hello: warn, hello-esm/hello: error' ../files/*.js";
-
-					const exitCode = await cli.execute(code, null, true);
-
-					assert.strictEqual(exitCode, 1);
-					assert.ok(log.info.calledOnce);
-					assert.include(
-						log.info.firstCall.firstArg,
-						"Hello CommonJS!",
-					);
-					assert.include(log.info.firstCall.firstArg, "Hello ESM!");
-				});
-
-				it("should resolve plugins specified with 'eslint-plugin-'", async () => {
-					const code =
-						"--plugin 'eslint-plugin-schema-array, @scope/eslint-plugin-example' --rule 'schema-array/rule1: warn, @scope/example/test: warn' ../passing.js";
-
-					const exitCode = await cli.execute(code, null, true);
-
-					assert.strictEqual(exitCode, 0);
-				});
-
-				it("should resolve plugins in the parent directory's node_module subdirectory", async () => {
-					process.chdir("subdir");
-					const code = "--plugin 'example, @scope/example' file.js";
-
-					const exitCode = await cli.execute(code, null, true);
-
-					assert.strictEqual(exitCode, 0);
-				});
-
-				it("should fail if a plugin is not found", async () => {
-					const code =
-						"--plugin 'example, no-such-plugin' ../passing.js";
-
-					await stdAssert.rejects(
-						cli.execute(code, null, true),
-						({ message }) => {
-							assert(
-								message.startsWith(
-									"Cannot find module 'eslint-plugin-no-such-plugin'\n",
-								),
-								`Unexpected error message:\n${message}`,
-							);
-							return true;
-						},
-					);
-				});
-
-				it("should fail if a plugin throws an error while loading", async () => {
-					const code =
-						"--plugin 'example, throws-on-load' ../passing.js";
-
-					await stdAssert.rejects(cli.execute(code, null, true), {
-						message: "error thrown while loading this module",
-					});
-				});
-
-				it("should fail to load a plugin from a package without a default export", async () => {
-					const code =
-						"--plugin 'example, no-default-export' ../passing.js";
-
-					await stdAssert.rejects(cli.execute(code, null, true), {
-						message:
-							'"eslint-plugin-no-default-export" cannot be used with the `--plugin` option because its default module does not provide a `default` export',
-					});
-				});
+			beforeEach(() => {
+				sinon.restore();
+				processStub = sinon
+					.stub(process, "emitWarning")
+					.withArgs(
+						sinon.match.any,
+						sinon.match(/^ESLintInactiveFlag_/u),
+					)
+					.returns();
 			});
 
-			describe("--flag option", () => {
-				let processStub;
-
-				beforeEach(() => {
-					sinon.restore();
-					processStub = sinon
-						.stub(process, "emitWarning")
-						.withArgs(
-							sinon.match.any,
-							sinon.match(/^ESLintInactiveFlag_/u),
-						)
-						.returns();
-				});
-
-				afterEach(() => {
-					sinon.restore();
-					delete process.env.ESLINT_FLAGS;
-				});
-
-				it("should throw an error when an inactive flag whose feature has been abandoned is used", async () => {
-					const configPath = getFixturePath("eslint.config.js");
-					const filePath = getFixturePath("passing.js");
-					const input = `--flag test_only_abandoned --config ${configPath} ${filePath}`;
-
-					await stdAssert.rejects(async () => {
-						await cli.execute(input, null, true);
-					}, /The flag 'test_only_abandoned' is inactive: This feature has been abandoned\./u);
-				});
-
-				it("should throw an error when an inactive flag whose feature has been abandoned is used in an environment variable", async () => {
-					const configPath = getFixturePath("eslint.config.js");
-					const filePath = getFixturePath("passing.js");
-
-					process.env.ESLINT_FLAGS = "test_only_abandoned";
-					const input = `--config ${configPath} ${filePath}`;
-
-					await stdAssert.rejects(async () => {
-						await cli.execute(input, null, true);
-					}, /The flag 'test_only_abandoned' is inactive: This feature has been abandoned\./u);
-				});
-
-				it("should error out when an unknown flag is used", async () => {
-					const configPath = getFixturePath("eslint.config.js");
-					const filePath = getFixturePath("passing.js");
-					const input = `--flag test_only_oldx --config ${configPath} ${filePath}`;
-
-					await stdAssert.rejects(async () => {
-						await cli.execute(input, null, true);
-					}, /Unknown flag 'test_only_oldx'\./u);
-				});
-
-				it("should error out when an unknown flag is used in an environment variable", async () => {
-					const configPath = getFixturePath("eslint.config.js");
-					const filePath = getFixturePath("passing.js");
-					const input = `--config ${configPath} ${filePath}`;
-
-					process.env.ESLINT_FLAGS = "test_only_oldx";
-
-					await stdAssert.rejects(async () => {
-						await cli.execute(input, null, true);
-					}, /Unknown flag 'test_only_oldx'\./u);
-				});
-
-				it("should emit a warning and not error out when an inactive flag that has been replaced by another flag is used", async () => {
-					const configPath = getFixturePath("eslint.config.js");
-					const filePath = getFixturePath("passing.js");
-					const input = `--flag test_only_replaced --config ${configPath} ${filePath}`;
-					const exitCode = await cli.execute(input, null, true);
-
-					assert.strictEqual(
-						processStub.callCount,
-						1,
-						"calls `process.emitWarning()` for flags once",
-					);
-					assert.deepStrictEqual(processStub.getCall(0).args, [
-						"The flag 'test_only_replaced' is inactive: This flag has been renamed 'test_only' to reflect its stabilization. Please use 'test_only' instead.",
-						"ESLintInactiveFlag_test_only_replaced",
-					]);
-					sinon.assert.notCalled(log.error);
-					assert.strictEqual(exitCode, 0);
-				});
-
-				it("should emit a warning and not error out when an inactive flag that has been replaced by another flag is used in an environment variable", async () => {
-					const configPath = getFixturePath("eslint.config.js");
-					const filePath = getFixturePath("passing.js");
-					const input = `--config ${configPath} ${filePath}`;
-
-					process.env.ESLINT_FLAGS = "test_only_replaced";
-
-					const exitCode = await cli.execute(input, null, true);
-
-					assert.strictEqual(
-						processStub.callCount,
-						1,
-						"calls `process.emitWarning()` for flags once",
-					);
-					assert.deepStrictEqual(processStub.getCall(0).args, [
-						"The flag 'test_only_replaced' is inactive: This flag has been renamed 'test_only' to reflect its stabilization. Please use 'test_only' instead.",
-						"ESLintInactiveFlag_test_only_replaced",
-					]);
-					sinon.assert.notCalled(log.error);
-					assert.strictEqual(exitCode, 0);
-				});
-
-				it("should emit a warning and not error out when an inactive flag whose feature is enabled by default is used", async () => {
-					const configPath = getFixturePath("eslint.config.js");
-					const filePath = getFixturePath("passing.js");
-					const input = `--flag test_only_enabled_by_default --config ${configPath} ${filePath}`;
-					const exitCode = await cli.execute(input, null, true);
-
-					assert.strictEqual(
-						processStub.callCount,
-						1,
-						"calls `process.emitWarning()` for flags once",
-					);
-					assert.deepStrictEqual(processStub.getCall(0).args, [
-						"The flag 'test_only_enabled_by_default' is inactive: This feature is now enabled by default.",
-						"ESLintInactiveFlag_test_only_enabled_by_default",
-					]);
-					sinon.assert.notCalled(log.error);
-					assert.strictEqual(exitCode, 0);
-				});
-
-				it("should emit a warning and not error out when an inactive flag whose feature is enabled by default is used in an environment variable", async () => {
-					const configPath = getFixturePath("eslint.config.js");
-					const filePath = getFixturePath("passing.js");
-					const input = `--config ${configPath} ${filePath}`;
-
-					process.env.ESLINT_FLAGS = "test_only_enabled_by_default";
-
-					const exitCode = await cli.execute(input, null, true);
-					assert.strictEqual(
-						processStub.callCount,
-						1,
-						"calls `process.emitWarning()` for flags once",
-					);
-					assert.deepStrictEqual(processStub.getCall(0).args, [
-						"The flag 'test_only_enabled_by_default' is inactive: This feature is now enabled by default.",
-						"ESLintInactiveFlag_test_only_enabled_by_default",
-					]);
-					sinon.assert.notCalled(log.error);
-					assert.strictEqual(exitCode, 0);
-				});
-
-				it("should not error when a valid flag is used", async () => {
-					const configPath = getFixturePath("eslint.config.js");
-					const filePath = getFixturePath("passing.js");
-					const input = `--flag test_only --config ${configPath} ${filePath}`;
-					const exitCode = await cli.execute(input, null, true);
-
-					sinon.assert.notCalled(log.error);
-					assert.strictEqual(exitCode, 0);
-				});
-
-				it("should not error when a valid flag is used in an environment variable", async () => {
-					const configPath = getFixturePath("eslint.config.js");
-					const filePath = getFixturePath("passing.js");
-					const input = `--config ${configPath} ${filePath}`;
-
-					process.env.ESLINT_FLAGS = "test_only";
-
-					const exitCode = await cli.execute(input, null, true);
-
-					sinon.assert.notCalled(log.error);
-					assert.strictEqual(exitCode, 0);
-				});
-
-				it("should error when a valid flag is used in an environment variable with an abandoned flag", async () => {
-					const configPath = getFixturePath("eslint.config.js");
-					const filePath = getFixturePath("passing.js");
-					const input = `--config ${configPath} ${filePath}`;
-
-					process.env.ESLINT_FLAGS = "test_only,test_only_abandoned";
-
-					await stdAssert.rejects(async () => {
-						await cli.execute(input, null, true);
-					}, /The flag 'test_only_abandoned' is inactive: This feature has been abandoned\./u);
-				});
+			afterEach(() => {
+				sinon.restore();
+				delete process.env.ESLINT_FLAGS;
 			});
 
-			describe("--report-unused-inline-configs option", () => {
-				it("does not report when --report-unused-inline-configs 0", async () => {
+			it("should throw an error when an inactive flag whose feature has been abandoned is used", async () => {
+				const configPath = getFixturePath("eslint.config.js");
+				const filePath = getFixturePath("passing.js");
+				const input = `--flag test_only_abandoned --config ${configPath} ${filePath}`;
+
+				await stdAssert.rejects(async () => {
+					await cli.execute(input);
+				}, /The flag 'test_only_abandoned' is inactive: This feature has been abandoned\./u);
+			});
+
+			it("should throw an error when an inactive flag whose feature has been abandoned is used in an environment variable", async () => {
+				const configPath = getFixturePath("eslint.config.js");
+				const filePath = getFixturePath("passing.js");
+
+				process.env.ESLINT_FLAGS = "test_only_abandoned";
+				const input = `--config ${configPath} ${filePath}`;
+
+				await stdAssert.rejects(async () => {
+					await cli.execute(input);
+				}, /The flag 'test_only_abandoned' is inactive: This feature has been abandoned\./u);
+			});
+
+			it("should error out when an unknown flag is used", async () => {
+				const configPath = getFixturePath("eslint.config.js");
+				const filePath = getFixturePath("passing.js");
+				const input = `--flag test_only_oldx --config ${configPath} ${filePath}`;
+
+				await stdAssert.rejects(async () => {
+					await cli.execute(input);
+				}, /Unknown flag 'test_only_oldx'\./u);
+			});
+
+			it("should error out when an unknown flag is used in an environment variable", async () => {
+				const configPath = getFixturePath("eslint.config.js");
+				const filePath = getFixturePath("passing.js");
+				const input = `--config ${configPath} ${filePath}`;
+
+				process.env.ESLINT_FLAGS = "test_only_oldx";
+
+				await stdAssert.rejects(async () => {
+					await cli.execute(input);
+				}, /Unknown flag 'test_only_oldx'\./u);
+			});
+
+			it("should emit a warning and not error out when an inactive flag that has been replaced by another flag is used", async () => {
+				const configPath = getFixturePath("eslint.config.js");
+				const filePath = getFixturePath("passing.js");
+				const input = `--flag test_only_replaced --config ${configPath} ${filePath}`;
+				const exitCode = await cli.execute(input);
+
+				assert.strictEqual(
+					processStub.callCount,
+					1,
+					"calls `process.emitWarning()` for flags once",
+				);
+				assert.deepStrictEqual(processStub.getCall(0).args, [
+					"The flag 'test_only_replaced' is inactive: This flag has been renamed 'test_only' to reflect its stabilization. Please use 'test_only' instead.",
+					"ESLintInactiveFlag_test_only_replaced",
+				]);
+				sinon.assert.notCalled(log.error);
+				assert.strictEqual(exitCode, 0);
+			});
+
+			it("should emit a warning and not error out when an inactive flag that has been replaced by another flag is used in an environment variable", async () => {
+				const configPath = getFixturePath("eslint.config.js");
+				const filePath = getFixturePath("passing.js");
+				const input = `--config ${configPath} ${filePath}`;
+
+				process.env.ESLINT_FLAGS = "test_only_replaced";
+
+				const exitCode = await cli.execute(input);
+
+				assert.strictEqual(
+					processStub.callCount,
+					1,
+					"calls `process.emitWarning()` for flags once",
+				);
+				assert.deepStrictEqual(processStub.getCall(0).args, [
+					"The flag 'test_only_replaced' is inactive: This flag has been renamed 'test_only' to reflect its stabilization. Please use 'test_only' instead.",
+					"ESLintInactiveFlag_test_only_replaced",
+				]);
+				sinon.assert.notCalled(log.error);
+				assert.strictEqual(exitCode, 0);
+			});
+
+			it("should emit a warning and not error out when an inactive flag whose feature is enabled by default is used", async () => {
+				const configPath = getFixturePath("eslint.config.js");
+				const filePath = getFixturePath("passing.js");
+				const input = `--flag test_only_enabled_by_default --config ${configPath} ${filePath}`;
+				const exitCode = await cli.execute(input);
+
+				assert.strictEqual(
+					processStub.callCount,
+					1,
+					"calls `process.emitWarning()` for flags once",
+				);
+				assert.deepStrictEqual(processStub.getCall(0).args, [
+					"The flag 'test_only_enabled_by_default' is inactive: This feature is now enabled by default.",
+					"ESLintInactiveFlag_test_only_enabled_by_default",
+				]);
+				sinon.assert.notCalled(log.error);
+				assert.strictEqual(exitCode, 0);
+			});
+
+			it("should emit a warning and not error out when an inactive flag whose feature is enabled by default is used in an environment variable", async () => {
+				const configPath = getFixturePath("eslint.config.js");
+				const filePath = getFixturePath("passing.js");
+				const input = `--config ${configPath} ${filePath}`;
+
+				process.env.ESLINT_FLAGS = "test_only_enabled_by_default";
+
+				const exitCode = await cli.execute(input);
+				assert.strictEqual(
+					processStub.callCount,
+					1,
+					"calls `process.emitWarning()` for flags once",
+				);
+				assert.deepStrictEqual(processStub.getCall(0).args, [
+					"The flag 'test_only_enabled_by_default' is inactive: This feature is now enabled by default.",
+					"ESLintInactiveFlag_test_only_enabled_by_default",
+				]);
+				sinon.assert.notCalled(log.error);
+				assert.strictEqual(exitCode, 0);
+			});
+
+			it("should not error when a valid flag is used", async () => {
+				const configPath = getFixturePath("eslint.config.js");
+				const filePath = getFixturePath("passing.js");
+				const input = `--flag test_only --config ${configPath} ${filePath}`;
+				const exitCode = await cli.execute(input);
+
+				sinon.assert.notCalled(log.error);
+				assert.strictEqual(exitCode, 0);
+			});
+
+			it("should not error when a valid flag is used in an environment variable", async () => {
+				const configPath = getFixturePath("eslint.config.js");
+				const filePath = getFixturePath("passing.js");
+				const input = `--config ${configPath} ${filePath}`;
+
+				process.env.ESLINT_FLAGS = "test_only";
+
+				const exitCode = await cli.execute(input);
+
+				sinon.assert.notCalled(log.error);
+				assert.strictEqual(exitCode, 0);
+			});
+
+			it("should error when a valid flag is used in an environment variable with an abandoned flag", async () => {
+				const configPath = getFixturePath("eslint.config.js");
+				const filePath = getFixturePath("passing.js");
+				const input = `--config ${configPath} ${filePath}`;
+
+				process.env.ESLINT_FLAGS = "test_only,test_only_abandoned";
+
+				await stdAssert.rejects(async () => {
+					await cli.execute(input);
+				}, /The flag 'test_only_abandoned' is inactive: This feature has been abandoned\./u);
+			});
+		});
+
+		describe("--report-unused-inline-configs option", () => {
+			it("does not report when --report-unused-inline-configs 0", async () => {
+				const exitCode = await cli.execute(
+					"--no-config-lookup --report-unused-inline-configs 0 --rule \"'no-console': 'error'\"",
+					"/* eslint no-console: 'error' */",
+				);
+
+				assert.strictEqual(
+					log.error.callCount,
+					0,
+					"log.error should not be called",
+				);
+				assert.strictEqual(
+					log.info.callCount,
+					0,
+					"log.info should not be called",
+				);
+				assert.strictEqual(exitCode, 0, "exit code should be 0");
+			});
+
+			[
+				[1, 0, "0 errors, 1 warning"],
+				["warn", 0, "0 errors, 1 warning"],
+				[2, 1, "1 error, 0 warnings"],
+				["error", 1, "1 error, 0 warnings"],
+			].forEach(([setting, status, descriptor]) => {
+				it(`reports when --report-unused-inline-configs ${setting}`, async () => {
 					const exitCode = await cli.execute(
-						"--no-config-lookup --report-unused-inline-configs 0 --rule \"'no-console': 'error'\"",
+						`--no-config-lookup --report-unused-inline-configs ${setting} --rule "'no-console': 'error'"`,
 						"/* eslint no-console: 'error' */",
-						true,
-					);
-
-					assert.strictEqual(
-						log.error.callCount,
-						0,
-						"log.error should not be called",
-					);
-					assert.strictEqual(
-						log.info.callCount,
-						0,
-						"log.info should not be called",
-					);
-					assert.strictEqual(exitCode, 0, "exit code should be 0");
-				});
-
-				[
-					[1, 0, "0 errors, 1 warning"],
-					["warn", 0, "0 errors, 1 warning"],
-					[2, 1, "1 error, 0 warnings"],
-					["error", 1, "1 error, 0 warnings"],
-				].forEach(([setting, status, descriptor]) => {
-					it(`reports when --report-unused-inline-configs ${setting}`, async () => {
-						const exitCode = await cli.execute(
-							`--no-config-lookup --report-unused-inline-configs ${setting} --rule "'no-console': 'error'"`,
-							"/* eslint no-console: 'error' */",
-							true,
-						);
-
-						assert.strictEqual(
-							log.info.callCount,
-							1,
-							"log.info is called once",
-						);
-						assert.ok(
-							log.info.firstCall.args[0].includes(
-								"Unused inline config ('no-console' is already configured to 'error')",
-							),
-							"has correct message about unused inline config",
-						);
-						assert.ok(
-							log.info.firstCall.args[0].includes(descriptor),
-							"has correct error and warning count",
-						);
-						assert.strictEqual(
-							exitCode,
-							status,
-							`exit code should be ${exitCode}`,
-						);
-					});
-				});
-
-				it("fails when passing invalid string for --report-unused-inline-configs", async () => {
-					const exitCode = await cli.execute(
-						"--no-config-lookup --report-unused-inline-configs foo",
-						null,
-						true,
 					);
 
 					assert.strictEqual(
 						log.info.callCount,
-						0,
-						"log.info should not be called",
-					);
-					assert.strictEqual(
-						log.error.callCount,
 						1,
-						"log.error should be called once",
+						"log.info is called once",
 					);
-
-					const lines = [
-						"Option report-unused-inline-configs: 'foo' not one of off, warn, error, 0, 1, or 2.",
-						"You're using eslint.config.js, some command line flags are no longer available. Please see https://eslint.org/docs/latest/use/command-line-interface for details.",
-					];
-
-					assert.deepStrictEqual(
-						log.error.firstCall.args,
-						[lines.join("\n")],
-						"has the right text to log.error",
-					);
-					assert.strictEqual(exitCode, 2, "exit code should be 2");
-				});
-			});
-
-			describe("--ext option", () => {
-				let originalCwd;
-
-				beforeEach(() => {
-					originalCwd = process.cwd();
-					process.chdir(getFixturePath("file-extensions"));
-				});
-
-				afterEach(() => {
-					process.chdir(originalCwd);
-					originalCwd = void 0;
-				});
-
-				it("when not provided, without config file only default extensions should be linted", async () => {
-					const exitCode = await cli.execute(
-						"--no-config-lookup -f json .",
-						null,
-						true,
-					);
-
-					assert.strictEqual(exitCode, 0, "exit code should be 0");
-
-					const results = JSON.parse(log.info.args[0][0]);
-
-					assert.deepStrictEqual(
-						results.map(({ filePath }) => filePath).sort(),
-						["a.js", "b.mjs", "c.cjs", "eslint.config.js"].map(
-							filename => path.resolve(filename),
+					assert.ok(
+						log.info.firstCall.args[0].includes(
+							"Unused inline config ('no-console' is already configured to 'error')",
 						),
+						"has correct message about unused inline config",
 					);
-				});
-
-				it("when not provided, only default extensions and extensions from the config file should be linted", async () => {
-					const exitCode = await cli.execute("-f json .", null, true);
-
-					assert.strictEqual(exitCode, 0, "exit code should be 0");
-
-					const results = JSON.parse(log.info.args[0][0]);
-
-					assert.deepStrictEqual(
-						results.map(({ filePath }) => filePath).sort(),
-						[
-							"a.js",
-							"b.mjs",
-							"c.cjs",
-							"d.jsx",
-							"eslint.config.js",
-						].map(filename => path.resolve(filename)),
-					);
-				});
-
-				it("should include an additional extension when specified with dot", async () => {
-					const exitCode = await cli.execute(
-						"-f json --ext .ts .",
-						null,
-						true,
-					);
-
-					assert.strictEqual(exitCode, 0, "exit code should be 0");
-
-					const results = JSON.parse(log.info.args[0][0]);
-
-					assert.deepStrictEqual(
-						results.map(({ filePath }) => filePath).sort(),
-						[
-							"a.js",
-							"b.mjs",
-							"c.cjs",
-							"d.jsx",
-							"eslint.config.js",
-							"f.ts",
-						].map(filename => path.resolve(filename)),
-					);
-				});
-
-				it("should include an additional extension when specified without dot", async () => {
-					const exitCode = await cli.execute(
-						"-f json --ext ts .",
-						null,
-						true,
-					);
-
-					assert.strictEqual(exitCode, 0, "exit code should be 0");
-
-					const results = JSON.parse(log.info.args[0][0]);
-
-					// should not include "foots"
-					assert.deepStrictEqual(
-						results.map(({ filePath }) => filePath).sort(),
-						[
-							"a.js",
-							"b.mjs",
-							"c.cjs",
-							"d.jsx",
-							"eslint.config.js",
-							"f.ts",
-						].map(filename => path.resolve(filename)),
-					);
-				});
-
-				it("should include multiple additional extensions when specified by repeating the option", async () => {
-					const exitCode = await cli.execute(
-						"-f json --ext .ts --ext tsx .",
-						null,
-						true,
-					);
-
-					assert.strictEqual(exitCode, 0, "exit code should be 0");
-
-					const results = JSON.parse(log.info.args[0][0]);
-
-					assert.deepStrictEqual(
-						results.map(({ filePath }) => filePath).sort(),
-						[
-							"a.js",
-							"b.mjs",
-							"c.cjs",
-							"d.jsx",
-							"eslint.config.js",
-							"f.ts",
-							"g.tsx",
-						].map(filename => path.resolve(filename)),
-					);
-				});
-
-				it("should include multiple additional extensions when specified with comma-delimited list", async () => {
-					const exitCode = await cli.execute(
-						"-f json --ext .ts,.tsx .",
-						null,
-						true,
-					);
-
-					assert.strictEqual(exitCode, 0, "exit code should be 0");
-
-					const results = JSON.parse(log.info.args[0][0]);
-
-					assert.deepStrictEqual(
-						results.map(({ filePath }) => filePath).sort(),
-						[
-							"a.js",
-							"b.mjs",
-							"c.cjs",
-							"d.jsx",
-							"eslint.config.js",
-							"f.ts",
-							"g.tsx",
-						].map(filename => path.resolve(filename)),
-					);
-				});
-
-				it('should fail when passing --ext ""', async () => {
-					// When passing "" on command line, its corresponding item in process.argv[] is an empty string
-					const exitCode = await cli.execute(
-						["argv0", "argv1", "--ext", ""],
-						null,
-						true,
-					);
-
-					assert.strictEqual(exitCode, 2, "exit code should be 2");
-					assert.strictEqual(
-						log.info.callCount,
-						0,
-						"log.info should not be called",
+					assert.ok(
+						log.info.firstCall.args[0].includes(descriptor),
+						"has correct error and warning count",
 					);
 					assert.strictEqual(
-						log.error.callCount,
-						1,
-						"log.error should be called once",
-					);
-					assert.deepStrictEqual(
-						log.error.firstCall.args[0],
-						"The --ext option value cannot be empty.",
-					);
-				});
-
-				it("should fail when passing --ext ,ts", async () => {
-					const exitCode = await cli.execute("--ext ,ts", null, true);
-
-					assert.strictEqual(exitCode, 2, "exit code should be 2");
-					assert.strictEqual(
-						log.info.callCount,
-						0,
-						"log.info should not be called",
-					);
-					assert.strictEqual(
-						log.error.callCount,
-						1,
-						"log.error should be called once",
-					);
-					assert.deepStrictEqual(
-						log.error.firstCall.args[0],
-						"The --ext option arguments cannot be empty strings. Found an empty string at index 0.",
-					);
-				});
-
-				it("should fail when passing --ext ts,,tsx", async () => {
-					const exitCode = await cli.execute(
-						"--ext ts,,tsx",
-						null,
-						true,
-					);
-
-					assert.strictEqual(exitCode, 2, "exit code should be 2");
-					assert.strictEqual(
-						log.info.callCount,
-						0,
-						"log.info should not be called",
-					);
-					assert.strictEqual(
-						log.error.callCount,
-						1,
-						"log.error should be called once",
-					);
-					assert.deepStrictEqual(
-						log.error.firstCall.args[0],
-						"The --ext option arguments cannot be empty strings. Found an empty string at index 1.",
+						exitCode,
+						status,
+						`exit code should be ${exitCode}`,
 					);
 				});
 			});
 
-			describe("v10_config_lookup_from_file", () => {
-				const flag = "v10_config_lookup_from_file";
+			it("fails when passing invalid string for --report-unused-inline-configs", async () => {
+				const exitCode = await cli.execute(
+					"--no-config-lookup --report-unused-inline-configs foo",
+					null,
+				);
 
-				it("should throw an error when text is passed and no config file is found", async () => {
-					await stdAssert.rejects(
-						() =>
-							cli.execute(
-								`--flag ${flag} --stdin --stdin-filename /foo.js"`,
-								"var foo = 'bar';",
-								true,
-							),
-						/Could not find config file/u,
+				assert.strictEqual(
+					log.info.callCount,
+					0,
+					"log.info should not be called",
+				);
+				assert.strictEqual(
+					log.error.callCount,
+					1,
+					"log.error should be called once",
+				);
+
+				const lines = [
+					"Option report-unused-inline-configs: 'foo' not one of off, warn, error, 0, 1, or 2.",
+					"You're using eslint.config.js, some command line flags are no longer available. Please see https://eslint.org/docs/latest/use/command-line-interface for details.",
+				];
+
+				assert.deepStrictEqual(
+					log.error.firstCall.args,
+					[lines.join("\n")],
+					"has the right text to log.error",
+				);
+				assert.strictEqual(exitCode, 2, "exit code should be 2");
+			});
+		});
+
+		describe("--ext option", () => {
+			let originalCwd;
+
+			beforeEach(() => {
+				originalCwd = process.cwd();
+				process.chdir(getFixturePath("file-extensions"));
+			});
+
+			afterEach(() => {
+				process.chdir(originalCwd);
+				originalCwd = void 0;
+			});
+
+			it("when not provided, without config file only default extensions should be linted", async () => {
+				const exitCode = await cli.execute(
+					"--no-config-lookup -f json .",
+					null,
+				);
+
+				assert.strictEqual(exitCode, 0, "exit code should be 0");
+
+				const results = JSON.parse(log.info.args[0][0]);
+
+				assert.deepStrictEqual(
+					results.map(({ filePath }) => filePath).sort(),
+					["a.js", "b.mjs", "c.cjs", "eslint.config.js"].map(
+						filename => path.resolve(filename),
+					),
+				);
+			});
+
+			it("when not provided, only default extensions and extensions from the config file should be linted", async () => {
+				const exitCode = await cli.execute("-f json .");
+
+				assert.strictEqual(exitCode, 0, "exit code should be 0");
+
+				const results = JSON.parse(log.info.args[0][0]);
+
+				assert.deepStrictEqual(
+					results.map(({ filePath }) => filePath).sort(),
+					["a.js", "b.mjs", "c.cjs", "d.jsx", "eslint.config.js"].map(
+						filename => path.resolve(filename),
+					),
+				);
+			});
+
+			it("should include an additional extension when specified with dot", async () => {
+				const exitCode = await cli.execute("-f json --ext .ts .");
+
+				assert.strictEqual(exitCode, 0, "exit code should be 0");
+
+				const results = JSON.parse(log.info.args[0][0]);
+
+				assert.deepStrictEqual(
+					results.map(({ filePath }) => filePath).sort(),
+					[
+						"a.js",
+						"b.mjs",
+						"c.cjs",
+						"d.jsx",
+						"eslint.config.js",
+						"f.ts",
+					].map(filename => path.resolve(filename)),
+				);
+			});
+
+			it("should include an additional extension when specified without dot", async () => {
+				const exitCode = await cli.execute("-f json --ext ts .");
+
+				assert.strictEqual(exitCode, 0, "exit code should be 0");
+
+				const results = JSON.parse(log.info.args[0][0]);
+
+				// should not include "foots"
+				assert.deepStrictEqual(
+					results.map(({ filePath }) => filePath).sort(),
+					[
+						"a.js",
+						"b.mjs",
+						"c.cjs",
+						"d.jsx",
+						"eslint.config.js",
+						"f.ts",
+					].map(filename => path.resolve(filename)),
+				);
+			});
+
+			it("should include multiple additional extensions when specified by repeating the option", async () => {
+				const exitCode = await cli.execute(
+					"-f json --ext .ts --ext tsx .",
+					null,
+				);
+
+				assert.strictEqual(exitCode, 0, "exit code should be 0");
+
+				const results = JSON.parse(log.info.args[0][0]);
+
+				assert.deepStrictEqual(
+					results.map(({ filePath }) => filePath).sort(),
+					[
+						"a.js",
+						"b.mjs",
+						"c.cjs",
+						"d.jsx",
+						"eslint.config.js",
+						"f.ts",
+						"g.tsx",
+					].map(filename => path.resolve(filename)),
+				);
+			});
+
+			it("should include multiple additional extensions when specified with comma-delimited list", async () => {
+				const exitCode = await cli.execute(
+					"-f json --ext .ts,.tsx .",
+					null,
+				);
+
+				assert.strictEqual(exitCode, 0, "exit code should be 0");
+
+				const results = JSON.parse(log.info.args[0][0]);
+
+				assert.deepStrictEqual(
+					results.map(({ filePath }) => filePath).sort(),
+					[
+						"a.js",
+						"b.mjs",
+						"c.cjs",
+						"d.jsx",
+						"eslint.config.js",
+						"f.ts",
+						"g.tsx",
+					].map(filename => path.resolve(filename)),
+				);
+			});
+
+			it('should fail when passing --ext ""', async () => {
+				// When passing "" on command line, its corresponding item in process.argv[] is an empty string
+				const exitCode = await cli.execute(
+					["argv0", "argv1", "--ext", ""],
+					null,
+				);
+
+				assert.strictEqual(exitCode, 2, "exit code should be 2");
+				assert.strictEqual(
+					log.info.callCount,
+					0,
+					"log.info should not be called",
+				);
+				assert.strictEqual(
+					log.error.callCount,
+					1,
+					"log.error should be called once",
+				);
+				assert.deepStrictEqual(
+					log.error.firstCall.args[0],
+					"The --ext option value cannot be empty.",
+				);
+			});
+
+			it("should fail when passing --ext ,ts", async () => {
+				const exitCode = await cli.execute("--ext ,ts");
+
+				assert.strictEqual(exitCode, 2, "exit code should be 2");
+				assert.strictEqual(
+					log.info.callCount,
+					0,
+					"log.info should not be called",
+				);
+				assert.strictEqual(
+					log.error.callCount,
+					1,
+					"log.error should be called once",
+				);
+				assert.deepStrictEqual(
+					log.error.firstCall.args[0],
+					"The --ext option arguments cannot be empty strings. Found an empty string at index 0.",
+				);
+			});
+
+			it("should fail when passing --ext ts,,tsx", async () => {
+				const exitCode = await cli.execute("--ext ts,,tsx");
+
+				assert.strictEqual(exitCode, 2, "exit code should be 2");
+				assert.strictEqual(
+					log.info.callCount,
+					0,
+					"log.info should not be called",
+				);
+				assert.strictEqual(
+					log.error.callCount,
+					1,
+					"log.error should be called once",
+				);
+				assert.deepStrictEqual(
+					log.error.firstCall.args[0],
+					"The --ext option arguments cannot be empty strings. Found an empty string at index 1.",
+				);
+			});
+		});
+
+		describe("v10_config_lookup_from_file", () => {
+			it("should throw an error when text is passed and no config file is found", async () => {
+				await stdAssert.rejects(
+					() =>
+						cli.execute(
+							`--flag v10_config_lookup_from_file --stdin --stdin-filename /foo.js"`,
+							"var foo = 'bar';",
+						),
+					/Could not find config file/u,
+				);
+			});
+		});
+
+		describe("--concurrency option", () => {
+			["1", "100", "0x10", "auto", "off"].forEach(value => {
+				it(`should accept the value ${value}`, async () => {
+					const exitCode = await cli.execute(
+						`--concurrency ${value} --pass-on-no-patterns`,
+						null,
 					);
+
+					assert.strictEqual(exitCode, 0, "exit code should be 0");
 				});
 			});
 
-			describe("--concurrency option", () => {
-				["1", "100", "0x10", "auto", "off"].forEach(value => {
-					it(`should accept the value ${value}`, async () => {
-						const exitCode = await cli.execute(
-							`--concurrency ${value} --pass-on-no-patterns`,
-							null,
-							true,
-						);
-
-						assert.strictEqual(
-							exitCode,
-							0,
-							"exit code should be 0",
-						);
-					});
-				});
-
-				["foo", "0", "-1", "1.5", "Infinity"].forEach(value => {
-					it(`should not accept the value ${value}`, async () => {
-						const exitCode = await cli.execute(
-							`--concurrency=${value}`,
-							null,
-							true,
-						);
-
-						assert.strictEqual(
-							log.info.callCount,
-							0,
-							"log.info should not be called",
-						);
-						assert.strictEqual(
-							log.error.callCount,
-							1,
-							"log.error should be called once",
-						);
-
-						assert.strictEqual(
-							log.error.firstCall.firstArg.replace(/\n.*/u, ""),
-							`Option concurrency: '${value}' is not a positive integer, 'auto' or 'off'.`,
-							"has the right text to log.error",
-						);
-						assert.strictEqual(
-							exitCode,
-							2,
-							"exit code should be 2",
-						);
-					});
-				});
-
-				it("should not accept an empty value", async () => {
+			["foo", "0", "-1", "1.5", "Infinity"].forEach(value => {
+				it(`should not accept the value ${value}`, async () => {
 					const exitCode = await cli.execute(
-						'--concurrency=""',
+						`--concurrency=${value}`,
 						null,
-						true,
 					);
 
 					assert.strictEqual(
@@ -3297,21 +2506,42 @@ describe("cli", () => {
 
 					assert.strictEqual(
 						log.error.firstCall.firstArg.replace(/\n.*/u, ""),
-						"No value for 'concurrency' specified.",
+						`Option concurrency: '${value}' is not a positive integer, 'auto' or 'off'.`,
 						"has the right text to log.error",
 					);
 					assert.strictEqual(exitCode, 2, "exit code should be 2");
 				});
+			});
 
-				it("should encode '?' and '#' in an options module", async () => {
-					const exitCode = await cli.execute(
-						"--concurrency=2 --no-config-lookup --no-ignore --rule 'no-fallthrough: [error, { commentPattern: \"#?\" }]' tests/fixtures/passing.js",
-						null,
-						true,
-					);
+			it("should not accept an empty value", async () => {
+				const exitCode = await cli.execute('--concurrency=""');
 
-					assert.strictEqual(exitCode, 0, "exit code should be 0");
-				});
+				assert.strictEqual(
+					log.info.callCount,
+					0,
+					"log.info should not be called",
+				);
+				assert.strictEqual(
+					log.error.callCount,
+					1,
+					"log.error should be called once",
+				);
+
+				assert.strictEqual(
+					log.error.firstCall.firstArg.replace(/\n.*/u, ""),
+					"No value for 'concurrency' specified.",
+					"has the right text to log.error",
+				);
+				assert.strictEqual(exitCode, 2, "exit code should be 2");
+			});
+
+			it("should encode '?' and '#' in an options module", async () => {
+				const exitCode = await cli.execute(
+					"--concurrency=2 --no-config-lookup --no-ignore --rule 'no-fallthrough: [error, { commentPattern: \"#?\" }]' tests/fixtures/passing.js",
+					null,
+				);
+
+				assert.strictEqual(exitCode, 0, "exit code should be 0");
 			});
 		});
 	});

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -16,8 +16,7 @@ const assert = require("chai").assert,
 // Data
 //-----------------------------------------------------------------------------
 
-const eslintrcOptions = createOptions(false);
-const flatOptions = createOptions(true);
+const options = createOptions();
 
 //------------------------------------------------------------------------------
 // Tests
@@ -29,412 +28,343 @@ const flatOptions = createOptions(true);
 
 describe("options", () => {
 	describe("Common options", () => {
-		[eslintrcOptions, flatOptions].forEach(options => {
-			describe("--help", () => {
-				it("should return true for .help when passed", () => {
-					const currentOptions = options.parse("--help");
-
-					assert.isTrue(currentOptions.help);
-				});
-			});
-
-			describe("-h", () => {
-				it("should return true for .help when passed", () => {
-					const currentOptions = options.parse("-h");
-
-					assert.isTrue(currentOptions.help);
-				});
-			});
-
-			describe("--config", () => {
-				it("should return a string for .config when passed a string", () => {
-					const currentOptions = options.parse("--config file");
-
-					assert.isString(currentOptions.config);
-					assert.strictEqual(currentOptions.config, "file");
-				});
-			});
-
-			describe("-c", () => {
-				it("should return a string for .config when passed a string", () => {
-					const currentOptions = options.parse("-c file");
-
-					assert.isString(currentOptions.config);
-					assert.strictEqual(currentOptions.config, "file");
-				});
-			});
-
-			describe("--format", () => {
-				it("should return a string for .format when passed a string", () => {
-					const currentOptions = options.parse("--format json");
-
-					assert.isString(currentOptions.format);
-					assert.strictEqual(currentOptions.format, "json");
-				});
-
-				it("should return stylish for .format when not passed", () => {
-					const currentOptions = options.parse("");
-
-					assert.isString(currentOptions.format);
-					assert.strictEqual(currentOptions.format, "stylish");
-				});
-			});
-
-			describe("-f", () => {
-				it("should return a string for .format when passed a string", () => {
-					const currentOptions = options.parse("-f json");
-
-					assert.isString(currentOptions.format);
-					assert.strictEqual(currentOptions.format, "json");
-				});
-			});
-
-			describe("--version", () => {
-				it("should return true for .version when passed", () => {
-					const currentOptions = options.parse("--version");
-
-					assert.isTrue(currentOptions.version);
-				});
-			});
-
-			describe("-v", () => {
-				it("should return true for .version when passed", () => {
-					const currentOptions = options.parse("-v");
-
-					assert.isTrue(currentOptions.version);
-				});
-			});
-
-			describe("when asking for help", () => {
-				it("should return string of help text when called", () => {
-					const helpText = options.generateHelp();
-
-					assert.isString(helpText);
-				});
-			});
-
-			describe("--no-ignore", () => {
-				it("should return false for .ignore when passed", () => {
-					const currentOptions = options.parse("--no-ignore");
-
-					assert.isFalse(currentOptions.ignore);
-				});
-			});
-
-			describe("--ignore-pattern", () => {
-				it("should return a string array for .ignorePattern when passed", () => {
-					const currentOptions = options.parse(
-						"--ignore-pattern *.js",
-					);
-
-					assert.ok(currentOptions.ignorePattern);
-					assert.strictEqual(currentOptions.ignorePattern.length, 1);
-					assert.strictEqual(currentOptions.ignorePattern[0], "*.js");
-				});
-
-				it("should return a string array for multiple values", () => {
-					const currentOptions = options.parse(
-						"--ignore-pattern *.js --ignore-pattern *.ts",
-					);
-
-					assert.ok(currentOptions.ignorePattern);
-					assert.strictEqual(currentOptions.ignorePattern.length, 2);
-					assert.strictEqual(currentOptions.ignorePattern[0], "*.js");
-					assert.strictEqual(currentOptions.ignorePattern[1], "*.ts");
-				});
-
-				it("should return a string array of properly parsed values, when those values include commas", () => {
-					const currentOptions = options.parse(
-						"--ignore-pattern *.js --ignore-pattern foo-{bar,baz}.js",
-					);
-
-					assert.ok(currentOptions.ignorePattern);
-					assert.strictEqual(currentOptions.ignorePattern.length, 2);
-					assert.strictEqual(currentOptions.ignorePattern[0], "*.js");
-					assert.strictEqual(
-						currentOptions.ignorePattern[1],
-						"foo-{bar,baz}.js",
-					);
-				});
-			});
-
-			describe("--color", () => {
-				it("should return true for .color when passed --color", () => {
-					const currentOptions = options.parse("--color");
-
-					assert.isTrue(currentOptions.color);
-				});
-
-				it("should return false for .color when passed --no-color", () => {
-					const currentOptions = options.parse("--no-color");
-
-					assert.isFalse(currentOptions.color);
-				});
-			});
-
-			describe("--stdin", () => {
-				it("should return true for .stdin when passed", () => {
-					const currentOptions = options.parse("--stdin");
-
-					assert.isTrue(currentOptions.stdin);
-				});
-			});
-
-			describe("--stdin-filename", () => {
-				it("should return a string for .stdinFilename when passed", () => {
-					const currentOptions = options.parse(
-						"--stdin-filename test.js",
-					);
-
-					assert.strictEqual(currentOptions.stdinFilename, "test.js");
-				});
-			});
-
-			describe("--global", () => {
-				it("should return an array for a single occurrence", () => {
-					const currentOptions = options.parse("--global foo");
-
-					assert.isArray(currentOptions.global);
-					assert.strictEqual(currentOptions.global.length, 1);
-					assert.strictEqual(currentOptions.global[0], "foo");
-				});
-
-				it("should split variable names using commas", () => {
-					const currentOptions = options.parse("--global foo,bar");
-
-					assert.isArray(currentOptions.global);
-					assert.strictEqual(currentOptions.global.length, 2);
-					assert.strictEqual(currentOptions.global[0], "foo");
-					assert.strictEqual(currentOptions.global[1], "bar");
-				});
-
-				it("should not split on colons", () => {
-					const currentOptions = options.parse(
-						"--global foo:false,bar:true",
-					);
-
-					assert.isArray(currentOptions.global);
-					assert.strictEqual(currentOptions.global.length, 2);
-					assert.strictEqual(currentOptions.global[0], "foo:false");
-					assert.strictEqual(currentOptions.global[1], "bar:true");
-				});
-
-				it("should concatenate successive occurrences", () => {
-					const currentOptions = options.parse(
-						"--global foo:true --global bar:false",
-					);
-
-					assert.isArray(currentOptions.global);
-					assert.strictEqual(currentOptions.global.length, 2);
-					assert.strictEqual(currentOptions.global[0], "foo:true");
-					assert.strictEqual(currentOptions.global[1], "bar:false");
-				});
-			});
-
-			describe("--quiet", () => {
-				it("should return true for .quiet when passed", () => {
-					const currentOptions = options.parse("--quiet");
-
-					assert.isTrue(currentOptions.quiet);
-				});
-			});
-
-			describe("--max-warnings", () => {
-				it("should return correct value for .maxWarnings when passed", () => {
-					const currentOptions = options.parse("--max-warnings 10");
-
-					assert.strictEqual(currentOptions.maxWarnings, 10);
-				});
-
-				it("should return -1 for .maxWarnings when not passed", () => {
-					const currentOptions = options.parse("");
-
-					assert.strictEqual(currentOptions.maxWarnings, -1);
-				});
-
-				it("should throw an error when supplied with a non-integer", () => {
-					assert.throws(() => {
-						options.parse("--max-warnings 10.2");
-					}, /Invalid value for option 'max-warnings' - expected type Int/u);
-				});
-			});
-
-			describe("--init", () => {
-				it("should return true for --init when passed", () => {
-					const currentOptions = options.parse("--init");
-
-					assert.isTrue(currentOptions.init);
-				});
-			});
-
-			describe("--fix", () => {
-				it("should return true for --fix when passed", () => {
-					const currentOptions = options.parse("--fix");
-
-					assert.isTrue(currentOptions.fix);
-				});
-			});
-
-			describe("--fix-type", () => {
-				it("should return one value with --fix-type is passed", () => {
-					const currentOptions = options.parse("--fix-type problem");
-
-					assert.strictEqual(currentOptions.fixType.length, 1);
-					assert.strictEqual(currentOptions.fixType[0], "problem");
-				});
-
-				it("should return two values when --fix-type is passed twice", () => {
-					const currentOptions = options.parse(
-						"--fix-type problem --fix-type suggestion",
-					);
-
-					assert.strictEqual(currentOptions.fixType.length, 2);
-					assert.strictEqual(currentOptions.fixType[0], "problem");
-					assert.strictEqual(currentOptions.fixType[1], "suggestion");
-				});
-
-				it("should return two values when --fix-type is passed a comma-separated value", () => {
-					const currentOptions = options.parse(
-						"--fix-type problem,suggestion",
-					);
-
-					assert.strictEqual(currentOptions.fixType.length, 2);
-					assert.strictEqual(currentOptions.fixType[0], "problem");
-					assert.strictEqual(currentOptions.fixType[1], "suggestion");
-				});
-			});
-
-			describe("--debug", () => {
-				it("should return true for --debug when passed", () => {
-					const currentOptions = options.parse("--debug");
-
-					assert.isTrue(currentOptions.debug);
-				});
-			});
-
-			describe("--inline-config", () => {
-				it("should return false when passed --no-inline-config", () => {
-					const currentOptions = options.parse("--no-inline-config");
-
-					assert.isFalse(currentOptions.inlineConfig);
-				});
-
-				it("should return true for --inline-config when empty", () => {
-					const currentOptions = options.parse("");
-
-					assert.isTrue(currentOptions.inlineConfig);
-				});
-			});
-
-			describe("--print-config", () => {
-				it("should return file path when passed --print-config", () => {
-					const currentOptions = options.parse(
-						"--print-config file.js",
-					);
-
-					assert.strictEqual(currentOptions.printConfig, "file.js");
-				});
-			});
-
-			describe("--ext", () => {
-				it("should return an array with one item when passed .jsx", () => {
-					const currentOptions = options.parse("--ext .jsx");
-
-					assert.isArray(currentOptions.ext);
-					assert.strictEqual(currentOptions.ext[0], ".jsx");
-				});
-
-				it("should return an array with two items when passed .js and .jsx", () => {
-					const currentOptions = options.parse(
-						"--ext .jsx --ext .js",
-					);
-
-					assert.isArray(currentOptions.ext);
-					assert.strictEqual(currentOptions.ext[0], ".jsx");
-					assert.strictEqual(currentOptions.ext[1], ".js");
-				});
-
-				it("should return an array with two items when passed .jsx,.js", () => {
-					const currentOptions = options.parse("--ext .jsx,.js");
-
-					assert.isArray(currentOptions.ext);
-					assert.strictEqual(currentOptions.ext[0], ".jsx");
-					assert.strictEqual(currentOptions.ext[1], ".js");
-				});
-
-				it("should not exist when not passed", () => {
-					const currentOptions = options.parse("");
-
-					assert.notProperty(currentOptions, "ext");
-				});
+		describe("--help", () => {
+			it("should return true for .help when passed", () => {
+				const currentOptions = options.parse("--help");
+
+				assert.isTrue(currentOptions.help);
 			});
 		});
-	});
 
-	describe("--rulesdir", () => {
-		it("should return a string for .rulesdir when passed a string", () => {
-			const currentOptions = eslintrcOptions.parse(
-				"--rulesdir /morerules",
-			);
+		describe("-h", () => {
+			it("should return true for .help when passed", () => {
+				const currentOptions = options.parse("-h");
 
-			assert.isArray(currentOptions.rulesdir);
-			assert.deepStrictEqual(currentOptions.rulesdir, ["/morerules"]);
-		});
-	});
-
-	describe("--ignore-path", () => {
-		it("should return a string for .ignorePath when passed", () => {
-			const currentOptions = eslintrcOptions.parse(
-				"--ignore-path .gitignore",
-			);
-
-			assert.strictEqual(currentOptions.ignorePath, ".gitignore");
-		});
-	});
-
-	describe("--parser", () => {
-		it("should return a string for --parser when passed", () => {
-			const currentOptions = eslintrcOptions.parse("--parser test");
-
-			assert.strictEqual(currentOptions.parser, "test");
-		});
-	});
-
-	describe("--plugin", () => {
-		it("should return an array when passed a single occurrence", () => {
-			const currentOptions = eslintrcOptions.parse("--plugin single");
-
-			assert.isArray(currentOptions.plugin);
-			assert.strictEqual(currentOptions.plugin.length, 1);
-			assert.strictEqual(currentOptions.plugin[0], "single");
+				assert.isTrue(currentOptions.help);
+			});
 		});
 
-		it("should return an array when passed a comma-delimited string", () => {
-			const currentOptions = eslintrcOptions.parse("--plugin foo,bar");
+		describe("--config", () => {
+			it("should return a string for .config when passed a string", () => {
+				const currentOptions = options.parse("--config file");
 
-			assert.isArray(currentOptions.plugin);
-			assert.strictEqual(currentOptions.plugin.length, 2);
-			assert.strictEqual(currentOptions.plugin[0], "foo");
-			assert.strictEqual(currentOptions.plugin[1], "bar");
+				assert.isString(currentOptions.config);
+				assert.strictEqual(currentOptions.config, "file");
+			});
 		});
 
-		it("should return an array when passed multiple times", () => {
-			const currentOptions = eslintrcOptions.parse(
-				"--plugin foo --plugin bar",
-			);
+		describe("-c", () => {
+			it("should return a string for .config when passed a string", () => {
+				const currentOptions = options.parse("-c file");
 
-			assert.isArray(currentOptions.plugin);
-			assert.strictEqual(currentOptions.plugin.length, 2);
-			assert.strictEqual(currentOptions.plugin[0], "foo");
-			assert.strictEqual(currentOptions.plugin[1], "bar");
+				assert.isString(currentOptions.config);
+				assert.strictEqual(currentOptions.config, "file");
+			});
+		});
+
+		describe("--format", () => {
+			it("should return a string for .format when passed a string", () => {
+				const currentOptions = options.parse("--format json");
+
+				assert.isString(currentOptions.format);
+				assert.strictEqual(currentOptions.format, "json");
+			});
+
+			it("should return stylish for .format when not passed", () => {
+				const currentOptions = options.parse("");
+
+				assert.isString(currentOptions.format);
+				assert.strictEqual(currentOptions.format, "stylish");
+			});
+		});
+
+		describe("-f", () => {
+			it("should return a string for .format when passed a string", () => {
+				const currentOptions = options.parse("-f json");
+
+				assert.isString(currentOptions.format);
+				assert.strictEqual(currentOptions.format, "json");
+			});
+		});
+
+		describe("--version", () => {
+			it("should return true for .version when passed", () => {
+				const currentOptions = options.parse("--version");
+
+				assert.isTrue(currentOptions.version);
+			});
+		});
+
+		describe("-v", () => {
+			it("should return true for .version when passed", () => {
+				const currentOptions = options.parse("-v");
+
+				assert.isTrue(currentOptions.version);
+			});
+		});
+
+		describe("when asking for help", () => {
+			it("should return string of help text when called", () => {
+				const helpText = options.generateHelp();
+
+				assert.isString(helpText);
+			});
+		});
+
+		describe("--no-ignore", () => {
+			it("should return false for .ignore when passed", () => {
+				const currentOptions = options.parse("--no-ignore");
+
+				assert.isFalse(currentOptions.ignore);
+			});
+		});
+
+		describe("--ignore-pattern", () => {
+			it("should return a string array for .ignorePattern when passed", () => {
+				const currentOptions = options.parse("--ignore-pattern *.js");
+
+				assert.ok(currentOptions.ignorePattern);
+				assert.strictEqual(currentOptions.ignorePattern.length, 1);
+				assert.strictEqual(currentOptions.ignorePattern[0], "*.js");
+			});
+
+			it("should return a string array for multiple values", () => {
+				const currentOptions = options.parse(
+					"--ignore-pattern *.js --ignore-pattern *.ts",
+				);
+
+				assert.ok(currentOptions.ignorePattern);
+				assert.strictEqual(currentOptions.ignorePattern.length, 2);
+				assert.strictEqual(currentOptions.ignorePattern[0], "*.js");
+				assert.strictEqual(currentOptions.ignorePattern[1], "*.ts");
+			});
+
+			it("should return a string array of properly parsed values, when those values include commas", () => {
+				const currentOptions = options.parse(
+					"--ignore-pattern *.js --ignore-pattern foo-{bar,baz}.js",
+				);
+
+				assert.ok(currentOptions.ignorePattern);
+				assert.strictEqual(currentOptions.ignorePattern.length, 2);
+				assert.strictEqual(currentOptions.ignorePattern[0], "*.js");
+				assert.strictEqual(
+					currentOptions.ignorePattern[1],
+					"foo-{bar,baz}.js",
+				);
+			});
+		});
+
+		describe("--color", () => {
+			it("should return true for .color when passed --color", () => {
+				const currentOptions = options.parse("--color");
+
+				assert.isTrue(currentOptions.color);
+			});
+
+			it("should return false for .color when passed --no-color", () => {
+				const currentOptions = options.parse("--no-color");
+
+				assert.isFalse(currentOptions.color);
+			});
+		});
+
+		describe("--stdin", () => {
+			it("should return true for .stdin when passed", () => {
+				const currentOptions = options.parse("--stdin");
+
+				assert.isTrue(currentOptions.stdin);
+			});
+		});
+
+		describe("--stdin-filename", () => {
+			it("should return a string for .stdinFilename when passed", () => {
+				const currentOptions = options.parse(
+					"--stdin-filename test.js",
+				);
+
+				assert.strictEqual(currentOptions.stdinFilename, "test.js");
+			});
+		});
+
+		describe("--global", () => {
+			it("should return an array for a single occurrence", () => {
+				const currentOptions = options.parse("--global foo");
+
+				assert.isArray(currentOptions.global);
+				assert.strictEqual(currentOptions.global.length, 1);
+				assert.strictEqual(currentOptions.global[0], "foo");
+			});
+
+			it("should split variable names using commas", () => {
+				const currentOptions = options.parse("--global foo,bar");
+
+				assert.isArray(currentOptions.global);
+				assert.strictEqual(currentOptions.global.length, 2);
+				assert.strictEqual(currentOptions.global[0], "foo");
+				assert.strictEqual(currentOptions.global[1], "bar");
+			});
+
+			it("should not split on colons", () => {
+				const currentOptions = options.parse(
+					"--global foo:false,bar:true",
+				);
+
+				assert.isArray(currentOptions.global);
+				assert.strictEqual(currentOptions.global.length, 2);
+				assert.strictEqual(currentOptions.global[0], "foo:false");
+				assert.strictEqual(currentOptions.global[1], "bar:true");
+			});
+
+			it("should concatenate successive occurrences", () => {
+				const currentOptions = options.parse(
+					"--global foo:true --global bar:false",
+				);
+
+				assert.isArray(currentOptions.global);
+				assert.strictEqual(currentOptions.global.length, 2);
+				assert.strictEqual(currentOptions.global[0], "foo:true");
+				assert.strictEqual(currentOptions.global[1], "bar:false");
+			});
+		});
+
+		describe("--quiet", () => {
+			it("should return true for .quiet when passed", () => {
+				const currentOptions = options.parse("--quiet");
+
+				assert.isTrue(currentOptions.quiet);
+			});
+		});
+
+		describe("--max-warnings", () => {
+			it("should return correct value for .maxWarnings when passed", () => {
+				const currentOptions = options.parse("--max-warnings 10");
+
+				assert.strictEqual(currentOptions.maxWarnings, 10);
+			});
+
+			it("should return -1 for .maxWarnings when not passed", () => {
+				const currentOptions = options.parse("");
+
+				assert.strictEqual(currentOptions.maxWarnings, -1);
+			});
+
+			it("should throw an error when supplied with a non-integer", () => {
+				assert.throws(() => {
+					options.parse("--max-warnings 10.2");
+				}, /Invalid value for option 'max-warnings' - expected type Int/u);
+			});
+		});
+
+		describe("--init", () => {
+			it("should return true for --init when passed", () => {
+				const currentOptions = options.parse("--init");
+
+				assert.isTrue(currentOptions.init);
+			});
+		});
+
+		describe("--fix", () => {
+			it("should return true for --fix when passed", () => {
+				const currentOptions = options.parse("--fix");
+
+				assert.isTrue(currentOptions.fix);
+			});
+		});
+
+		describe("--fix-type", () => {
+			it("should return one value with --fix-type is passed", () => {
+				const currentOptions = options.parse("--fix-type problem");
+
+				assert.strictEqual(currentOptions.fixType.length, 1);
+				assert.strictEqual(currentOptions.fixType[0], "problem");
+			});
+
+			it("should return two values when --fix-type is passed twice", () => {
+				const currentOptions = options.parse(
+					"--fix-type problem --fix-type suggestion",
+				);
+
+				assert.strictEqual(currentOptions.fixType.length, 2);
+				assert.strictEqual(currentOptions.fixType[0], "problem");
+				assert.strictEqual(currentOptions.fixType[1], "suggestion");
+			});
+
+			it("should return two values when --fix-type is passed a comma-separated value", () => {
+				const currentOptions = options.parse(
+					"--fix-type problem,suggestion",
+				);
+
+				assert.strictEqual(currentOptions.fixType.length, 2);
+				assert.strictEqual(currentOptions.fixType[0], "problem");
+				assert.strictEqual(currentOptions.fixType[1], "suggestion");
+			});
+		});
+
+		describe("--debug", () => {
+			it("should return true for --debug when passed", () => {
+				const currentOptions = options.parse("--debug");
+
+				assert.isTrue(currentOptions.debug);
+			});
+		});
+
+		describe("--inline-config", () => {
+			it("should return false when passed --no-inline-config", () => {
+				const currentOptions = options.parse("--no-inline-config");
+
+				assert.isFalse(currentOptions.inlineConfig);
+			});
+
+			it("should return true for --inline-config when empty", () => {
+				const currentOptions = options.parse("");
+
+				assert.isTrue(currentOptions.inlineConfig);
+			});
+		});
+
+		describe("--print-config", () => {
+			it("should return file path when passed --print-config", () => {
+				const currentOptions = options.parse("--print-config file.js");
+
+				assert.strictEqual(currentOptions.printConfig, "file.js");
+			});
+		});
+
+		describe("--ext", () => {
+			it("should return an array with one item when passed .jsx", () => {
+				const currentOptions = options.parse("--ext .jsx");
+
+				assert.isArray(currentOptions.ext);
+				assert.strictEqual(currentOptions.ext[0], ".jsx");
+			});
+
+			it("should return an array with two items when passed .js and .jsx", () => {
+				const currentOptions = options.parse("--ext .jsx --ext .js");
+
+				assert.isArray(currentOptions.ext);
+				assert.strictEqual(currentOptions.ext[0], ".jsx");
+				assert.strictEqual(currentOptions.ext[1], ".js");
+			});
+
+			it("should return an array with two items when passed .jsx,.js", () => {
+				const currentOptions = options.parse("--ext .jsx,.js");
+
+				assert.isArray(currentOptions.ext);
+				assert.strictEqual(currentOptions.ext[0], ".jsx");
+				assert.strictEqual(currentOptions.ext[1], ".js");
+			});
+
+			it("should not exist when not passed", () => {
+				const currentOptions = options.parse("");
+
+				assert.notProperty(currentOptions, "ext");
+			});
 		});
 	});
 
 	describe("--no-config-lookup", () => {
 		it("should return a boolean for .configLookup when passed a string", () => {
-			const currentOptions = flatOptions.parse(
-				"--no-config-lookup foo.js",
-			);
+			const currentOptions = options.parse("--no-config-lookup foo.js");
 
 			assert.isFalse(currentOptions.configLookup);
 		});
@@ -442,7 +372,7 @@ describe("options", () => {
 
 	describe("--pass-on-no-patterns", () => {
 		it("should return a boolean for .passOnNoPatterns when passed a string", () => {
-			const currentOptions = flatOptions.parse("--pass-on-no-patterns");
+			const currentOptions = options.parse("--pass-on-no-patterns");
 
 			assert.isTrue(currentOptions.passOnNoPatterns);
 		});
@@ -450,13 +380,13 @@ describe("options", () => {
 
 	describe("--no-warn-ignored", () => {
 		it("should return false when --no-warn-ignored is passed", () => {
-			const currentOptions = flatOptions.parse("--no-warn-ignored");
+			const currentOptions = options.parse("--no-warn-ignored");
 
 			assert.isFalse(currentOptions.warnIgnored);
 		});
 
 		it("should return true when --warn-ignored is passed", () => {
-			const currentOptions = flatOptions.parse("--warn-ignored");
+			const currentOptions = options.parse("--warn-ignored");
 
 			assert.isTrue(currentOptions.warnIgnored);
 		});
@@ -464,7 +394,7 @@ describe("options", () => {
 
 	describe("--stats", () => {
 		it("should return true --stats is passed", () => {
-			const currentOptions = flatOptions.parse("--stats");
+			const currentOptions = options.parse("--stats");
 
 			assert.isTrue(currentOptions.stats);
 		});
@@ -472,7 +402,7 @@ describe("options", () => {
 
 	describe("--inspect-config", () => {
 		it("should return true when --inspect-config is passed", () => {
-			const currentOptions = flatOptions.parse("--inspect-config");
+			const currentOptions = options.parse("--inspect-config");
 
 			assert.isTrue(currentOptions.inspectConfig);
 		});
@@ -480,13 +410,13 @@ describe("options", () => {
 
 	describe("--flag", () => {
 		it("should return single-item array when --flag is passed once", () => {
-			const currentOptions = flatOptions.parse("--flag x_feature");
+			const currentOptions = options.parse("--flag x_feature");
 
 			assert.deepStrictEqual(currentOptions.flag, ["x_feature"]);
 		});
 
 		it("should return multi-item array when --flag is passed multiple times", () => {
-			const currentOptions = flatOptions.parse(
+			const currentOptions = options.parse(
 				"--flag x_feature --flag y_feature",
 			);
 

--- a/tests/lib/services/warning-service.js
+++ b/tests/lib/services/warning-service.js
@@ -73,18 +73,6 @@ describe("WarningService", () => {
 			);
 		});
 
-		it("emitESLintRCWarning", () => {
-			warningService.emitESLintRCWarning();
-
-			assert(
-				process.emitWarning.calledOnceWithExactly(
-					"You are using an eslintrc configuration file, which is deprecated and support will be removed in v10.0.0. Please migrate to an eslint.config.js file. See https://eslint.org/docs/latest/use/configure/migration-guide for details. An eslintrc configuration file is used because you have the ESLINT_USE_FLAT_CONFIG environment variable set to false. If you want to use an eslint.config.js file, remove the environment variable. If you want to find the location of the eslintrc configuration file, use the --debug flag.",
-					"ESLintRCWarning",
-				),
-				"Expected process.emitWarning to be called with the correct arguments",
-			);
-		});
-
 		it("emitInactiveFlagWarning", () => {
 			const flag = "unstable_foo_bar";
 			const message = `Lorem ipsum ${flag}.`;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Remove eslintrc from the CLI.

refs #13481

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This change revoves eslintrc support from the CLI, including eslintrc CLI flags, documentation and related tests. After this change, ESLint will always run in flat mode from the command line, regardless of the `ESLINT_USE_FLAT_CONFIG` variable setting.

This pull request does not change the Node.js API. `LegacyESLint`, `Linter`, `shouldUseFlatConfig`, etc. work the same as before.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
