### PR TITLE
refactor: normalize paths before passing to `Minimatch`

### DIFF
--- a/tests/lib/cli-engine/file-enumerator.js
+++ b/tests/lib/cli-engine/file-enumerator.js
@@ -232,54 +232,6 @@ describe("FileEnumerator", () => {
 					);
 				});
 			});
-
-			describe("if 'lib\\*.js' was given,", () => {
-				/** @type {Array<{config:(typeof import('../../../lib/cli-engine')).ConfigArray, filePath:string, ignored:boolean}>} */
-				let list;
-
-				beforeEach(() => {
-					list = [...enumerator.iterateFiles("lib\\*.js")];
-				});
-
-				it("should list two files.", () => {
-					assert.strictEqual(list.length, 2);
-				});
-
-				it("should list 'lib/one.js' and 'lib/two.js'.", () => {
-					assert.deepStrictEqual(
-						list.map(entry => entry.filePath),
-						[
-							path.join(root, "lib/one.js"),
-							path.join(root, "lib/two.js"),
-						],
-					);
-				});
-			});
-
-			describe("if 'lib\\**\\*.js' was given,", () => {
-				/** @type {Array<{config:(typeof import('../../../lib/cli-engine')).ConfigArray, filePath:string, ignored:boolean}>} */
-				let list;
-
-				beforeEach(() => {
-					list = [...enumerator.iterateFiles("lib\\**\\*.js")];
-				});
-
-				it("should list four files.", () => {
-					assert.strictEqual(list.length, 4);
-				});
-
-				it("should list 'lib/nested/one.js', 'lib/nested/two.js', 'lib/one.js', 'lib/two.js'.", () => {
-					assert.deepStrictEqual(
-						list.map(entry => entry.filePath),
-						[
-							path.join(root, "lib/nested/one.js"),
-							path.join(root, "lib/nested/two.js"),
-							path.join(root, "lib/one.js"),
-							path.join(root, "lib/two.js"),
-						],
-					);
-				});
-			});
 		});
 
 		// https://github.com/eslint/eslint/issues/14742


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR prepares ESLint for an upcoming upgrade to `minimatch@10` by ensuring paths are consistently normalized before being passed to `Minimatch`.

#### What changes did you make? (Give an overview)

- In `_iterateFilesWithGlob`, the `absolutePath` is now explicitly normalized to POSIX-style separators before being passed to `Minimatch`.

This was the only remaining `Minimatch` call site in the codebase where paths were not normalized. All other usages already normalize paths before passing them to `Minimatch`.

#### Why is this change necessary?

Currently, with `minimatch@3.1.2`:
- Backslashes (`\`) are automatically normalized to forward slashes on Windows, unless `allowWindowsEscape` is explicitly set to true.
- ESLint does not set `allowWindowsEscape`, so normalization always occurs and matching works as expected.

In `minimatch@5+` (including v10):
- Backslashes are normalized only if `windowsPathsNoEscape` is true or `allowWindowsEscape` is false.
- Otherwise, patterns with `\` are left unchanged, and backslashes are treated as escape characters instead of path separators.

To avoid future breakage, we now explicitly normalize file paths to POSIX-style separators.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
