### PR TITLE
fix: update `eslint-all.js` to use `Object.freeze` for rules object

### DIFF
--- a/packages/js/src/configs/eslint-all.js
+++ b/packages/js/src/configs/eslint-all.js
@@ -13,7 +13,7 @@
  */
 
 module.exports = Object.freeze({
-    "rules": {
+    rules: Object.freeze({
         "accessor-pairs": "error",
         "array-callback-return": "error",
         "arrow-body-style": "error",
@@ -213,5 +213,5 @@ module.exports = Object.freeze({
         "valid-typeof": "error",
         "vars-on-top": "error",
         "yoda": "error"
-    }
+    })
 });

--- a/tools/update-eslint-all.js
+++ b/tools/update-eslint-all.js
@@ -42,7 +42,9 @@ const code = `/*
  * cause an error.
  */
 
-module.exports = Object.freeze(${JSON.stringify({ rules: allRules }, null, 4)});
+module.exports = Object.freeze({
+    rules: Object.freeze(${JSON.stringify(allRules, null, 4).replaceAll("\n", "\n    ")})
+});
 `;
 
 fs.writeFileSync("./packages/js/src/configs/eslint-all.js", code, "utf8");


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

In this PR, I've updated `eslint-all.js` to use `Object.freeze` for the rules object.

I noticed it was odd that the `all` configuration didn't use `Object.freeze`, especially since the `recommended` configuration does, and the TypeScript type signature indicates that the rules object is readonly.

https://github.com/eslint/eslint/blob/1ace67d9f7903adc3d3f09868aa05b673e7d3f3b/packages/js/src/configs/eslint-recommended.js#L19-L22

https://github.com/eslint/eslint/blob/1ace67d9f7903adc3d3f09868aa05b673e7d3f3b/packages/js/types/index.d.ts#L10

So, to keep things consistent across the rule configurations and with the type signature, I've updated `eslint-all.js` to use `Object.freeze` for the rules object.

#### Is there anything you'd like reviewers to focus on?

I'm not sure if this should be considered a breaking change. If anyone has another opinion, I'm happy to follow your suggestion.

<!-- markdownlint-disable-file MD004 -->
