### PR TITLE
docs: add missing "the" in rule deprecation docs

### DIFF
--- a/docs/src/use/rule-deprecation.md
+++ b/docs/src/use/rule-deprecation.md
@@ -10,7 +10,7 @@ The ESLint team is committed to making upgrading as easy and painless as possibl
     - The rule has been replaced by another core rule.
     - A plugin exists with a functionally equivalent rule.
 - Rules will be deprecated as needed, and marked as such in all documentation.
-- After a rule has been deprecated, the team will no longer do any work on it. This includes bug fixes, enhancements, and updates to the rule's documentation. Issues and pull requests related to deprecated rule will not be accepted and will be closed.
+- After a rule has been deprecated, the team will no longer do any work on it. This includes bug fixes, enhancements, and updates to the rule's documentation. Issues and pull requests related to the deprecated rule will not be accepted and will be closed.
 
 You can continue to use deprecated rules indefinitely if they are working for you. However, keep in mind that deprecated rules will effectively be unmaintained and may be removed at some point.
 


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

Adds a missing "the" to the sentence.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
