### PR TITLE
chore: mark deprecated rules as available until v11.0.0

### DIFF
--- a/docs/src/_data/rules_meta.json
+++ b/docs/src/_data/rules_meta.json
@@ -260,7 +260,7 @@
             "message": "Node.js rules were moved out of ESLint core.",
             "url": "https://eslint.org/docs/latest/use/migrating-to-7.0.0#deprecate-node-rules",
             "deprecatedSince": "7.0.0",
-            "availableUntil": null,
+            "availableUntil": "11.0.0",
             "replacedBy": [
                 {
                     "message": "eslint-plugin-n now maintains deprecated Node.js-related rules.",
@@ -807,7 +807,7 @@
             "message": "Node.js rules were moved out of ESLint core.",
             "url": "https://eslint.org/docs/latest/use/migrating-to-7.0.0#deprecate-node-rules",
             "deprecatedSince": "7.0.0",
-            "availableUntil": null,
+            "availableUntil": "11.0.0",
             "replacedBy": [
                 {
                     "message": "eslint-plugin-n now maintains deprecated Node.js-related rules.",
@@ -856,7 +856,7 @@
             "message": "Node.js rules were moved out of ESLint core.",
             "url": "https://eslint.org/docs/latest/use/migrating-to-7.0.0#deprecate-node-rules",
             "deprecatedSince": "7.0.0",
-            "availableUntil": null,
+            "availableUntil": "11.0.0",
             "replacedBy": [
                 {
                     "message": "eslint-plugin-n now maintains deprecated Node.js-related rules.",
@@ -883,7 +883,7 @@
             "message": "The rule was renamed.",
             "url": "https://eslint.org/blog/2020/07/eslint-v7.5.0-released/#deprecating-id-blacklist",
             "deprecatedSince": "7.5.0",
-            "availableUntil": null,
+            "availableUntil": "11.0.0",
             "replacedBy": [
                 {
                     "rule": {
@@ -1667,7 +1667,7 @@
             "message": "Node.js rules were moved out of ESLint core.",
             "url": "https://eslint.org/docs/latest/use/migrating-to-7.0.0#deprecate-node-rules",
             "deprecatedSince": "7.0.0",
-            "availableUntil": null,
+            "availableUntil": "11.0.0",
             "replacedBy": [
                 {
                     "message": "eslint-plugin-n now maintains deprecated Node.js-related rules.",
@@ -1717,7 +1717,7 @@
             "message": "This rule was renamed.",
             "url": "https://eslint.org/blog/2018/07/eslint-v5.1.0-released/",
             "deprecatedSince": "5.1.0",
-            "availableUntil": null,
+            "availableUntil": "11.0.0",
             "replacedBy": [
                 {
                     "rule": {
@@ -2475,7 +2475,7 @@
             "message": "Node.js rules were moved out of ESLint core.",
             "url": "https://eslint.org/docs/latest/use/migrating-to-7.0.0#deprecate-node-rules",
             "deprecatedSince": "7.0.0",
-            "availableUntil": null,
+            "availableUntil": "11.0.0",
             "replacedBy": [
                 {
                     "message": "eslint-plugin-n now maintains deprecated Node.js-related rules.",
@@ -2616,7 +2616,7 @@
             "message": "Renamed rule.",
             "url": "https://eslint.org/blog/2016/08/eslint-v3.3.0-released/#deprecated-rules",
             "deprecatedSince": "3.3.0",
-            "availableUntil": null,
+            "availableUntil": "11.0.0",
             "replacedBy": [
                 {
                     "rule": {
@@ -2647,7 +2647,7 @@
             "message": "Renamed rule.",
             "url": "https://eslint.org/blog/2016/08/eslint-v3.3.0-released/#deprecated-rules",
             "deprecatedSince": "3.3.0",
-            "availableUntil": null,
+            "availableUntil": "11.0.0",
             "replacedBy": [
                 {
                     "rule": {
@@ -2702,7 +2702,7 @@
             "message": "The new rule flags more situations where object literal syntax can be used, and it does not report a problem when the `Object` constructor is invoked with an argument.",
             "url": "https://eslint.org/blog/2023/09/eslint-v8.50.0-released/",
             "deprecatedSince": "8.50.0",
-            "availableUntil": null,
+            "availableUntil": "11.0.0",
             "replacedBy": [
                 {
                     "rule": {
@@ -2718,7 +2718,7 @@
             "message": "Node.js rules were moved out of ESLint core.",
             "url": "https://eslint.org/docs/latest/use/migrating-to-7.0.0#deprecate-node-rules",
             "deprecatedSince": "7.0.0",
-            "availableUntil": null,
+            "availableUntil": "11.0.0",
             "replacedBy": [
                 {
                     "message": "eslint-plugin-n now maintains deprecated Node.js-related rules.",
@@ -2751,7 +2751,7 @@
             "message": "The rule was replaced with a more general rule.",
             "url": "https://eslint.org/docs/latest/use/migrate-to-9.0.0#eslint-recommended",
             "deprecatedSince": "9.0.0",
-            "availableUntil": null,
+            "availableUntil": "11.0.0",
             "replacedBy": [
                 {
                     "rule": {
@@ -2825,7 +2825,7 @@
             "message": "Node.js rules were moved out of ESLint core.",
             "url": "https://eslint.org/docs/latest/use/migrating-to-7.0.0#deprecate-node-rules",
             "deprecatedSince": "7.0.0",
-            "availableUntil": null,
+            "availableUntil": "11.0.0",
             "replacedBy": [
                 {
                     "message": "eslint-plugin-n now maintains deprecated Node.js-related rules.",
@@ -2866,7 +2866,7 @@
             "message": "Node.js rules were moved out of ESLint core.",
             "url": "https://eslint.org/docs/latest/use/migrating-to-7.0.0#deprecate-node-rules",
             "deprecatedSince": "7.0.0",
-            "availableUntil": null,
+            "availableUntil": "11.0.0",
             "replacedBy": [
                 {
                     "message": "eslint-plugin-n now maintains deprecated Node.js-related rules.",
@@ -2893,7 +2893,7 @@
             "message": "Node.js rules were moved out of ESLint core.",
             "url": "https://eslint.org/docs/latest/use/migrating-to-7.0.0#deprecate-node-rules",
             "deprecatedSince": "7.0.0",
-            "availableUntil": null,
+            "availableUntil": "11.0.0",
             "replacedBy": [
                 {
                     "message": "eslint-plugin-n now maintains deprecated Node.js-related rules.",
@@ -3007,7 +3007,7 @@
             "message": "Node.js rules were moved out of ESLint core.",
             "url": "https://eslint.org/docs/latest/use/migrating-to-7.0.0#deprecate-node-rules",
             "deprecatedSince": "7.0.0",
-            "availableUntil": null,
+            "availableUntil": "11.0.0",
             "replacedBy": [
                 {
                     "message": "eslint-plugin-n now maintains deprecated Node.js-related rules.",
@@ -3200,7 +3200,7 @@
             "message": "Node.js rules were moved out of ESLint core.",
             "url": "https://eslint.org/docs/latest/use/migrating-to-7.0.0#deprecate-node-rules",
             "deprecatedSince": "7.0.0",
-            "availableUntil": null,
+            "availableUntil": "11.0.0",
             "replacedBy": [
                 {
                     "message": "eslint-plugin-n now maintains deprecated Node.js-related rules.",

--- a/lib/rules/callback-return.js
+++ b/lib/rules/callback-return.js
@@ -16,7 +16,7 @@ module.exports = {
 			message: "Node.js rules were moved out of ESLint core.",
 			url: "https://eslint.org/docs/latest/use/migrating-to-7.0.0#deprecate-node-rules",
 			deprecatedSince: "7.0.0",
-			availableUntil: null,
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/global-require.js
+++ b/lib/rules/global-require.js
@@ -60,7 +60,7 @@ module.exports = {
 			message: "Node.js rules were moved out of ESLint core.",
 			url: "https://eslint.org/docs/latest/use/migrating-to-7.0.0#deprecate-node-rules",
 			deprecatedSince: "7.0.0",
-			availableUntil: null,
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/handle-callback-err.js
+++ b/lib/rules/handle-callback-err.js
@@ -17,7 +17,7 @@ module.exports = {
 			message: "Node.js rules were moved out of ESLint core.",
 			url: "https://eslint.org/docs/latest/use/migrating-to-7.0.0#deprecate-node-rules",
 			deprecatedSince: "7.0.0",
-			availableUntil: null,
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/id-blacklist.js
+++ b/lib/rules/id-blacklist.js
@@ -101,7 +101,7 @@ module.exports = {
 			message: "The rule was renamed.",
 			url: "https://eslint.org/blog/2020/07/eslint-v7.5.0-released/#deprecating-id-blacklist",
 			deprecatedSince: "7.5.0",
-			availableUntil: null,
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					rule: {

--- a/lib/rules/no-buffer-constructor.js
+++ b/lib/rules/no-buffer-constructor.js
@@ -16,7 +16,7 @@ module.exports = {
 			message: "Node.js rules were moved out of ESLint core.",
 			url: "https://eslint.org/docs/latest/use/migrating-to-7.0.0#deprecate-node-rules",
 			deprecatedSince: "7.0.0",
-			availableUntil: null,
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/no-catch-shadow.js
+++ b/lib/rules/no-catch-shadow.js
@@ -32,7 +32,7 @@ module.exports = {
 			message: "This rule was renamed.",
 			url: "https://eslint.org/blog/2018/07/eslint-v5.1.0-released/",
 			deprecatedSince: "5.1.0",
-			availableUntil: null,
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					rule: {

--- a/lib/rules/no-mixed-requires.js
+++ b/lib/rules/no-mixed-requires.js
@@ -17,7 +17,7 @@ module.exports = {
 			message: "Node.js rules were moved out of ESLint core.",
 			url: "https://eslint.org/docs/latest/use/migrating-to-7.0.0#deprecate-node-rules",
 			deprecatedSince: "7.0.0",
-			availableUntil: null,
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/no-native-reassign.js
+++ b/lib/rules/no-native-reassign.js
@@ -26,7 +26,7 @@ module.exports = {
 			message: "Renamed rule.",
 			url: "https://eslint.org/blog/2016/08/eslint-v3.3.0-released/#deprecated-rules",
 			deprecatedSince: "3.3.0",
-			availableUntil: null,
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					rule: {

--- a/lib/rules/no-negated-in-lhs.js
+++ b/lib/rules/no-negated-in-lhs.js
@@ -26,7 +26,7 @@ module.exports = {
 			message: "Renamed rule.",
 			url: "https://eslint.org/blog/2016/08/eslint-v3.3.0-released/#deprecated-rules",
 			deprecatedSince: "3.3.0",
-			availableUntil: null,
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					rule: {

--- a/lib/rules/no-new-object.js
+++ b/lib/rules/no-new-object.js
@@ -32,7 +32,7 @@ module.exports = {
 				"The new rule flags more situations where object literal syntax can be used, and it does not report a problem when the `Object` constructor is invoked with an argument.",
 			url: "https://eslint.org/blog/2023/09/eslint-v8.50.0-released/",
 			deprecatedSince: "8.50.0",
-			availableUntil: null,
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					rule: {

--- a/lib/rules/no-new-require.js
+++ b/lib/rules/no-new-require.js
@@ -17,7 +17,7 @@ module.exports = {
 			message: "Node.js rules were moved out of ESLint core.",
 			url: "https://eslint.org/docs/latest/use/migrating-to-7.0.0#deprecate-node-rules",
 			deprecatedSince: "7.0.0",
-			availableUntil: null,
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/no-new-symbol.js
+++ b/lib/rules/no-new-symbol.js
@@ -25,7 +25,7 @@ module.exports = {
 			message: "The rule was replaced with a more general rule.",
 			url: "https://eslint.org/docs/latest/use/migrate-to-9.0.0#eslint-recommended",
 			deprecatedSince: "9.0.0",
-			availableUntil: null,
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					rule: {

--- a/lib/rules/no-path-concat.js
+++ b/lib/rules/no-path-concat.js
@@ -16,7 +16,7 @@ module.exports = {
 			message: "Node.js rules were moved out of ESLint core.",
 			url: "https://eslint.org/docs/latest/use/migrating-to-7.0.0#deprecate-node-rules",
 			deprecatedSince: "7.0.0",
-			availableUntil: null,
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/no-process-env.js
+++ b/lib/rules/no-process-env.js
@@ -16,7 +16,7 @@ module.exports = {
 			message: "Node.js rules were moved out of ESLint core.",
 			url: "https://eslint.org/docs/latest/use/migrating-to-7.0.0#deprecate-node-rules",
 			deprecatedSince: "7.0.0",
-			availableUntil: null,
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/no-process-exit.js
+++ b/lib/rules/no-process-exit.js
@@ -16,7 +16,7 @@ module.exports = {
 			message: "Node.js rules were moved out of ESLint core.",
 			url: "https://eslint.org/docs/latest/use/migrating-to-7.0.0#deprecate-node-rules",
 			deprecatedSince: "7.0.0",
-			availableUntil: null,
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/no-restricted-modules.js
+++ b/lib/rules/no-restricted-modules.js
@@ -52,7 +52,7 @@ module.exports = {
 			message: "Node.js rules were moved out of ESLint core.",
 			url: "https://eslint.org/docs/latest/use/migrating-to-7.0.0#deprecate-node-rules",
 			deprecatedSince: "7.0.0",
-			availableUntil: null,
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:

--- a/lib/rules/no-sync.js
+++ b/lib/rules/no-sync.js
@@ -17,7 +17,7 @@ module.exports = {
 			message: "Node.js rules were moved out of ESLint core.",
 			url: "https://eslint.org/docs/latest/use/migrating-to-7.0.0#deprecate-node-rules",
 			deprecatedSince: "7.0.0",
-			availableUntil: null,
+			availableUntil: "11.0.0",
 			replacedBy: [
 				{
 					message:


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

Refs https://github.com/eslint/eslint/issues/20171

Marks deprecated Node and replaced/renamed core rules as available until ESLint v11.0.0, i.e. planned for removal in ESLint v11.0.0.

This affects a total of 17 rules:

**11 Node.js rules deprecated in v7.0.0:**  
`callback-return`, `global-require`, `handle-callback-err`, `no-buffer-constructor`, `no-mixed-requires`, `no-new-require`, `no-path-concat`, `no-process-env`, `no-process-exit`, `no-restricted-modules`, `no-sync`

**6 replaced/renamed by core rules:**  
`id-blacklist`, `no-native-reassign`, `no-negated-in-lhs`, `no-new-object`, `no-new-symbol`, `no-catch-shadow`

#### What changes did you make? (Give an overview)

Updated `availableUntil: "11.0.0"` property in `meta.deprecated` for all 17 rules.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
