### PR TITLE
feat: --no-fixable-warnings option to exit with code 1

### DIFF
--- a/docs/src/use/command-line-interface.md
+++ b/docs/src/use/command-line-interface.md
@@ -116,6 +116,7 @@ Use stdin:
 Handle Warnings:
   --quiet                          Report errors only - default: false
   --max-warnings Int               Number of warnings to trigger nonzero exit code - default: -1
+  --no-fixable-warnings            Exit with non-zero code if fixable warnings are found
 
 Output:
   -o, --output-file path::String   Specify file to write report to
@@ -617,6 +618,25 @@ When used alongside `--quiet`, this will cause rules marked as warn to still be 
     package: "eslint",
     args: ["--max-warnings", "10", "file.js"]
 }) }}
+
+#### `--no-fixable-warnings`
+
+This option causes ESLint to exit with exit code 1 if any fixable warnings are found, even if there are no errors.
+
+- **Argument Type**: No argument.
+
+Normally, ESLint exits with a success status (code 0) when only warnings are found. However, if `--no-fixable-warnings` is specified and there are any warnings that could be automatically fixed using `eslint --fix`, ESLint will exit with an error status (code 1) and display a message indicating how many fixable warnings were found.
+
+This option is useful in CI/CD pipelines or development workflows where you want to ensure that all automatically fixable issues are resolved before considering the code as passing.
+
+##### `--no-fixable-warnings` example
+
+{{ npx_tabs ({
+    package: "eslint",
+    args: ["--no-fixable-warnings", "file.js"]
+}) }}
+
+If `file.js` contains warnings that can be fixed with `eslint --fix`, the command will exit with code 1 and display a message like: "ESLint found 3 fixable warnings. Run 'eslint --fix' to fix them."
 
 ### Output
 
@@ -1132,6 +1152,6 @@ The value `off` causes all files to be linted in the main thread. The value `aut
 
 When linting files, ESLint exits with one of the following exit codes:
 
-- `0`: Linting was successful and there are no linting errors. If the [`--max-warnings`](#--max-warnings) flag is set to `n`, the number of linting warnings is at most `n`.
-- `1`: Linting was successful and there is at least one linting error, or there are more linting warnings than allowed by the [`--max-warnings`](#--max-warnings) option.
+- `0`: Linting was successful and there are no linting errors. If the [`--max-warnings`](#--max-warnings) flag is set to `n`, the number of linting warnings is at most `n`. If the [`--no-fixable-warnings`](#--no-fixable-warnings) flag is used, there are no fixable warnings.
+- `1`: Linting was successful and there is at least one linting error, or there are more linting warnings than allowed by the [`--max-warnings`](#--max-warnings) option, or the [`--no-fixable-warnings`](#--no-fixable-warnings) flag is used and there are fixable warnings.
 - `2`: Linting was unsuccessful due to a configuration problem or an internal error.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -48,20 +48,22 @@ const debug = require("debug")("eslint:cli");
 /**
  * Count error messages.
  * @param {LintResult[]} results The lint results.
- * @returns {{errorCount:number;fatalErrorCount:number,warningCount:number}} The number of error messages.
+ * @returns {{errorCount:number;fatalErrorCount:number,warningCount:number,fixableWarningCount:number}} The number of error messages.
  */
 function countErrors(results) {
 	let errorCount = 0;
 	let fatalErrorCount = 0;
 	let warningCount = 0;
+	let fixableWarningCount = 0;
 
 	for (const result of results) {
 		errorCount += result.errorCount;
 		fatalErrorCount += result.fatalErrorCount;
 		warningCount += result.warningCount;
+		fixableWarningCount += result.fixableWarningCount || 0;
 	}
 
-	return { errorCount, fatalErrorCount, warningCount };
+	return { errorCount, fatalErrorCount, warningCount, fixableWarningCount };
 }
 
 /**
@@ -496,6 +498,8 @@ const cli = {
 		const tooManyWarnings =
 			options.maxWarnings >= 0 &&
 			resultCounts.warningCount > options.maxWarnings;
+		const hasFixableWarnings =
+			!options.fixableWarnings && resultCounts.fixableWarningCount > 0;
 		const resultsMeta = tooManyWarnings
 			? {
 					maxWarningsExceeded: {
@@ -525,6 +529,14 @@ const cli = {
 				);
 			}
 
+			if (hasFixableWarnings) {
+				log.error(
+					"ESLint found %s fixable warning%s. Run 'eslint --fix' to fix them.",
+					resultCounts.fixableWarningCount,
+					resultCounts.fixableWarningCount === 1 ? "" : "s",
+				);
+			}
+
 			if (!options.passOnUnprunedSuppressions) {
 				const unusedSuppressionsCount =
 					Object.keys(unusedSuppressions).length;
@@ -543,7 +555,11 @@ const cli = {
 				return 2;
 			}
 
-			return resultCounts.errorCount || tooManyWarnings ? 1 : 0;
+			return resultCounts.errorCount ||
+				tooManyWarnings ||
+				hasFixableWarnings
+				? 1
+				: 0;
 		}
 
 		return 2;

--- a/lib/options.js
+++ b/lib/options.js
@@ -44,6 +44,7 @@ const optionator = require("optionator");
  * @property {boolean} init Run config initialization wizard
  * @property {boolean} inlineConfig Prevent comments from changing config or rules
  * @property {number} maxWarnings Number of warnings to trigger nonzero exit code
+ * @property {boolean} fixableWarnings Allow fixable warnings (when false, exit with non-zero code if fixable warnings are found)
  * @property {string} [outputFile] Specify file to write report to
  * @property {string} [parser] Specify the parser to be used
  * @property {Object} [parserOptions] Specify parser options
@@ -360,6 +361,13 @@ module.exports = function (usingFlatConfig) {
 				type: "Int",
 				default: "-1",
 				description: "Number of warnings to trigger nonzero exit code",
+			},
+			{
+				option: "fixable-warnings",
+				type: "Boolean",
+				default: "true",
+				description:
+					"Exit with non-zero code if fixable warnings are found",
 			},
 			{
 				heading: "Output",

--- a/tests/fixtures/no-fixable-warnings/.eslintrc
+++ b/tests/fixtures/no-fixable-warnings/.eslintrc
@@ -1,0 +1,7 @@
+{
+    "rules": {
+        "quotes": [1, "single"],
+        "semi": [1, "always"]
+    },
+    "root": true
+}

--- a/tests/fixtures/no-fixable-warnings/eslint.config.js
+++ b/tests/fixtures/no-fixable-warnings/eslint.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+    rules: {
+        quotes: [1, "single"],  // Warning level, fixable
+        semi: [1, "always"]     // Warning level, fixable
+    }
+};

--- a/tests/fixtures/no-fixable-warnings/fixable-warnings.js
+++ b/tests/fixtures/no-fixable-warnings/fixable-warnings.js
@@ -1,0 +1,2 @@
+var message = "Hello world"
+console.log(message)

--- a/tests/fixtures/no-fixable-warnings/no-fixable-warnings.js
+++ b/tests/fixtures/no-fixable-warnings/no-fixable-warnings.js
@@ -1,0 +1,2 @@
+var message = 'Hello world';
+console.log(message);

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -1080,6 +1080,71 @@ describe("cli", () => {
 					});
 				});
 
+				describe("when given the no-fixable-warnings flag", () => {
+					it(`should not change exit code if no fixable warnings are found with configType:${configType}`, async () => {
+						const filePath = getFixturePath(
+							"no-fixable-warnings",
+							"no-fixable-warnings.js",
+						);
+						const configFilePath = getFixturePath(
+							"no-fixable-warnings",
+							useFlatConfig ? "eslint.config.js" : ".eslintrc",
+						);
+						const exitCode = await cli.execute(
+							`--no-ignore --no-fixable-warnings -c ${configFilePath} ${filePath}`,
+							null,
+							useFlatConfig,
+						);
+
+						assert.strictEqual(exitCode, 0);
+					});
+
+					it(`should exit with exit code 1 if fixable warnings are found with configType:${configType}`, async () => {
+						const filePath = getFixturePath(
+							"no-fixable-warnings",
+							"fixable-warnings.js",
+						);
+						const configFilePath = getFixturePath(
+							"no-fixable-warnings",
+							useFlatConfig ? "eslint.config.js" : ".eslintrc",
+						);
+						const exitCode = await cli.execute(
+							`--no-ignore --no-fixable-warnings -c ${configFilePath} ${filePath}`,
+							null,
+							useFlatConfig,
+						);
+
+						assert.strictEqual(exitCode, 1);
+						assert.ok(log.error.calledOnce);
+						assert.include(
+							log.error.getCall(0).args[0],
+							"ESLint found",
+						);
+						assert.include(
+							log.error.getCall(0).args[0],
+							"fixable warning",
+						);
+					});
+
+					it(`should not change exit code if flag is not specified and there are fixable warnings with configType:${configType}`, async () => {
+						const filePath = getFixturePath(
+							"no-fixable-warnings",
+							"fixable-warnings.js",
+						);
+						const configFilePath = getFixturePath(
+							"no-fixable-warnings",
+							useFlatConfig ? "eslint.config.js" : ".eslintrc",
+						);
+						const exitCode = await cli.execute(
+							`--no-ignore -c ${configFilePath} ${filePath}`,
+							null,
+							useFlatConfig,
+						);
+
+						assert.strictEqual(exitCode, 0);
+					});
+				});
+
 				describe("when given the exit-on-fatal-error flag", () => {
 					it(`should not change exit code if no fatal errors are reported with configType:${configType}`, async () => {
 						const filePath = getFixturePath(


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? 

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[x] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? 


  This addresses a common CI/CD inconsistency issue that causes developer frustration:

  The Problem Scenario

  Dev 1's Workflow:
  1. Writes code with some style violations (e.g., missing semicolons, wrong quotes)
  2. Runs ESLint locally → gets warnings but exit code 0 ✅
  3. Commits and pushes → CI passes ✅
  4. Thinks everything is fine

  Dev 2's Workflow:
  1. Pulls Dev 1's code
  2. Has their editor configured to auto-fix on save, OR runs eslint --fix as part of their workflow
  3. Now has "changes" in their working directory that they didn't make
  4. Has to decide: commit the fixes (polluting git history) or stash them (losing the improvements)

  The Inconsistency

  - Without --no-fixable-warnings: ESLint treats fixable warnings as "acceptable" (exit code 0)
  - In practice: Many teams want fixable issues resolved immediately since they're zero-effort to fix
  - Result: Inconsistent code state across developers and CI environments

  How --no-fixable-warnings Solves This

  With this flag enabled in CI:

  Dev 1's Updated Workflow:
  1. Writes code with style violations
  2. Runs ESLint locally → gets warnings and exit code 1 ❌
  3. Cannot commit/push until running eslint --fix or manually fixing issues
  4. Commits clean, consistent code

  Dev 2's Workflow:
  1. Pulls Dev 1's code
  2. Code is already properly formatted
  3. No unexpected changes in working directory
  4. Can focus on actual development instead of formatting cleanup


#### Is there anything you'd like reviewers to focus on?

N/A
