### PR TITLE
Refactor: Update uncloneable options error message

### DIFF
--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -543,7 +543,7 @@ function validateOptionCloneability(options) {
 		})
 		.sort();
 	const error = new TypeError(
-		`The ${uncloneableOptionKeys.length === 1 ? "option" : "options"} ${new Intl.ListFormat("en-US").format(uncloneableOptionKeys.map(key => `"${key}"`))} cannot be cloned. When concurrency is enabled, all options must be cloneable. Remove uncloneable options or use an options module.`,
+		`The ${uncloneableOptionKeys.length === 1 ? "option" : "options"} ${new Intl.ListFormat("en-US").format(uncloneableOptionKeys.map(key => `"${key}"`))} cannot be cloned. When concurrency is enabled, all options must be cloneable values--such as primitives, plain objects, or arrays. Remove uncloneable options or use an options module.`,
 	);
 	error.code = "ESLINT_UNCLONEABLE_OPTIONS";
 	throw error;

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -426,7 +426,7 @@ describe("ESLint", () => {
 						constructor: TypeError,
 						code: "ESLINT_UNCLONEABLE_OPTIONS",
 						message:
-							'The options "baseConfig", "fix", and "plugins" cannot be cloned. When concurrency is enabled, all options must be cloneable. Remove uncloneable options or use an options module.',
+							'The options "baseConfig", "fix", and "plugins" cannot be cloned. When concurrency is enabled, all options must be cloneable values--such as primitives, plain objects, or arrays. Remove uncloneable options or use an options module.',
 					},
 				);
 			});
@@ -445,7 +445,7 @@ describe("ESLint", () => {
 						constructor: TypeError,
 						code: "ESLINT_UNCLONEABLE_OPTIONS",
 						message:
-							'The option "ruleFilter" cannot be cloned. When concurrency is enabled, all options must be cloneable. Remove uncloneable options or use an options module.',
+							'The option "ruleFilter" cannot be cloned. When concurrency is enabled, all options must be cloneable values--such as primitives, plain objects, or arrays. Remove uncloneable options or use an options module.',
 					},
 				);
 			});
@@ -9775,13 +9775,13 @@ describe("ESLint", () => {
 					const optionsSrc = `
 					import assert from "node:assert";
 					import { isMainThread } from "node:worker_threads";
-					
+
 					if (!isMainThread) {
 						if (process.env.ESLINT_TEST_ENV !== "test") {
 							assert.fail("Environment variable ESLINT_TEST_ENV is not set as expected in worker threads.");
 						}
 					}
-					
+
 					export default {
 						concurrency: 2,
 						cwd: ${JSON.stringify(fixtureDir)},
@@ -9800,11 +9800,11 @@ describe("ESLint", () => {
 				it("should propagate environment variables from worker threads to the controlling thread", async () => {
 					const optionsSrc = `
 					import { isMainThread } from "node:worker_threads";
-					
+
 					if (!isMainThread) {
 						process.env.ESLINT_TEST_ENV = "test";
 					}
-					
+
 					export default {
 						concurrency: 2,
 						cwd: ${JSON.stringify(fixtureDir)},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
This change updates the error message for UNCLONEABLE_OPTIONS. I was reading the latest blog post about [multithreading in eslint](https://eslint.org/blog/2025/08/multithread-linting/). It's a fantastic new feature and the post is great. When I reached the section about the `cloneablity requirement`, I thought it was helpful how the author mentioned some example cloneables in the text, but then noticed the error message itself didn't:

> The option “ruleFilter” cannot be cloned. When concurrency is enabled, all options must be cloneable. Remove uncloneable options or use an options module.

I thought it would be helpful to add those examples directly in the error message. Users will get an additional hint about what is causing the error and it will help narrow the fix.  

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
