### PR TITLE
fix: add `before` and `after` to test case types

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -2259,6 +2259,8 @@ export namespace RuleTester {
 		only?: boolean;
 		languageOptions?: Linter.LanguageOptions | undefined;
 		settings?: { [name: string]: any } | undefined;
+		before?: () => void;
+		after?: () => void;
 	}
 
 	interface SuggestionOutput {

--- a/tests/lib/types/types.test.ts
+++ b/tests/lib/types/types.test.ts
@@ -1924,6 +1924,15 @@ ruleTester.run("my-rule", rule, {
 		{ code: "foo", filename: "test.js" },
 		{ code: "foo", languageOptions: { globals: { foo: true } } },
 		{ code: "foo", settings: { foo: true } },
+		{
+			code: "foo",
+			before() {
+				/* do something */
+			},
+			after() {
+				/* undo something */
+			},
+		},
 		RuleTester.only("foo"),
 	],
 
@@ -1954,6 +1963,12 @@ ruleTester.run("my-rule", rule, {
 			],
 		},
 		{ code: "foo", errors: 1, only: true },
+		{
+			code: "foo",
+			errors: [{ messageId: "bar" }],
+			before: () => {},
+			after: () => {},
+		},
 		// @ts-expect-error // `message` cannot be `undefined`
 		{ code: "foo", errors: [{ message: undefined }], only: true },
 		// @ts-expect-error // `messageId` cannot be `undefined`
@@ -1972,6 +1987,10 @@ ruleTester.run("my-rule", rule, {
 				},
 			],
 		},
+		// @ts-expect-error // `before` should be a function
+		{ code: "foo", errors: [{ messageId: "bar" }], before: {} },
+		// @ts-expect-error // `after` should be a function
+		{ code: "foo", errors: [{ messageId: "bar" }], after: void 0 },
 	],
 });
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Fix types

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

refs #18771

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added `before` and `after` properties to test case base type (`RuleTester.ValidTestCase`). Support for `before` and `after` in test cases was added in [ESLint v9.12.0](https://github.com/eslint/eslint/releases/tag/v9.12.0) following the proposal in [this RFC document](https://github.com/eslint/rfcs/tree/main/designs/2024-hooks-for-test-cases#readme), but the types were not updated.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
