### PR TITLE
refactor: mark `ESLint.findConfigFile()` as `async`, add missing docs

### DIFF
--- a/docs/src/integrate/nodejs-api.md
+++ b/docs/src/integrate/nodejs-api.md
@@ -259,6 +259,24 @@ This method calculates the configuration for a given file, which can be useful f
 - (`Promise<Object>`)<br>
   The promise that will be fulfilled with a configuration object.
 
+### ◆ eslint.findConfigFile(filePath)
+
+```js
+const configFilePath = await eslint.findConfigFile(filePath);
+```
+
+This method finds the configuration file that this `ESLint` instance would use based on the options passed to the constructor.
+
+#### Parameters
+
+- `filePath` (`string`)<br>
+  Optional. The path of a file for which to find the associated config file. If omitted, ESLint determines the config file based on the current working directory of this instance.
+
+#### Return Value
+
+- (`Promise<string | undefined>`)<br>
+  The promise that will be fulfilled with the absolute path to the config file being used, or `undefined` when no config file is used (for example, when `overrideConfigFile: true` is set).
+
 ### ◆ eslint.isPathIgnored(filePath)
 
 ```js

--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -1299,7 +1299,7 @@ class ESLint {
 	 * @returns {Promise<string|undefined>} The path to the config file being used or
 	 *      `undefined` if no config file is being used.
 	 */
-	findConfigFile(filePath) {
+	async findConfigFile(filePath) {
 		const options = privateMembers.get(this).options;
 
 		/*

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -10862,6 +10862,60 @@ describe("ESLint", () => {
 					configFilePath,
 				);
 			});
+
+			it("should return undefined when overrideConfigFile is true even when filePath is provided", async () => {
+				const engine = new ESLint({
+					flags,
+					overrideConfigFile: true,
+					cwd: getFixturePath("lookup-from-file"),
+				});
+
+				const filePath = path.join("subdir", "code.js");
+				assert.strictEqual(
+					await engine.findConfigFile(filePath),
+					void 0,
+				);
+			});
+
+			it("should return custom config file path when overrideConfigFile is a nonempty string even when filePath is provided", async () => {
+				const engine = new ESLint({
+					flags,
+					overrideConfigFile: "my-config.js",
+				});
+
+				const configFilePath = path.resolve(
+					__dirname,
+					"../../../my-config.js",
+				);
+
+				assert.strictEqual(
+					await engine.findConfigFile("some/file.js"),
+					configFilePath,
+				);
+			});
+
+			it("should return the config file relative to the provided filePath when specified", async () => {
+				const engine = new ESLint({
+					flags,
+					cwd: getFixturePath("lookup-from-file"),
+				});
+
+				const foundConfig = await engine.findConfigFile(
+					path.join("subdir", "code.js"),
+				);
+
+				const expectedConfig = flags.includes(
+					"v10_config_lookup_from_file",
+				)
+					? getFixturePath(
+							"lookup-from-file",
+							"subdir",
+							"eslint.config.js",
+						)
+					: getFixturePath("lookup-from-file", "eslint.config.js");
+
+				assert.strictEqual(foundConfig, expectedConfig);
+			});
 		});
 
 		describe("Use stats option", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

This PR improves coverage of the `ESLint.findConfigFile()` API in both documentation and tests.

#### What changes did you make? (Give an overview)

- Document `ESLint.findConfigFile()` in the Node.js API guide.
- Add tests for `filePath` parameter behavior.
- Mark method as async.

Closes #20130

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
