### PR TITLE
test: remove `tests/lib/eslint/eslint.config.js`

### DIFF
--- a/tests/fixtures/configurations/cwd/eslint.config.js
+++ b/tests/fixtures/configurations/cwd/eslint.config.js
@@ -1,5 +1,3 @@
-/* eslint strict: off -- config used for testing only */
-
 module.exports = {
 	rules: {
 		quotes: 2,

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -201,14 +201,14 @@ describe("ESLint", () => {
 			});
 
 			it("the default value of 'options.cwd' should be the current working directory.", async () => {
-				process.chdir(__dirname);
+				process.chdir(fixtureDir);
 				try {
 					const engine = new ESLint({ flags });
-					const results = await engine.lintFiles("eslint.js");
+					const results = await engine.lintFiles("passing.js");
 
 					assert.strictEqual(
 						path.dirname(results[0].filePath),
-						__dirname,
+						fixtureDir,
 					);
 				} finally {
 					process.chdir(originalDir);
@@ -629,7 +629,7 @@ describe("ESLint", () => {
 			it("should report the total and per file errors when using local cwd eslint.config.js", async () => {
 				eslint = new ESLint({
 					flags,
-					cwd: __dirname,
+					cwd: getFixturePath("configurations", "cwd"),
 				});
 
 				const results = await eslint.lintText("var foo = 'bar';");
@@ -13490,7 +13490,7 @@ describe("ESLint", () => {
 				const originalCwd = process.cwd();
 
 				beforeEach(() => {
-					process.chdir(__dirname);
+					process.chdir(fixtureDir);
 				});
 
 				afterEach(() => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Removes `tests/lib/eslint/eslint.config.js` fixture config file. When lookup from config file becomes default behavior in v10, this config would apply to files in `tests/lib/eslint/` when linting this project, which is not what we want. Also, it seems that VSCode by default already applies the nearest config file, so I was always getting wrong lint errors when editing `tests/lib/eslint/eslint.js` because VSCode used this config instead of the root one.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Removed `tests/lib/eslint/eslint.config.js` and updated tests that were using it.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
