### PR TITLE
refactor: remove deprecated `context.parserOptions` usage across rules

### DIFF
--- a/lib/rules/no-eval.js
+++ b/lib/rules/no-eval.js
@@ -226,7 +226,9 @@ module.exports = {
 
 			Program(node) {
 				const scope = sourceCode.getScope(node),
-					features = context.parserOptions.ecmaFeatures || {},
+					features =
+						context.languageOptions.parserOptions.ecmaFeatures ||
+						{},
 					strict =
 						scope.isStrict ||
 						node.sourceType === "module" ||

--- a/lib/rules/strict.js
+++ b/lib/rules/strict.js
@@ -101,7 +101,8 @@ module.exports = {
 	},
 
 	create(context) {
-		const ecmaFeatures = context.parserOptions.ecmaFeatures || {},
+		const ecmaFeatures =
+				context.languageOptions.parserOptions.ecmaFeatures || {},
 			scopes = [],
 			classScopes = [];
 		let [mode] = context.options;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated rules to use `context.languageOptions.parserOptions` instead of deprecated `context.parserOptions`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
