### PR TITLE
ci: pin `jiti` to version 2.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "globals": "^16.2.0",
     "got": "^11.8.3",
     "gray-matter": "^4.0.3",
-    "jiti": "^2.5.1",
+    "jiti": "2.5.1",
     "jiti-v2.0": "npm:jiti@2.0.x",
     "jiti-v2.1": "npm:jiti@2.1.x",
     "knip": "^5.60.2",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR temporarily pins the `jiti` dependency to version 2.5.1 to fix unit tests which are currently failing with jiti v2.6.0. E.g.:

https://github.com/eslint/eslint/actions/runs/17924949525/job/50968611432?pr=20149

Refs https://github.com/unjs/jiti/issues/406

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
