### PR TITLE
feat: `preserve-caught-error` should recognize all static "cause" keys

### DIFF
--- a/lib/rules/preserve-caught-error.js
+++ b/lib/rules/preserve-caught-error.js
@@ -82,11 +82,7 @@ function getErrorCause(throwStatement) {
 			}
 
 			const causeProperties = errorOptions.properties.filter(
-				prop =>
-					prop.type === "Property" &&
-					prop.key.type === "Identifier" &&
-					prop.key.name === "cause" &&
-					!prop.computed, // It is hard to accurately identify the value of computed props
+				prop => astUtils.getStaticPropertyName(prop) === "cause",
 			);
 
 			const causeProperty = causeProperties.at(-1);

--- a/tests/lib/rules/preserve-caught-error.js
+++ b/tests/lib/rules/preserve-caught-error.js
@@ -23,6 +23,31 @@ ruleTester.run("preserve-caught-error", rule, {
     } catch (error) {
         throw new Error("Failed to perform error prone operations", { cause: error });
     }`,
+		`try {
+		doSomething();
+	} catch (error) {
+		throw new Error("Something failed", { 'cause': error });
+	}`,
+		`try {
+		doSomething();
+	} catch (error) {
+		throw new Error("Something failed", { "cause": error });
+	}`,
+		`try {
+		doSomething();
+	} catch (error) {
+		throw new Error("Something failed", { ['cause']: error });
+	}`,
+		`try {
+		doSomething();
+	} catch (error) {
+		throw new Error("Something failed", { ["cause"]: error });
+	}`,
+		`try {
+		doSomething();
+	} catch (error) {
+		throw new Error("Something failed", { [\`cause\`]: error });
+	}`,
 		/* No throw inside catch */
 		`try {
         doSomething();
@@ -92,6 +117,16 @@ ruleTester.run("preserve-caught-error", rule, {
 		} catch (error) {
 			throw new Error("Something failed", { cause: anotherError, cause: error });
 		}`,
+		`try {
+			doSomething();
+		} catch (error) {
+			throw new Error("Something failed", { "cause": anotherError, "cause": error });
+		}`,
+		`try {
+			doSomething();
+		} catch (error) {
+			throw new Error("Something failed", { cause: anotherError, "cause": error });
+		}`,
 	],
 	invalid: [
 		/* 1. Throws a new Error without cause, even though an error was caught */
@@ -136,6 +171,30 @@ ruleTester.run("preserve-caught-error", rule, {
         } catch (err) {
             const unrelated = new Error("other");
             throw new Error("Something failed", { cause: err });
+        }`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `try {
+            doSomething();
+        } catch (err) {
+            const unrelated = new Error("other");
+            throw new Error("Something failed", { "cause": unrelated });
+        }`,
+			errors: [
+				{
+					messageId: "incorrectCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `try {
+            doSomething();
+        } catch (err) {
+            const unrelated = new Error("other");
+            throw new Error("Something failed", { "cause": err });
         }`,
 						},
 					],
@@ -732,6 +791,12 @@ ruleTester.run("preserve-caught-error", rule, {
 		{
 			code: `try {} catch (error) {
 				throw new Error("Something failed", { cause: error, cause: anotherError });
+			}`,
+			errors: [{ messageId: "incorrectCause" }],
+		},
+		{
+			code: `try {} catch (error) {
+				throw new Error("Something failed", { cause: error, "cause": anotherError });
 			}`,
 			errors: [{ messageId: "incorrectCause" }],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

The `preserve-caught-error` rule was producing false positives when a caught error was re-thrown using a quoted or computed static `"cause"` key. For example:

```js
try {
    doSomething();
} catch (error) {
    throw new Error("Something failed", { "cause": error });
}
```

Previously, the rule only recognized unquoted identifier keys and would incorrectly report that the caught error was not preserved.

#### What changes did you make? (Give an overview)

- Replaced the manual property checks with `astUtils.getStaticPropertyName(prop) === "cause"` to correctly handle all static `"cause"` keys (unquoted, quoted, and computed).
- Added tests covering different forms of static `"cause"` keys, both valid and invalid.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
