### PR TITLE
feat: correct `preserve-caught-error` edge cases

### DIFF
--- a/lib/rules/preserve-caught-error.js
+++ b/lib/rules/preserve-caught-error.js
@@ -26,9 +26,6 @@ const astUtils = require("./utils/ast-utils");
  */
 const UNKNOWN_CAUSE = Symbol("unknown_cause");
 
-// This is an indicator of multiple `cause` properties found in error options.
-const MULTIPLE_CAUSE = Symbol("multiple_cause");
-
 const BUILT_IN_ERROR_TYPES = new Set([
 	"Error",
 	"EvalError",
@@ -41,9 +38,11 @@ const BUILT_IN_ERROR_TYPES = new Set([
 ]);
 
 /**
- * Finds and returns the ASTNode that is used as the `cause` of the Error being thrown
+ * Finds and returns information about the `cause` property of an error being thrown.
  * @param {ASTNode} throwStatement `ThrowStatement` to be checked.
- * @returns {ASTNode | UNKNOWN_CAUSE | MULTIPLE_CAUSE | null} The `cause` of the `Error` being thrown, `null` if not set.
+ * @returns {{ value: ASTNode; multipleDefinitions: boolean; } | UNKNOWN_CAUSE | null}
+ * Information about the `cause` of the error being thrown, such as the value node and
+ * whether there are multiple definitions of `cause`. `null` if there is no `cause`.
  */
 function getErrorCause(throwStatement) {
 	const throwExpression = throwStatement.argument;
@@ -90,16 +89,13 @@ function getErrorCause(throwStatement) {
 					!prop.computed, // It is hard to accurately identify the value of computed props
 			);
 
-			switch (causeProperties.length) {
-				case 0:
-					return null; // No cause property found
-				case 1:
-					// Single cause property found
-					return causeProperties[0].value;
-				default:
-					// Multiple cause properties found
-					return MULTIPLE_CAUSE;
-			}
+			const causeProperty = causeProperties.at(-1);
+			return causeProperty
+				? {
+						value: causeProperty.value,
+						multipleDefinitions: causeProperties.length > 1,
+					}
+				: null;
 		}
 
 		// Error options exist, but too complicated to be analyzed/fixed
@@ -308,24 +304,14 @@ module.exports = {
 					}
 
 					// Check if there is a cause attached to the new error
-					const thrownErrorCause = getErrorCause(throwStatement);
+					const errorCauseInfo = getErrorCause(throwStatement);
 
-					if (thrownErrorCause === UNKNOWN_CAUSE) {
+					if (errorCauseInfo === UNKNOWN_CAUSE) {
 						// Error options exist, but too complicated to be analyzed/fixed
 						return;
 					}
 
-					if (thrownErrorCause === MULTIPLE_CAUSE) {
-						// Multiple cause properties found, no reliable suggestion can be made
-
-						context.report({
-							messageId: "incorrectCause",
-							node: throwStatement,
-						});
-						return;
-					}
-
-					if (thrownErrorCause === null) {
+					if (errorCauseInfo === null) {
 						// If there is no `cause` attached to the error being thrown.
 						context.report({
 							messageId: "missingCause",
@@ -467,6 +453,8 @@ module.exports = {
 						return;
 					}
 
+					const { value: thrownErrorCause } = errorCauseInfo;
+
 					// If there is an attached cause, verify that it matches the caught error
 					if (
 						!(
@@ -474,38 +462,43 @@ module.exports = {
 							thrownErrorCause.name === caughtError.name
 						)
 					) {
+						const suggest = errorCauseInfo.multipleDefinitions
+							? null // If there are multiple `cause` definitions, a suggestion could be confusing.
+							: [
+									{
+										messageId: "includeCause",
+										fix(fixer) {
+											/*
+											 * In case `cause` is attached using object property shorthand or as a method or accessor.
+											 * e.g. throw Error("fail", { cause });
+											 *      throw Error("fail", { cause() { doSomething(); } });
+											 *      throw Error("fail", { get cause() { return error; } });
+											 */
+											if (
+												thrownErrorCause.parent
+													.method ||
+												thrownErrorCause.parent
+													.shorthand ||
+												thrownErrorCause.parent.kind !==
+													"init"
+											) {
+												return fixer.replaceText(
+													thrownErrorCause.parent,
+													`cause: ${caughtError.name}`,
+												);
+											}
+
+											return fixer.replaceText(
+												thrownErrorCause,
+												caughtError.name,
+											);
+										},
+									},
+								];
 						context.report({
 							messageId: "incorrectCause",
 							node: thrownErrorCause,
-							suggest: [
-								{
-									messageId: "includeCause",
-									fix(fixer) {
-										/*
-										 * In case `cause` is attached using object property shorthand or as a method or accessor.
-										 * e.g. throw Error("fail", { cause });
-										 *      throw Error("fail", { cause() { doSomething(); } });
-										 *      throw Error("fail", { get cause() { return error; } });
-										 */
-										if (
-											thrownErrorCause.parent.method ||
-											thrownErrorCause.parent.shorthand ||
-											thrownErrorCause.parent.kind !==
-												"init"
-										) {
-											return fixer.replaceText(
-												thrownErrorCause.parent,
-												`cause: ${caughtError.name}`,
-											);
-										}
-
-										return fixer.replaceText(
-											thrownErrorCause,
-											caughtError.name,
-										);
-									},
-								},
-							],
+							suggest,
 						});
 						return;
 					}

--- a/lib/rules/preserve-caught-error.js
+++ b/lib/rules/preserve-caught-error.js
@@ -10,15 +10,24 @@
 
 const astUtils = require("./utils/ast-utils");
 
-//----------------------------------------------------------------------
+//------------------------------------------------------------------------------
+// Types
+//------------------------------------------------------------------------------
+
+/** @typedef {import("estree").Node} ASTNode */
+
+//------------------------------------------------------------------------------
 // Helpers
-//----------------------------------------------------------------------
+//------------------------------------------------------------------------------
 
 /*
  * This is an indicator of an error cause node, that is too complicated to be detected and fixed.
  * Eg, when error options is an `Identifier` or a `SpreadElement`.
  */
 const UNKNOWN_CAUSE = Symbol("unknown_cause");
+
+// This is an indicator of multiple `cause` properties found in error options.
+const MULTIPLE_CAUSE = Symbol("multiple_cause");
 
 const BUILT_IN_ERROR_TYPES = new Set([
 	"Error",
@@ -34,7 +43,7 @@ const BUILT_IN_ERROR_TYPES = new Set([
 /**
  * Finds and returns the ASTNode that is used as the `cause` of the Error being thrown
  * @param {ASTNode} throwStatement `ThrowStatement` to be checked.
- * @returns {ASTNode | UNKNOWN_CAUSE | null} The `cause` of `Error` being thrown, `null` if not set.
+ * @returns {ASTNode | UNKNOWN_CAUSE | MULTIPLE_CAUSE | null} The `cause` of the `Error` being thrown, `null` if not set.
  */
 function getErrorCause(throwStatement) {
 	const throwExpression = throwStatement.argument;
@@ -73,7 +82,7 @@ function getErrorCause(throwStatement) {
 				return UNKNOWN_CAUSE;
 			}
 
-			const causeProperty = errorOptions.properties.find(
+			const causeProperties = errorOptions.properties.filter(
 				prop =>
 					prop.type === "Property" &&
 					prop.key.type === "Identifier" &&
@@ -81,7 +90,16 @@ function getErrorCause(throwStatement) {
 					!prop.computed, // It is hard to accurately identify the value of computed props
 			);
 
-			return causeProperty ? causeProperty.value : null;
+			switch (causeProperties.length) {
+				case 0:
+					return null; // No cause property found
+				case 1:
+					// Single cause property found
+					return causeProperties[0].value;
+				default:
+					// Multiple cause properties found
+					return MULTIPLE_CAUSE;
+			}
 		}
 
 		// Error options exist, but too complicated to be analyzed/fixed
@@ -297,6 +315,16 @@ module.exports = {
 						return;
 					}
 
+					if (thrownErrorCause === MULTIPLE_CAUSE) {
+						// Multiple cause properties found, no reliable suggestion can be made
+
+						context.report({
+							messageId: "incorrectCause",
+							node: throwStatement,
+						});
+						return;
+					}
+
 					if (thrownErrorCause === null) {
 						// If there is no `cause` attached to the error being thrown.
 						context.report({
@@ -439,7 +467,7 @@ module.exports = {
 						return;
 					}
 
-					// If there is an attached cause, verify that is matches the caught error
+					// If there is an attached cause, verify that it matches the caught error
 					if (
 						!(
 							thrownErrorCause.type === "Identifier" &&
@@ -454,13 +482,16 @@ module.exports = {
 									messageId: "includeCause",
 									fix(fixer) {
 										/*
-										 * In case `cause` is attached using object property shorthand or as a method.
+										 * In case `cause` is attached using object property shorthand or as a method or accessor.
 										 * e.g. throw Error("fail", { cause });
-										 *      throw Error("fail", { cause() { // do something } });
+										 *      throw Error("fail", { cause() { doSomething(); } });
+										 *      throw Error("fail", { get cause() { return error; } });
 										 */
 										if (
 											thrownErrorCause.parent.method ||
-											thrownErrorCause.parent.shorthand
+											thrownErrorCause.parent.shorthand ||
+											thrownErrorCause.parent.kind !==
+												"init"
 										) {
 											return fixer.replaceText(
 												thrownErrorCause.parent,

--- a/tests/lib/rules/preserve-caught-error.js
+++ b/tests/lib/rules/preserve-caught-error.js
@@ -722,5 +722,58 @@ ruleTester.run("preserve-caught-error", rule, {
 				},
 			],
 		},
+		/* 25. When multiple `cause` properties are present. */
+		{
+			code: `try {} catch (error) {
+				throw new Error("Something failed", { cause: error, cause: anotherError });
+			}`,
+			errors: [{ messageId: "incorrectCause" }],
+		},
+		/* 26. Getters and setters as `cause`. */
+		{
+			code: `try {} catch (error) {
+				throw new Error("Something failed", { get cause() { } });
+			}`,
+			errors: [
+				{
+					messageId: "incorrectCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `try {} catch (error) {
+				throw new Error("Something failed", { cause: error });
+			}`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `try {} catch (error) {
+				throw new Error("Something failed", { set cause(value) { } });
+			}`,
+			errors: [
+				{
+					messageId: "incorrectCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `try {} catch (error) {
+				throw new Error("Something failed", { cause: error });
+			}`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `try {} catch (error) {
+				throw new Error("Something failed", {
+					get cause() { return error; },
+					set cause(value) { error = value; },
+				});
+			}`,
+			errors: [{ messageId: "incorrectCause" }],
+		},
 	],
 });

--- a/tests/lib/rules/preserve-caught-error.js
+++ b/tests/lib/rules/preserve-caught-error.js
@@ -86,6 +86,12 @@ ruleTester.run("preserve-caught-error", rule, {
 	}`,
 			options: [{ requireCatchParameter: false }],
 		},
+		/* Multiple cause properties are present and the last one is the expected caught error value. */
+		`try {
+			doSomething();
+		} catch (error) {
+			throw new Error("Something failed", { cause: anotherError, cause: error });
+		}`,
 	],
 	invalid: [
 		/* 1. Throws a new Error without cause, even though an error was caught */


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

Node version: v22.19.0
npm version: v10.9.3
Local ESLint version: v9.35.0 (Currently used)
Global ESLint version: v9.35.0
Operating System: darwin 24.6.0

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

inline config only

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint preserve-caught-error: "error" */

try {
  trySomething();
} catch (error) {
  throw new Error("Something's broken", {
    get cause() {
      return error;
    },
  });
}
```

[**Playground link**](https://eslint.org/play/#eyJ0ZXh0IjoiLyogZXNsaW50IHByZXNlcnZlLWNhdWdodC1lcnJvcjogXCJlcnJvclwiICovXG5cbnRyeSB7XG4gIHRyeVNvbWV0aGluZygpO1xufSBjYXRjaCAoZXJyb3IpIHtcbiAgdGhyb3cgbmV3IEVycm9yKFwiU29tZXRoaW5nJ3MgYnJva2VuXCIsIHtcbiAgICBnZXQgY2F1c2UoKSB7XG4gICAgICByZXR1cm4gZXJyb3I7XG4gICAgfSxcbiAgfSk7XG59Iiwib3B0aW9ucyI6eyJydWxlcyI6e30sImxhbmd1YWdlT3B0aW9ucyI6eyJzb3VyY2VUeXBlIjoic2NyaXB0IiwicGFyc2VyT3B0aW9ucyI6eyJlY21hRmVhdHVyZXMiOnt9fX19fQ==)

```js
/* eslint preserve-caught-error: "error" */

try {
  trySomething();
} catch (error) {
  throw new Error("Something's broken", {
    cause: error,
    cause: bar,
  });
}
```

[**Playground link**](https://eslint.org/play/#eyJ0ZXh0IjoiLyogZXNsaW50IHByZXNlcnZlLWNhdWdodC1lcnJvcjogXCJlcnJvclwiICovXG5cbnRyeSB7XG4gIHRyeVNvbWV0aGluZygpO1xufSBjYXRjaCAoZXJyb3IpIHtcbiAgdGhyb3cgbmV3IEVycm9yKFwiU29tZXRoaW5nJ3MgYnJva2VuXCIsIHtcbiAgICBjYXVzZTogZXJyb3IsXG4gICAgY2F1c2U6IGJhcixcbiAgfSk7XG59Iiwib3B0aW9ucyI6eyJydWxlcyI6e30sImxhbmd1YWdlT3B0aW9ucyI6eyJzb3VyY2VUeXBlIjoic2NyaXB0IiwicGFyc2VyT3B0aW9ucyI6eyJlY21hRmVhdHVyZXMiOnt9fX19fQ==)

**What did you expect to happen?**

In the first example with the getter, the suggestion should produce valid code but it doesn't.

In the second example, the rule should report an error because the cause value will be `bar`.

**What actually happened? Please include the actual, raw output from ESLint.**

In the first example, the suggested fix is producing invalid JavaScript.

In the second example, no error is being reported.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This pull request ensures that if there are multiple `cause` definitions, only the last one is checked and no suggestions are provided. The suggestion for getters and setters has been fixed.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
