### PR TITLE
chore: disallow use of deprecated `type` property in core rule tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -163,11 +163,21 @@ module.exports = defineConfig([
 			],
 			"eslint-plugin/test-case-shorthand-strings": "error",
 			"no-useless-concat": "off",
+			"no-restricted-syntax": [
+				"error",
+				{
+					selector:
+						"ObjectExpression > Property[key.name='errors'] > ArrayExpression.value > ObjectExpression > Property[key.name='type']",
+					message:
+						"Do not use deprecated 'type' property in rule tests.",
+				},
+			],
 		},
 	},
 	{
 		name: "eslint/tests",
 		files: ["tests/**/*.js"],
+		ignores: ["tests/lib/rules/*.js", "tests/tools/internal-rules/*.js"],
 		languageOptions: {
 			globals: {
 				...globals.mocha,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Updates eslint config for this project to disallow use of deprecated `type` property in core rule tests.

Refs https://github.com/eslint/eslint/issues/19029, https://github.com/eslint/eslint/pull/20093.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Configured `no-restricted-syntax` to disallow the mentioned use of deprecated `type` property.

#### Is there anything you'd like reviewers to focus on?

This won't be able to catch all possible ways to pass `type` to RuleTester, but it should be good enough to catch the most common ones until we implement https://github.com/eslint/eslint/issues/19029.

<!-- markdownlint-disable-file MD004 -->
