### PR TITLE
fix: correct rule option typings in `rules.d.ts`

### DIFF
--- a/lib/types/rules.d.ts
+++ b/lib/types/rules.d.ts
@@ -84,6 +84,18 @@ type ValidNoRestrictedImportPatternOptions =
 		EitherGroupOrRegEx &
 		EitherNameSpecifiers;
 
+interface CapitalizedCommentsCommonOptions {
+	ignorePattern?: string;
+	/**
+	 * @default false
+	 */
+	ignoreInlineComments?: boolean;
+	/**
+	 * @default false
+	 */
+	ignoreConsecutiveComments?: boolean;
+}
+
 //-----------------------------------------------------------------------------
 // Public types
 //-----------------------------------------------------------------------------
@@ -396,17 +408,13 @@ export interface ESLintRules extends Linter.RulesRecord {
 	"capitalized-comments": Linter.RuleEntry<
 		[
 			"always" | "never",
-			Partial<{
-				ignorePattern: string;
-				/**
-				 * @default false
-				 */
-				ignoreInlineComments: boolean;
-				/**
-				 * @default false
-				 */
-				ignoreConsecutiveComments: boolean;
-			}>,
+			(
+				| CapitalizedCommentsCommonOptions
+				| Partial<{
+						line: CapitalizedCommentsCommonOptions;
+						block: CapitalizedCommentsCommonOptions;
+				  }>
+			),
 		]
 	>;
 
@@ -1655,7 +1663,21 @@ export interface ESLintRules extends Linter.RulesRecord {
 	 * @since 5.0.0-alpha.3
 	 * @see https://eslint.org/docs/latest/rules/max-classes-per-file
 	 */
-	"max-classes-per-file": Linter.RuleEntry<[number]>;
+	"max-classes-per-file": Linter.RuleEntry<
+		[
+			| number
+			| Partial<{
+					/**
+					 * @default false
+					 */
+					ignoreExpressions: boolean;
+					/**
+					 * @default 1
+					 */
+					max: number;
+			  }>,
+		]
+	>;
 
 	/**
 	 * Rule to enforce a maximum depth that blocks can be nested.
@@ -1665,12 +1687,18 @@ export interface ESLintRules extends Linter.RulesRecord {
 	 */
 	"max-depth": Linter.RuleEntry<
 		[
-			Partial<{
-				/**
-				 * @default 4
-				 */
-				max: number;
-			}>,
+			| number
+			| Partial<{
+					/**
+					 * @deprecated
+					 * @default 4
+					 */
+					maximum: number;
+					/**
+					 * @default 4
+					 */
+					max: number;
+			  }>,
 		]
 	>;
 
@@ -1758,24 +1786,25 @@ export interface ESLintRules extends Linter.RulesRecord {
 	 */
 	"max-lines-per-function": Linter.RuleEntry<
 		[
-			Partial<{
-				/**
-				 * @default 50
-				 */
-				max: number;
-				/**
-				 * @default false
-				 */
-				skipBlankLines: boolean;
-				/**
-				 * @default false
-				 */
-				skipComments: boolean;
-				/**
-				 * @default false
-				 */
-				IIFEs: boolean;
-			}>,
+			| number
+			| Partial<{
+					/**
+					 * @default 50
+					 */
+					max: number;
+					/**
+					 * @default false
+					 */
+					skipBlankLines: boolean;
+					/**
+					 * @default false
+					 */
+					skipComments: boolean;
+					/**
+					 * @default false
+					 */
+					IIFEs: boolean;
+			  }>,
 		]
 	>;
 
@@ -1787,13 +1816,18 @@ export interface ESLintRules extends Linter.RulesRecord {
 	 */
 	"max-nested-callbacks": Linter.RuleEntry<
 		[
+			| number
 			| Partial<{
+					/**
+					 * @deprecated
+					 * @default 10
+					 */
+					maximum: number;
 					/**
 					 * @default 10
 					 */
 					max: number;
-			  }>
-			| number,
+			  }>,
 		]
 	>;
 
@@ -1805,7 +1839,13 @@ export interface ESLintRules extends Linter.RulesRecord {
 	 */
 	"max-params": Linter.RuleEntry<
 		[
+			| number
 			| Partial<{
+					/**
+					 * @deprecated
+					 * @default 3
+					 */
+					maximum: number;
 					/**
 					 * @default 3
 					 */
@@ -1814,8 +1854,7 @@ export interface ESLintRules extends Linter.RulesRecord {
 					 * @default false
 					 */
 					countVoidThis: boolean;
-			  }>
-			| number,
+			  }>,
 		]
 	>;
 
@@ -1827,17 +1866,26 @@ export interface ESLintRules extends Linter.RulesRecord {
 	 */
 	"max-statements": Linter.RuleEntry<
 		[
-			| Partial<{
-					/**
-					 * @default 10
-					 */
-					max: number;
-					/**
-					 * @default false
-					 */
-					ignoreTopLevelFunctions: boolean;
-			  }>
-			| number,
+			(
+				| number
+				| Partial<{
+						/**
+						 * @deprecated
+						 * @default 10
+						 */
+						maximum: number;
+						/**
+						 * @default 10
+						 */
+						max: number;
+				  }>
+			),
+			Partial<{
+				/**
+				 * @default false
+				 */
+				ignoreTopLevelFunctions: boolean;
+			}>,
 		]
 	>;
 
@@ -2014,7 +2062,24 @@ export interface ESLintRules extends Linter.RulesRecord {
 	"no-bitwise": Linter.RuleEntry<
 		[
 			Partial<{
-				allow: string[];
+				/**
+				 * @default []
+				 */
+				allow: Array<
+					| "^"
+					| "|"
+					| "&"
+					| "<<"
+					| ">>"
+					| ">>>"
+					| "^="
+					| "|="
+					| "&="
+					| "<<="
+					| ">>="
+					| ">>>="
+					| "~"
+				>;
 				/**
 				 * @default false
 				 */
@@ -2166,9 +2231,9 @@ export interface ESLintRules extends Linter.RulesRecord {
 		[
 			{
 				/**
-				 * @default true
+				 * @default "allExceptWhileTrue"
 				 */
-				checkLoops: boolean;
+				checkLoops: "all" | "allExceptWhileTrue" | "none" | boolean;
 			},
 		]
 	>;
@@ -2395,7 +2460,16 @@ export interface ESLintRules extends Linter.RulesRecord {
 	 * @since 1.7.0
 	 * @see https://eslint.org/docs/latest/rules/no-empty-pattern
 	 */
-	"no-empty-pattern": Linter.RuleEntry<[]>;
+	"no-empty-pattern": Linter.RuleEntry<
+		[
+			Partial<{
+				/**
+				 * @default false
+				 */
+				allowObjectPatternsAsParameters: boolean;
+			}>,
+		]
+	>;
 
 	/**
 	 * Rule to disallow empty static blocks.
@@ -2668,7 +2742,16 @@ export interface ESLintRules extends Linter.RulesRecord {
 	 * @since 2.0.0-alpha-1
 	 * @see https://eslint.org/docs/latest/rules/no-implicit-globals
 	 */
-	"no-implicit-globals": Linter.RuleEntry<[]>;
+	"no-implicit-globals": Linter.RuleEntry<
+		[
+			Partial<{
+				/**
+				 * @default false
+				 */
+				lexicalBindings: boolean;
+			}>,
+		]
+	>;
 
 	/**
 	 * Rule to disallow the use of `eval()`-like methods.
@@ -2695,7 +2778,13 @@ export interface ESLintRules extends Linter.RulesRecord {
 	 * @since 0.10.0
 	 * @see https://eslint.org/docs/latest/rules/no-inline-comments
 	 */
-	"no-inline-comments": Linter.RuleEntry<[]>;
+	"no-inline-comments": Linter.RuleEntry<
+		[
+			Partial<{
+				ignorePattern: string;
+			}>,
+		]
+	>;
 
 	/**
 	 * Rule to disallow variable or `function` declarations in nested blocks.
@@ -2703,7 +2792,17 @@ export interface ESLintRules extends Linter.RulesRecord {
 	 * @since 0.6.0
 	 * @see https://eslint.org/docs/latest/rules/no-inner-declarations
 	 */
-	"no-inner-declarations": Linter.RuleEntry<["functions" | "both"]>;
+	"no-inner-declarations": Linter.RuleEntry<
+		[
+			"functions" | "both",
+			Partial<{
+				/**
+				 * @default "allow"
+				 */
+				blockScopedFunctions: "allow" | "disallow";
+			}>,
+		]
+	>;
 
 	/**
 	 * Rule to disallow invalid regular expression strings in `RegExp` constructors.
@@ -2767,6 +2866,10 @@ export interface ESLintRules extends Linter.RulesRecord {
 				 * @default false
 				 */
 				skipTemplates: boolean;
+				/**
+				 * @default false
+				 */
+				skipJSXText: boolean;
 			}>,
 		]
 	>;
@@ -2855,11 +2958,19 @@ export interface ESLintRules extends Linter.RulesRecord {
 				/**
 				 * @default []
 				 */
-				ignore: number[];
+				ignore: Array<number | string>;
 				/**
 				 * @default false
 				 */
 				ignoreArrayIndexes: boolean;
+				/**
+				 * @default false
+				 */
+				ignoreDefaultValues: boolean;
+				/**
+				 * @default false
+				 */
+				ignoreClassFieldInitialValues: boolean;
 				/**
 				 * @default false
 				 */
@@ -2981,7 +3092,16 @@ export interface ESLintRules extends Linter.RulesRecord {
 	 * @since 3.14.0
 	 * @see https://eslint.org/docs/latest/rules/no-multi-assign
 	 */
-	"no-multi-assign": Linter.RuleEntry<[]>;
+	"no-multi-assign": Linter.RuleEntry<
+		[
+			Partial<{
+				/**
+				 * @default false
+				 */
+				ignoreNonDeclaration: boolean;
+			}>,
+		]
+	>;
 
 	/**
 	 * Rule to disallow multiple spaces.
@@ -3555,7 +3675,16 @@ export interface ESLintRules extends Linter.RulesRecord {
 	 * @since 2.0.0-rc.0
 	 * @see https://eslint.org/docs/latest/rules/no-self-assign
 	 */
-	"no-self-assign": Linter.RuleEntry<[]>;
+	"no-self-assign": Linter.RuleEntry<
+		[
+			Partial<{
+				/**
+				 * @default true
+				 */
+				props: boolean;
+			}>,
+		]
+	>;
 
 	/**
 	 * Rule to disallow comparisons where both sides are exactly the same.
@@ -3929,12 +4058,13 @@ export interface ESLintRules extends Linter.RulesRecord {
 				/**
 				 * @default []
 				 */
-				ignore:
+				ignore: Array<
 					| "WhileStatement"
 					| "DoWhileStatement"
 					| "ForStatement"
 					| "ForInStatement"
-					| "ForOfStatement";
+					| "ForOfStatement"
+				>;
 			}>,
 		]
 	>;
@@ -4293,7 +4423,7 @@ export interface ESLintRules extends Linter.RulesRecord {
 	 */
 	"no-warning-comments": Linter.RuleEntry<
 		[
-			{
+			Partial<{
 				/**
 				 * @default ["todo", "fixme", "xxx"]
 				 */
@@ -4302,7 +4432,8 @@ export interface ESLintRules extends Linter.RulesRecord {
 				 * @default 'start'
 				 */
 				location: "start" | "anywhere";
-			},
+				decoration: string[];
+			}>,
 		]
 	>;
 
@@ -5339,7 +5470,7 @@ export interface ESLintRules extends Linter.RulesRecord {
 				 */
 				enforceForSwitchCase: boolean;
 				/**
-				 * @default true
+				 * @default false
 				 */
 				enforceForIndexOf: boolean;
 			}>,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Aligned rule option typings in `rules.d.ts` with the actual rule schemas. This includes adding missing options, supporting `number | { ... }` forms for relevant max-* rules, and refining unions and defaults.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
