### PR TITLE
refactor: use `defaultOptions` in rules

### DIFF
--- a/lib/rules/no-misleading-character-class.js
+++ b/lib/rules/no-misleading-character-class.js
@@ -278,6 +278,12 @@ module.exports = {
 	meta: {
 		type: "problem",
 
+		defaultOptions: [
+			{
+				allowEscape: false,
+			},
+		],
+
 		docs: {
 			description:
 				"Disallow characters which are made with multiple code points in character class syntax",
@@ -293,7 +299,6 @@ module.exports = {
 				properties: {
 					allowEscape: {
 						type: "boolean",
-						default: false,
 					},
 				},
 				additionalProperties: false,
@@ -313,7 +318,7 @@ module.exports = {
 		},
 	},
 	create(context) {
-		const allowEscape = context.options[0]?.allowEscape;
+		const [{ allowEscape }] = context.options;
 		const sourceCode = context.sourceCode;
 		const parser = new RegExpParser();
 		const checkedPatternNodes = new Set();

--- a/lib/rules/require-unicode-regexp.js
+++ b/lib/rules/require-unicode-regexp.js
@@ -47,6 +47,8 @@ module.exports = {
 	meta: {
 		type: "suggestion",
 
+		defaultOptions: [{}],
+
 		docs: {
 			description:
 				"Enforce the use of `u` or `v` flag on regular expressions",
@@ -79,7 +81,7 @@ module.exports = {
 	create(context) {
 		const sourceCode = context.sourceCode;
 
-		const { requireFlag } = context.options[0] ?? {};
+		const [{ requireFlag }] = context.options;
 
 		return {
 			"Literal[regex]"(node) {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR refactors `no-misleading-character-class` and `require-unicode-regexp` to use `defaultOptions` instead of runtime fallbacks.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
