### PR TITLE
refactor: use `meta.defaultOptions` in `preserve-caught-error`

### DIFF
--- a/lib/rules/preserve-caught-error.js
+++ b/lib/rules/preserve-caught-error.js
@@ -138,6 +138,13 @@ function findParentCatch(node) {
 module.exports = {
 	meta: {
 		type: "suggestion",
+
+		defaultOptions: [
+			{
+				requireCatchParameter: false,
+			},
+		],
+
 		docs: {
 			description:
 				"Disallow losing originally caught error when re-throwing custom errors",
@@ -158,7 +165,6 @@ module.exports = {
 				properties: {
 					requireCatchParameter: {
 						type: "boolean",
-						default: false,
 						description:
 							"Requires the catch blocks to always have the caught error parameter so it is not discarded.",
 					},
@@ -185,7 +191,7 @@ module.exports = {
 
 	create(context) {
 		const sourceCode = context.sourceCode;
-		const options = context.options[0] || {};
+		const [{ requireCatchParameter }] = context.options;
 
 		//----------------------------------------------------------------------
 		// Helpers
@@ -273,7 +279,7 @@ module.exports = {
 
 					// Check if there are throw statements and caught error is being ignored
 					if (!caughtError) {
-						if (options.requireCatchParameter) {
+						if (requireCatchParameter) {
 							context.report({
 								node: throwStatement,
 								messageId: "missingCatchErrorParam",

--- a/lib/types/rules.d.ts
+++ b/lib/types/rules.d.ts
@@ -4812,6 +4812,9 @@ export interface ESLintRules extends Linter.RulesRecord {
 	"preserve-caught-error": Linter.RuleEntry<
 		[
 			Partial<{
+				/**
+				 * @default false
+				 */
 				requireCatchParameter: boolean;
 			}>,
 		]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR refactors `preserve-caught-error` to use `meta.defaultOptions` instead of a manual `|| {}` fallback.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
