### PR TITLE
fix: Fixes fatal typeerror for bun runtime when using the "--concurrency" flag.

### DIFF
--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -317,6 +317,25 @@ const disableCloneabilityCheck = Symbol(
 );
 
 /**
+ * Simple check to see if the runtime is Bun.
+ * @returns {boolean} True if the runtime is Bun, false otherwise.
+ */
+function isBunRuntime() {
+	/* eslint-disable no-undef -- Disable undef for Bun is a global in Bun runtime, safe as it's wrapped in try/catch */
+	try {
+		return (
+			typeof Bun !== "undefined" &&
+			typeof Bun.spawn === "function" &&
+			typeof Bun.write === "function" &&
+			typeof Bun.file === "function"
+		);
+	} catch {
+		return false;
+	}
+	/* eslint-enable no-undef -- re-enable no-undef */
+}
+
+/**
  * The smallest net linting ratio that doesn't trigger a poor concurrency warning.
  * The net linting ratio is defined as the net linting duration divided by the thread's total runtime,
  * where the net linting duration is the total linting time minus the time spent on I/O-intensive operations:
@@ -352,13 +371,16 @@ async function runWorkers(
 	const abortController = new AbortController();
 	const abortSignal = abortController.signal;
 	const workerOptions = {
-		env: SHARE_ENV,
+		//env: SHARE_ENV,
 		workerData: {
 			eslintOptionsOrURL,
 			filePathIndexArray,
 			filePaths,
 		},
 	};
+	if (!isBunRuntime()) {
+		workerOptions.env = SHARE_ENV;
+	}
 
 	const hrtimeBigint = process.hrtime.bigint;
 	let worstNetLintingRatio = 1;


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:**: 24.x.x
- **npm version:**: irrelevant
- **Local ESLint version:**: v9.35.0
- **Global ESLint version:**: v9.35.0
- **Operating System:**: Ubuntu 25.04

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**What did you do? Please include the actual source code causing the issue.**

Adjusted the  passed `workeroptions` to omitt the SHARE_ENV option, which is not present in Buns implementation.
Previously the incorrect code that caused the issue was:
```js
//file: lib/eslint/eslint.js
	const workerOptions = {
		env: SHARE_ENV,
		workerData: {
			eslintOptionsOrURL,
			filePathIndexArray,
			filePaths,
		},
	};
```
Updated to now instead dont include it when declaring the const, and add the prop conditionally after checking if runtime == bun.


<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Previously the incorrect code that caused the issue was:
```js
//file: lib/eslint/eslint.js
        const workerOptions = {
                env: SHARE_ENV,
                workerData: {
                        eslintOptionsOrURL,
                        filePathIndexArray,
                        filePaths,
                },
        };
```
Updated to now instead dont include it when declaring the const, and add the prop conditionally after checking if runtime == bun.

#### Is there anything you'd like reviewers to focus on?
No

