### PR TITLE
feat: implement suggestions for no-empty-static-block

### DIFF
--- a/lib/rules/no-empty-static-block.js
+++ b/lib/rules/no-empty-static-block.js
@@ -11,6 +11,7 @@
 /** @type {import('../types').Rule.RuleModule} */
 module.exports = {
 	meta: {
+		hasSuggestions: true,
 		type: "suggestion",
 
 		docs: {
@@ -23,6 +24,7 @@ module.exports = {
 
 		messages: {
 			unexpected: "Unexpected empty static block.",
+			suggestComment: "Add comment inside empty static block.",
 		},
 	},
 
@@ -32,14 +34,36 @@ module.exports = {
 		return {
 			StaticBlock(node) {
 				if (node.body.length === 0) {
+					const openingBrace = sourceCode.getFirstToken(node, {
+						skip: 1,
+					});
 					const closingBrace = sourceCode.getLastToken(node);
 
 					if (
 						sourceCode.getCommentsBefore(closingBrace).length === 0
 					) {
 						context.report({
-							node,
+							loc: {
+								start: openingBrace.loc.start,
+								end: closingBrace.loc.end,
+							},
 							messageId: "unexpected",
+							suggest: [
+								{
+									messageId: "suggestComment",
+									fix(fixer) {
+										const range = [
+											openingBrace.range[1],
+											closingBrace.range[0],
+										];
+
+										return fixer.replaceTextRange(
+											range,
+											" /* empty */ ",
+										);
+									},
+								},
+							],
 						});
 					}
 				}

--- a/tests/lib/rules/no-empty-static-block.js
+++ b/tests/lib/rules/no-empty-static-block.js
@@ -29,23 +29,111 @@ ruleTester.run("no-empty-static-block", rule, {
 	invalid: [
 		{
 			code: "class Foo { static {} }",
-			errors: [{ messageId: "unexpected" }],
+			errors: [
+				{
+					messageId: "unexpected",
+					line: 1,
+					column: 20,
+					endLine: 1,
+					endColumn: 22,
+					suggestions: [
+						{
+							messageId: "suggestComment",
+							output: "class Foo { static { /* empty */ } }",
+						},
+					],
+				},
+			],
 		},
 		{
 			code: "class Foo { static { } }",
-			errors: [{ messageId: "unexpected" }],
+			errors: [
+				{
+					messageId: "unexpected",
+					line: 1,
+					column: 20,
+					endLine: 1,
+					endColumn: 23,
+					suggestions: [
+						{
+							messageId: "suggestComment",
+							output: "class Foo { static { /* empty */ } }",
+						},
+					],
+				},
+			],
 		},
 		{
 			code: "class Foo { static { \n\n } }",
-			errors: [{ messageId: "unexpected" }],
+			errors: [
+				{
+					messageId: "unexpected",
+					line: 1,
+					column: 20,
+					endLine: 3,
+					endColumn: 3,
+					suggestions: [
+						{
+							messageId: "suggestComment",
+							output: "class Foo { static { /* empty */ } }",
+						},
+					],
+				},
+			],
 		},
 		{
 			code: "class Foo { static { bar(); } static {} }",
-			errors: [{ messageId: "unexpected" }],
+			errors: [
+				{
+					messageId: "unexpected",
+					line: 1,
+					column: 38,
+					endLine: 1,
+					endColumn: 40,
+					suggestions: [
+						{
+							messageId: "suggestComment",
+							output: "class Foo { static { bar(); } static { /* empty */ } }",
+						},
+					],
+				},
+			],
 		},
 		{
 			code: "class Foo { static // comment\n {} }",
-			errors: [{ messageId: "unexpected" }],
+			errors: [
+				{
+					messageId: "unexpected",
+					line: 2,
+					column: 2,
+					endLine: 2,
+					endColumn: 4,
+					suggestions: [
+						{
+							messageId: "suggestComment",
+							output: "class Foo { static // comment\n { /* empty */ } }",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "class Foo { static /* empty */ {} /* empty */ }",
+			errors: [
+				{
+					messageId: "unexpected",
+					line: 1,
+					column: 32,
+					endLine: 1,
+					endColumn: 34,
+					suggestions: [
+						{
+							messageId: "suggestComment",
+							output: "class Foo { static /* empty */ { /* empty */ } /* empty */ }",
+						},
+					],
+				},
+			],
 		},
 	],
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

- Added fixable suggestions to insert `/* empty */` inside empty static blocks.
- Updated highlighting so that only the opening and closing braces `{}` are marked, instead of the entire static block.

Closes #20054

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
