### PR TITLE
docs: add guidance on when to use extends vs cascading configs

### DIFF
--- a/docs/src/use/configure/configuration-files.md
+++ b/docs/src/use/configure/configuration-files.md
@@ -423,6 +423,10 @@ export default defineConfig([
 
 #### Cascading Configuration Objects
 
+::: tip
+Cascading provides automatic configuration layering, while [`extends`](#extending-configurations) offers explicit inheritance. Choose cascading for progressive file-based configuration and extends for reusing established configurations.
+:::
+
 When more than one configuration object matches a given filename, the configuration objects are merged with later objects overriding previous objects when there is a conflict. For example:
 
 ```js
@@ -600,6 +604,23 @@ A configuration object uses `extends` to inherit all the traits of another confi
 - a string that specifies the name of a configuration in a plugin
 - a configuration object
 - a configuration array
+
+#### When to Use Extends vs Cascading
+
+Both `extends` and cascading configuration objects can achieve similar organizational results, but they serve different purposes:
+
+**Use `extends` when:**
+- Reusing predefined or shareable configurations from plugins/packages
+- You want explicit inheritance with clear intent 
+- Combining multiple existing configurations
+- Building on established configuration patterns
+
+**Use cascading when:**
+- Creating layered configurations based on file patterns or directories
+- You prefer automatic merging behavior for progressive configuration
+- Building configuration that naturally flows from general to specific rules
+
+For example, use `extends` to inherit from `@eslint/js` recommended rules, but use cascading to apply different rules to test files vs source files.
 
 #### Using Configurations from Plugins
 


### PR DESCRIPTION
  #### Prerequisites checklist

  - [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

  #### What is the purpose of this pull request? (put an "X" next to an item)

  <!--
      The following template is intentionally not a markdown checkbox list for the reasons
      explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
  -->

  [x] Documentation update
  [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
  [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/ru le-proposal.md))
  [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change proposal.md))
  [ ] Add autofix to a rule
  [ ] Add a CLI option
  [ ] Add something to the core
  [ ] Other, please explain:

  <!--
      If the item you've checked above has a template, please paste the template questions
  below and answer them. (If this pull request is addressing an issue, you can just paste a
  link to the issue here instead.)
  -->

  <!--
      Please ensure your pull request is ready:

      - Read the pull request guide
  (https://eslint.org/docs/latest/contribute/pull-requests)
      - Include tests for this change
      - Update documentation for this change (if appropriate)
  -->

  <!--
      The following is required for all pull requests:
  -->

  #### What changes did you make? (Give an overview)

  I added documentation to clarify when to use `extends` vs cascading configuration
  approaches in ESLint flat config files. The changes include:

  1. **Added a new subsection "When to Use Extends vs Cascading"** in the "Extending
  Configurations" section that explains:
     - Clear use cases for `extends` (reusing predefined configs, explicit inheritance,
  combining shareable configs)
     - Clear use cases for cascading (layered file-based configuration, automatic merging,
  progressive configuration)
     - A practical example comparing the two approaches

  2. **Added a tip box in the "Cascading Configuration Objects" section** that provides a
  quick reference comparing the two approaches and links to the detailed explanation

  #### Is there anything you'd like reviewers to focus on?

  Did I miss some rule?

  