### PR TITLE
fix!: Remove deprecated rule context methods

### DIFF
--- a/lib/linter/file-context.js
+++ b/lib/linter/file-context.js
@@ -94,42 +94,6 @@ class FileContext {
 	}
 
 	/**
-	 * Gets the current working directory.
-	 * @returns {string} The current working directory.
-	 * @deprecated Use `cwd` instead.
-	 */
-	getCwd() {
-		return this.cwd;
-	}
-
-	/**
-	 * Gets the filename of the file being linted.
-	 * @returns {string} The filename of the file being linted.
-	 * @deprecated Use `filename` instead.
-	 */
-	getFilename() {
-		return this.filename;
-	}
-
-	/**
-	 * Gets the physical filename of the file being linted.
-	 * @returns {string} The physical filename of the file being linted.
-	 * @deprecated Use `physicalFilename` instead.
-	 */
-	getPhysicalFilename() {
-		return this.physicalFilename;
-	}
-
-	/**
-	 * Gets the source code of the file being linted.
-	 * @returns {SourceCode} The source code of the file being linted.
-	 * @deprecated Use `sourceCode` instead.
-	 */
-	getSourceCode() {
-		return this.sourceCode;
-	}
-
-	/**
 	 * Creates a new object with the current object as the prototype and
 	 * the specified properties as its own properties.
 	 * @param {Object} extension The properties to add to the new object.

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "eslint-plugin-expect-type": "^0.6.0",
     "eslint-plugin-yml": "^1.14.0",
     "eslint-release": "^3.3.0",
-    "eslint-rule-composer": "^0.3.0",
+    "eslint-rule-extender": "^0.0.1",
     "eslump": "^3.0.0",
     "esprima": "^4.0.1",
     "fast-glob": "^3.2.11",

--- a/tests/lib/linter/file-context.js
+++ b/tests/lib/linter/file-context.js
@@ -81,43 +81,6 @@ describe("FileContext", () => {
 		});
 	});
 
-	describe("deprecated methods", () => {
-		let context;
-
-		beforeEach(() => {
-			context = new FileContext(defaultConfig);
-		});
-
-		it("getCwd() should return the cwd property", () => {
-			assert.strictEqual(context.getCwd(), context.cwd);
-			assert.strictEqual(context.getCwd(), defaultConfig.cwd);
-		});
-
-		it("getFilename() should return the filename property", () => {
-			assert.strictEqual(context.getFilename(), context.filename);
-			assert.strictEqual(context.getFilename(), defaultConfig.filename);
-		});
-
-		it("getPhysicalFilename() should return the physicalFilename property", () => {
-			assert.strictEqual(
-				context.getPhysicalFilename(),
-				context.physicalFilename,
-			);
-			assert.strictEqual(
-				context.getPhysicalFilename(),
-				defaultConfig.physicalFilename,
-			);
-		});
-
-		it("getSourceCode() should return the sourceCode property", () => {
-			assert.strictEqual(context.getSourceCode(), context.sourceCode);
-			assert.strictEqual(
-				context.getSourceCode(),
-				defaultConfig.sourceCode,
-			);
-		});
-	});
-
 	describe("extend()", () => {
 		let context;
 

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -134,7 +134,6 @@ describe("Linter", () => {
 
 		it("has all the `parent` properties on nodes when the rule listeners are created", () => {
 			const spy = sinon.spy(context => {
-				assert.strictEqual(context.getSourceCode(), context.sourceCode);
 				const ast = context.sourceCode.ast;
 
 				assert.strictEqual(ast.body[0].parent, ast);
@@ -1353,10 +1352,6 @@ describe("Linter", () => {
 			linter.defineRule(code, {
 				create: context => ({
 					Literal(node) {
-						assert.strictEqual(
-							context.getFilename(),
-							context.filename,
-						);
 						context.report(node, context.filename);
 					},
 				}),
@@ -1377,10 +1372,6 @@ describe("Linter", () => {
 			linter.defineRule(code, {
 				create: context => ({
 					Literal(node) {
-						assert.strictEqual(
-							context.getPhysicalFilename(),
-							context.physicalFilename,
-						);
 						context.report(node, context.physicalFilename);
 					},
 				}),
@@ -1401,10 +1392,6 @@ describe("Linter", () => {
 			linter.defineRule(code, {
 				create: context => ({
 					Literal(node) {
-						assert.strictEqual(
-							context.getFilename(),
-							context.filename,
-						);
 						context.report(node, context.filename);
 					},
 				}),
@@ -4083,10 +4070,6 @@ var a = "test2";
 							const sourceCode = context.sourceCode;
 							const comments = sourceCode.getAllComments();
 
-							assert.strictEqual(
-								context.getSourceCode(),
-								sourceCode,
-							);
 							assert.strictEqual(1, comments.length);
 
 							const foo = getVariable(scope, "foo");
@@ -4264,7 +4247,6 @@ var a = "test2";
 			linterWithOption.defineRule("checker", {
 				create(context) {
 					spy = sinon.spy(() => {
-						assert.strictEqual(context.getCwd(), context.cwd);
 						assert.strictEqual(context.cwd, cwd);
 					});
 					return { Program: spy };
@@ -4282,7 +4264,6 @@ var a = "test2";
 			linterWithOption.defineRule("checker", {
 				create(context) {
 					spy = sinon.spy(() => {
-						assert.strictEqual(context.getCwd(), context.cwd);
 						assert.strictEqual(context.cwd, process.cwd());
 					});
 					return { Program: spy };
@@ -4299,7 +4280,6 @@ var a = "test2";
 			linter.defineRule("checker", {
 				create(context) {
 					spy = sinon.spy(() => {
-						assert.strictEqual(context.getCwd(), context.cwd);
 						assert.strictEqual(context.cwd, process.cwd());
 					});
 					return { Program: spy };
@@ -6002,10 +5982,6 @@ var a = "test2";
 		describe("physicalFilenames", () => {
 			it("should be same as `filename` passed on options object, if no processors are used", () => {
 				const physicalFilenameChecker = sinon.spy(context => {
-					assert.strictEqual(
-						context.getPhysicalFilename(),
-						context.physicalFilename,
-					);
 					assert.strictEqual(context.physicalFilename, "foo.js");
 					return {};
 				});
@@ -6023,10 +5999,6 @@ var a = "test2";
 
 			it("should default physicalFilename to <input> when options object doesn't have filename", () => {
 				const physicalFilenameChecker = sinon.spy(context => {
-					assert.strictEqual(
-						context.getPhysicalFilename(),
-						context.physicalFilename,
-					);
 					assert.strictEqual(context.physicalFilename, "<input>");
 					return {};
 				});
@@ -6040,10 +6012,6 @@ var a = "test2";
 
 			it("should default physicalFilename to <input> when only two arguments are passed", () => {
 				const physicalFilenameChecker = sinon.spy(context => {
-					assert.strictEqual(
-						context.getPhysicalFilename(),
-						context.physicalFilename,
-					);
 					assert.strictEqual(context.physicalFilename, "<input>");
 					return {};
 				});
@@ -6726,10 +6694,6 @@ var a = "test2";
 							const sourceCode = context.sourceCode;
 							const comments = sourceCode.getAllComments();
 
-							assert.strictEqual(
-								context.getSourceCode(),
-								sourceCode,
-							);
 							assert.strictEqual(2, comments.length);
 
 							const foo = getVariable(scope, "foo");
@@ -7906,15 +7870,6 @@ var a = "test2";
 			linter.defineRule("report-original-text", {
 				create: context => ({
 					Program(ast) {
-						assert.strictEqual(
-							context.getFilename(),
-							context.filename,
-						);
-						assert.strictEqual(
-							context.getPhysicalFilename(),
-							context.physicalFilename,
-						);
-
 						receivedFilenames.push(context.filename);
 						receivedPhysicalFilenames.push(
 							context.physicalFilename,
@@ -11002,10 +10957,6 @@ describe("Linter with FlatConfigArray", () => {
 
 			it("should have all the `parent` properties on nodes when the rule visitors are created", () => {
 				const spy = sinon.spy(context => {
-					assert.strictEqual(
-						context.getSourceCode(),
-						context.sourceCode,
-					);
 					const ast = context.sourceCode.ast;
 
 					assert.strictEqual(ast.body[0].parent, ast);
@@ -11232,70 +11183,6 @@ describe("Linter with FlatConfigArray", () => {
 		});
 
 		describe("Rule Context", () => {
-			describe("context.getFilename()", () => {
-				const ruleId = "filename-rule";
-
-				it("has access to the filename", () => {
-					const config = {
-						plugins: {
-							test: {
-								rules: {
-									[ruleId]: {
-										create: context => ({
-											Literal(node) {
-												context.report(
-													node,
-													context.getFilename(),
-												);
-											},
-										}),
-									},
-								},
-							},
-						},
-						rules: {
-							[`test/${ruleId}`]: 1,
-						},
-					};
-
-					const messages = linter.verify("0", config, filename);
-					const suppressedMessages = linter.getSuppressedMessages();
-
-					assert.strictEqual(messages[0].message, filename);
-					assert.strictEqual(suppressedMessages.length, 0);
-				});
-
-				it("defaults filename to '<input>'", () => {
-					const config = {
-						plugins: {
-							test: {
-								rules: {
-									[ruleId]: {
-										create: context => ({
-											Literal(node) {
-												context.report(
-													node,
-													context.getFilename(),
-												);
-											},
-										}),
-									},
-								},
-							},
-						},
-						rules: {
-							[`test/${ruleId}`]: 1,
-						},
-					};
-
-					const messages = linter.verify("0", config);
-					const suppressedMessages = linter.getSuppressedMessages();
-
-					assert.strictEqual(messages[0].message, "<input>");
-					assert.strictEqual(suppressedMessages.length, 0);
-				});
-			});
-
 			describe("context.filename", () => {
 				const ruleId = "filename-rule";
 
@@ -11307,10 +11194,6 @@ describe("Linter with FlatConfigArray", () => {
 									[ruleId]: {
 										create: context => ({
 											Literal(node) {
-												assert.strictEqual(
-													context.getFilename(),
-													context.filename,
-												);
 												context.report(
 													node,
 													context.filename,
@@ -11341,10 +11224,6 @@ describe("Linter with FlatConfigArray", () => {
 									[ruleId]: {
 										create: context => ({
 											Literal(node) {
-												assert.strictEqual(
-													context.getFilename(),
-													context.filename,
-												);
 												context.report(
 													node,
 													context.filename,
@@ -11364,40 +11243,6 @@ describe("Linter with FlatConfigArray", () => {
 					const suppressedMessages = linter.getSuppressedMessages();
 
 					assert.strictEqual(messages[0].message, "<input>");
-					assert.strictEqual(suppressedMessages.length, 0);
-				});
-			});
-
-			describe("context.getPhysicalFilename()", () => {
-				const ruleId = "filename-rule";
-
-				it("has access to the physicalFilename", () => {
-					const config = {
-						plugins: {
-							test: {
-								rules: {
-									[ruleId]: {
-										create: context => ({
-											Literal(node) {
-												context.report(
-													node,
-													context.getPhysicalFilename(),
-												);
-											},
-										}),
-									},
-								},
-							},
-						},
-						rules: {
-							[`test/${ruleId}`]: 1,
-						},
-					};
-
-					const messages = linter.verify("0", config, filename);
-					const suppressedMessages = linter.getSuppressedMessages();
-
-					assert.strictEqual(messages[0].message, filename);
 					assert.strictEqual(suppressedMessages.length, 0);
 				});
 			});
@@ -11413,10 +11258,6 @@ describe("Linter with FlatConfigArray", () => {
 									[ruleId]: {
 										create: context => ({
 											Literal(node) {
-												assert.strictEqual(
-													context.getPhysicalFilename(),
-													context.physicalFilename,
-												);
 												context.report(
 													node,
 													context.physicalFilename,
@@ -11437,98 +11278,6 @@ describe("Linter with FlatConfigArray", () => {
 
 					assert.strictEqual(messages[0].message, filename);
 					assert.strictEqual(suppressedMessages.length, 0);
-				});
-			});
-
-			describe("context.getCwd()", () => {
-				const code = "a;\nb;";
-				const baseConfig = { rules: { "test/checker": "error" } };
-
-				it("should get cwd correctly in the context", () => {
-					const cwd = "/cwd";
-					const linterWithOption = new Linter({
-						cwd,
-						configType: "flat",
-					});
-					let spy;
-					const config = {
-						plugins: {
-							test: {
-								rules: {
-									checker: {
-										create(context) {
-											spy = sinon.spy(() => {
-												assert.strictEqual(
-													context.getCwd(),
-													cwd,
-												);
-											});
-											return { Program: spy };
-										},
-									},
-								},
-							},
-						},
-						...baseConfig,
-					};
-
-					linterWithOption.verify(code, config, `${cwd}/file.js`);
-					assert(spy && spy.calledOnce);
-				});
-
-				it("should assign process.cwd() to it if cwd is undefined", () => {
-					const linterWithOption = new Linter({ configType: "flat" });
-					let spy;
-					const config = {
-						plugins: {
-							test: {
-								rules: {
-									checker: {
-										create(context) {
-											spy = sinon.spy(() => {
-												assert.strictEqual(
-													context.getCwd(),
-													process.cwd(),
-												);
-											});
-											return { Program: spy };
-										},
-									},
-								},
-							},
-						},
-						...baseConfig,
-					};
-
-					linterWithOption.verify(code, config);
-					assert(spy && spy.calledOnce);
-				});
-
-				it("should assign process.cwd() to it if the option is undefined", () => {
-					let spy;
-					const config = {
-						plugins: {
-							test: {
-								rules: {
-									checker: {
-										create(context) {
-											spy = sinon.spy(() => {
-												assert.strictEqual(
-													context.getCwd(),
-													process.cwd(),
-												);
-											});
-											return { Program: spy };
-										},
-									},
-								},
-							},
-						},
-						...baseConfig,
-					};
-
-					linter.verify(code, config);
-					assert(spy && spy.calledOnce);
 				});
 			});
 
@@ -11579,10 +11328,6 @@ describe("Linter with FlatConfigArray", () => {
 										create(context) {
 											spy = sinon.spy(() => {
 												assert.strictEqual(
-													context.getCwd(),
-													context.cwd,
-												);
-												assert.strictEqual(
 													context.cwd,
 													process.cwd(),
 												);
@@ -11609,10 +11354,6 @@ describe("Linter with FlatConfigArray", () => {
 									checker: {
 										create(context) {
 											spy = sinon.spy(() => {
-												assert.strictEqual(
-													context.getCwd(),
-													context.cwd,
-												);
 												assert.strictEqual(
 													context.cwd,
 													process.cwd(),
@@ -11845,10 +11586,6 @@ describe("Linter with FlatConfigArray", () => {
 			describe("physicalFilename", () => {
 				it("should be same as `filename` passed on options object, if no processors are used", () => {
 					const physicalFilenameChecker = sinon.spy(context => {
-						assert.strictEqual(
-							context.getPhysicalFilename(),
-							context.physicalFilename,
-						);
 						assert.strictEqual(context.physicalFilename, "foo.js");
 						return {};
 					});
@@ -11874,10 +11611,6 @@ describe("Linter with FlatConfigArray", () => {
 
 				it("should default physicalFilename to <input> when options object doesn't have filename", () => {
 					const physicalFilenameChecker = sinon.spy(context => {
-						assert.strictEqual(
-							context.getPhysicalFilename(),
-							context.physicalFilename,
-						);
 						assert.strictEqual(context.physicalFilename, "<input>");
 						return {};
 					});
@@ -11903,10 +11636,6 @@ describe("Linter with FlatConfigArray", () => {
 
 				it("should default physicalFilename to <input> when only two arguments are passed", () => {
 					const physicalFilenameChecker = sinon.spy(context => {
-						assert.strictEqual(
-							context.getPhysicalFilename(),
-							context.physicalFilename,
-						);
 						assert.strictEqual(context.physicalFilename, "<input>");
 						return {};
 					});
@@ -12474,10 +12203,6 @@ describe("Linter with FlatConfigArray", () => {
 												const comments =
 													sourceCode.getAllComments();
 
-												assert.strictEqual(
-													context.getSourceCode(),
-													sourceCode,
-												);
 												assert.strictEqual(
 													2,
 													comments.length,
@@ -16266,10 +15991,6 @@ var a = "test2";
 														sourceCode.getAllComments();
 
 													assert.strictEqual(
-														context.getSourceCode(),
-														sourceCode,
-													);
-													assert.strictEqual(
 														1,
 														comments.length,
 													);
@@ -19255,15 +18976,6 @@ var a = "test2";
 							create(context) {
 								return {
 									Program(ast) {
-										assert.strictEqual(
-											context.getFilename(),
-											context.filename,
-										);
-										assert.strictEqual(
-											context.getPhysicalFilename(),
-											context.physicalFilename,
-										);
-
 										receivedFilenames.push(
 											context.filename,
 										);

--- a/tests/lib/types/types.test.ts
+++ b/tests/lib/types/types.test.ts
@@ -626,16 +626,8 @@ rule = {
 rule = {
 	create(context: Rule.RuleContext) {
 		context.filename;
-
-		context.getFilename();
-
 		context.physicalFilename;
-
-		context.getPhysicalFilename();
-
 		context.cwd;
-
-		context.getCwd();
 
 		context.languageOptions;
 		context.languageOptions
@@ -645,9 +637,6 @@ rule = {
 
 		context.sourceCode;
 		context.sourceCode.getLocFromIndex(42);
-
-		context.getSourceCode();
-		context.getSourceCode().getLocFromIndex(42);
 
 		if (typeof context.parserPath === "string") {
 			context.parserPath;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Removed the deprecated methods from the `context` object:

- `getCwd()`
- `getFilename()`
- `getPhysicalFilename()`
- `getSourceCode()`

I also removed the associated tests.

I also had to update the internal rule `no-multiline-comment` because it was using `eslint-rule-composer`, which relies on the removed methods. I switched to `eslint-rule-extender`, which does not rely on those methods.

#### Is there anything you'd like reviewers to focus on?



<!-- markdownlint-disable-file MD004 -->
