### PR TITLE
chore: Mark deprecated formatting rules as available until v11.0.0

### DIFF
--- a/lib/rules/array-bracket-newline.js
+++ b/lib/rules/array-bracket-newline.js
@@ -19,7 +19,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/array-bracket-spacing.js
+++ b/lib/rules/array-bracket-spacing.js
@@ -18,7 +18,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/array-element-newline.js
+++ b/lib/rules/array-element-newline.js
@@ -19,7 +19,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/arrow-parens.js
+++ b/lib/rules/arrow-parens.js
@@ -35,7 +35,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/arrow-spacing.js
+++ b/lib/rules/arrow-spacing.js
@@ -22,7 +22,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/block-spacing.js
+++ b/lib/rules/block-spacing.js
@@ -19,7 +19,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -19,7 +19,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/comma-dangle.js
+++ b/lib/rules/comma-dangle.js
@@ -78,7 +78,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/comma-spacing.js
+++ b/lib/rules/comma-spacing.js
@@ -18,7 +18,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/comma-style.js
+++ b/lib/rules/comma-style.js
@@ -19,7 +19,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/computed-property-spacing.js
+++ b/lib/rules/computed-property-spacing.js
@@ -18,7 +18,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/dot-location.js
+++ b/lib/rules/dot-location.js
@@ -19,7 +19,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/eol-last.js
+++ b/lib/rules/eol-last.js
@@ -16,7 +16,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/func-call-spacing.js
+++ b/lib/rules/func-call-spacing.js
@@ -23,7 +23,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/function-call-argument-newline.js
+++ b/lib/rules/function-call-argument-newline.js
@@ -17,7 +17,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/function-paren-newline.js
+++ b/lib/rules/function-paren-newline.js
@@ -22,7 +22,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/generator-star-spacing.js
+++ b/lib/rules/generator-star-spacing.js
@@ -33,7 +33,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/implicit-arrow-linebreak.js
+++ b/lib/rules/implicit-arrow-linebreak.js
@@ -17,7 +17,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/indent-legacy.js
+++ b/lib/rules/indent-legacy.js
@@ -35,6 +35,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "4.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -512,7 +512,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/jsx-quotes.js
+++ b/lib/rules/jsx-quotes.js
@@ -44,7 +44,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -151,7 +151,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/keyword-spacing.js
+++ b/lib/rules/keyword-spacing.js
@@ -82,7 +82,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/line-comment-position.js
+++ b/lib/rules/line-comment-position.js
@@ -18,7 +18,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "9.3.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/linebreak-style.js
+++ b/lib/rules/linebreak-style.js
@@ -31,7 +31,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/lines-around-comment.js
+++ b/lib/rules/lines-around-comment.js
@@ -60,7 +60,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/lines-around-directive.js
+++ b/lib/rules/lines-around-directive.js
@@ -56,7 +56,7 @@ module.exports = {
 			message: "The rule was replaced with a more general rule.",
 			url: "https://eslint.org/blog/2017/06/eslint-v4.0.0-released/",
 			deprecatedSince: "4.0.0",
-			availableUntil: null,
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message: "The new rule moved to a plugin.",

--- a/lib/rules/lines-between-class-members.js
+++ b/lib/rules/lines-between-class-members.js
@@ -37,7 +37,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -71,7 +71,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/max-statements-per-line.js
+++ b/lib/rules/max-statements-per-line.js
@@ -22,7 +22,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/multiline-comment-style.js
+++ b/lib/rules/multiline-comment-style.js
@@ -18,7 +18,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "9.3.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/multiline-ternary.js
+++ b/lib/rules/multiline-ternary.js
@@ -19,7 +19,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/new-parens.js
+++ b/lib/rules/new-parens.js
@@ -27,7 +27,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/newline-after-var.js
+++ b/lib/rules/newline-after-var.js
@@ -42,7 +42,7 @@ module.exports = {
 			message: "The rule was replaced with a more general rule.",
 			url: "https://eslint.org/blog/2017/06/eslint-v4.0.0-released/",
 			deprecatedSince: "4.0.0",
-			availableUntil: null,
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message: "The new rule moved to a plugin.",

--- a/lib/rules/newline-before-return.js
+++ b/lib/rules/newline-before-return.js
@@ -30,7 +30,7 @@ module.exports = {
 			message: "The rule was replaced with a more general rule.",
 			url: "https://eslint.org/blog/2017/06/eslint-v4.0.0-released/",
 			deprecatedSince: "4.0.0",
-			availableUntil: null,
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message: "The new rule moved to a plugin.",

--- a/lib/rules/newline-per-chained-call.js
+++ b/lib/rules/newline-per-chained-call.js
@@ -20,7 +20,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/no-confusing-arrow.js
+++ b/lib/rules/no-confusing-arrow.js
@@ -33,7 +33,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -21,7 +21,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/no-extra-semi.js
+++ b/lib/rules/no-extra-semi.js
@@ -24,7 +24,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/no-floating-decimal.js
+++ b/lib/rules/no-floating-decimal.js
@@ -23,7 +23,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/no-mixed-operators.js
+++ b/lib/rules/no-mixed-operators.js
@@ -90,7 +90,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/no-mixed-spaces-and-tabs.js
+++ b/lib/rules/no-mixed-spaces-and-tabs.js
@@ -16,7 +16,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -19,7 +19,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -17,7 +17,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/no-spaced-func.js
+++ b/lib/rules/no-spaced-func.js
@@ -26,7 +26,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2016/08/eslint-v3.3.0-released/#deprecated-rules",
 			deprecatedSince: "3.3.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/no-tabs.js
+++ b/lib/rules/no-tabs.js
@@ -24,7 +24,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/no-trailing-spaces.js
+++ b/lib/rules/no-trailing-spaces.js
@@ -30,7 +30,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/no-whitespace-before-property.js
+++ b/lib/rules/no-whitespace-before-property.js
@@ -22,7 +22,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/nonblock-statement-body-position.js
+++ b/lib/rules/nonblock-statement-body-position.js
@@ -18,7 +18,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/object-curly-newline.js
+++ b/lib/rules/object-curly-newline.js
@@ -162,7 +162,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/object-curly-spacing.js
+++ b/lib/rules/object-curly-spacing.js
@@ -18,7 +18,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/object-property-newline.js
+++ b/lib/rules/object-property-newline.js
@@ -17,7 +17,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/one-var-declaration-per-line.js
+++ b/lib/rules/one-var-declaration-per-line.js
@@ -16,7 +16,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/operator-linebreak.js
+++ b/lib/rules/operator-linebreak.js
@@ -23,7 +23,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/padded-blocks.js
+++ b/lib/rules/padded-blocks.js
@@ -23,7 +23,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/padding-line-between-statements.js
+++ b/lib/rules/padding-line-between-statements.js
@@ -393,7 +393,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/quote-props.js
+++ b/lib/rules/quote-props.js
@@ -24,7 +24,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -101,7 +101,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/rest-spread-spacing.js
+++ b/lib/rules/rest-spread-spacing.js
@@ -17,7 +17,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/semi-spacing.js
+++ b/lib/rules/semi-spacing.js
@@ -19,7 +19,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/semi-style.js
+++ b/lib/rules/semi-style.js
@@ -89,7 +89,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/semi.js
+++ b/lib/rules/semi.js
@@ -23,7 +23,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/space-before-blocks.js
+++ b/lib/rules/space-before-blocks.js
@@ -42,7 +42,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/space-before-function-paren.js
+++ b/lib/rules/space-before-function-paren.js
@@ -22,7 +22,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/space-in-parens.js
+++ b/lib/rules/space-in-parens.js
@@ -18,7 +18,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/space-infix-ops.js
+++ b/lib/rules/space-infix-ops.js
@@ -18,7 +18,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/space-unary-ops.js
+++ b/lib/rules/space-unary-ops.js
@@ -22,7 +22,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/spaced-comment.js
+++ b/lib/rules/spaced-comment.js
@@ -147,7 +147,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/switch-colon-spacing.js
+++ b/lib/rules/switch-colon-spacing.js
@@ -23,7 +23,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/template-curly-spacing.js
+++ b/lib/rules/template-curly-spacing.js
@@ -23,7 +23,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/template-tag-spacing.js
+++ b/lib/rules/template-tag-spacing.js
@@ -17,7 +17,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/wrap-iife.js
+++ b/lib/rules/wrap-iife.js
@@ -44,7 +44,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/wrap-regex.js
+++ b/lib/rules/wrap-regex.js
@@ -17,7 +17,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/yield-star-spacing.js
+++ b/lib/rules/yield-star-spacing.js
@@ -17,7 +17,7 @@ module.exports = {
 			message: "Formatting rules are being moved out of ESLint core.",
 			url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 			deprecatedSince: "8.53.0",
-			availableUntil: "10.0.0",
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/tests/bin/eslint.js
+++ b/tests/bin/eslint.js
@@ -137,7 +137,7 @@ describe("bin/eslint.js", () => {
 									"Formatting rules are being moved out of ESLint core.",
 								url: "https://eslint.org/blog/2023/10/deprecating-formatting-rules/",
 								deprecatedSince: "8.53.0",
-								availableUntil: "10.0.0",
+								availableUntil: "11.0.0",
 								replacedBy: [
 									{
 										message:


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Refs https://github.com/eslint/eslint/issues/20097

Marks deprecated formatting rules as available until ESLint v11.0.0, i.e. planned for removal in ESLint v11.0.0.

This is a total of 74 rules:

* 67 rules deprecated in v8.53.0. The list is here: https://eslint.org/blog/2023/10/deprecating-formatting-rules/.
* 2 rules deprecated in v9.3.0: `line-comment-position` and `multiline-comment-style`.
* 5 rules previously deprecated in favor of some of the above one: `indent-legacy`, `lines-around-directive`, `newline-after-var`, `newline-before-return`, and `no-spaced-func`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated/added `availableUntil: "11.0.0"` property of `meta.deprecated` in 74 rules and 1 test.

#### Is there anything you'd like reviewers to focus on?

Did I miss some rules?

<!-- markdownlint-disable-file MD004 -->
