### PR TITLE
fix: correct `no-loss-of-precision` false positives with `e` notation

### DIFF
--- a/lib/rules/no-loss-of-precision.js
+++ b/lib/rules/no-loss-of-precision.js
@@ -6,6 +6,209 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/** Class representing a number in scientific notation. */
+class ScientificNotation {
+	/** @type {string} The digits of the coefficient. A decimal point is implied after the first digit. */
+	coefficient;
+
+	/** @type {number} The order of magnitude. */
+	magnitude;
+
+	constructor(coefficient, magnitude) {
+		this.coefficient = coefficient;
+		this.magnitude = magnitude;
+	}
+
+	/* c8 ignore start -- debug only */
+	toString() {
+		return `${this.coefficient[0]}${this.coefficient.length > 1 ? `.${this.coefficient.slice(1)}` : ""}e${this.magnitude}`;
+	}
+	/* c8 ignore stop */
+}
+
+/**
+ * Returns whether the node is number literal
+ * @param {Node} node the node literal being evaluated
+ * @returns {boolean} true if the node is a number literal
+ */
+function isNumber(node) {
+	return typeof node.value === "number";
+}
+
+/**
+ * Gets the source code of the given number literal. Removes `_` numeric separators from the result.
+ * @param {Node} node the number `Literal` node
+ * @returns {string} raw source code of the literal, without numeric separators
+ */
+function getRaw(node) {
+	return node.raw.replace(/_/gu, "");
+}
+
+/**
+ * Checks whether the number is base ten
+ * @param {ASTNode} node the node being evaluated
+ * @returns {boolean} true if the node is in base ten
+ */
+function isBaseTen(node) {
+	const prefixes = ["0x", "0X", "0b", "0B", "0o", "0O"];
+
+	return (
+		prefixes.every(prefix => !node.raw.startsWith(prefix)) &&
+		!/^0[0-7]+$/u.test(node.raw)
+	);
+}
+
+/**
+ * Checks that the user-intended non-base ten number equals the actual number after is has been converted to the Number type
+ * @param {Node} node the node being evaluated
+ * @returns {boolean} true if they do not match
+ */
+function notBaseTenLosesPrecision(node) {
+	const rawString = getRaw(node).toUpperCase();
+	let base;
+
+	if (rawString.startsWith("0B")) {
+		base = 2;
+	} else if (rawString.startsWith("0X")) {
+		base = 16;
+	} else {
+		base = 8;
+	}
+
+	return !rawString.endsWith(node.value.toString(base).toUpperCase());
+}
+
+/**
+ * Returns the number stripped of leading zeros
+ * @param {string} numberAsString the string representation of the number
+ * @returns {string} the stripped string
+ */
+function removeLeadingZeros(numberAsString) {
+	for (let i = 0; i < numberAsString.length; i++) {
+		if (numberAsString[i] !== "0") {
+			return numberAsString.slice(i);
+		}
+	}
+	return numberAsString;
+}
+
+/**
+ * Returns the number stripped of trailing zeros
+ * @param {string} numberAsString the string representation of the number
+ * @returns {string} the stripped string
+ */
+function removeTrailingZeros(numberAsString) {
+	for (let i = numberAsString.length - 1; i >= 0; i--) {
+		if (numberAsString[i] !== "0") {
+			return numberAsString.slice(0, i + 1);
+		}
+	}
+	return numberAsString;
+}
+
+/**
+ * Converts an integer to an object containing the integer's coefficient and order of magnitude
+ * @param {string} stringInteger the string representation of the integer being converted
+ * @param {boolean} preserveTrailingZeros if `true`, the decimal coefficient will have the same number of trailing zeros as the original integer
+ * @returns {ScientificNotation} the object containing the integer's coefficient and order of magnitude
+ */
+function normalizeInteger(stringInteger, preserveTrailingZeros) {
+	const trimmedInteger = removeLeadingZeros(stringInteger);
+	const significantDigits = preserveTrailingZeros
+		? trimmedInteger
+		: removeTrailingZeros(trimmedInteger);
+
+	return new ScientificNotation(significantDigits, trimmedInteger.length - 1);
+}
+
+/**
+ * Converts a float to an object containing the float's coefficient and order of magnitude
+ * @param {string} stringFloat the string representation of the float being converted
+ * @returns {ScientificNotation} the object containing the float's coefficient and order of magnitude
+ */
+function normalizeFloat(stringFloat) {
+	const trimmedFloat = removeLeadingZeros(stringFloat);
+
+	if (trimmedFloat.startsWith(".")) {
+		const decimalDigits = trimmedFloat.slice(1);
+		const significantDigits = removeLeadingZeros(decimalDigits);
+
+		return new ScientificNotation(
+			significantDigits,
+			significantDigits.length - decimalDigits.length - 1,
+		);
+	}
+	return new ScientificNotation(
+		trimmedFloat.replace(".", ""),
+		trimmedFloat.indexOf(".") - 1,
+	);
+}
+
+/**
+ * Converts a base ten number to proper scientific notation
+ * @param {string} stringNumber the string representation of the base ten number to be converted
+ * @param {boolean} preserveTrailingZeros whether to always preserve trailing decimal zeros in the coefficient
+ * @returns {ScientificNotation} the object containing the number's coefficient and order of magnitude
+ */
+function convertNumberToScientificNotation(
+	stringNumber,
+	preserveTrailingZeros,
+) {
+	const splitNumber = stringNumber.split("e");
+	const originalCoefficient = splitNumber[0];
+	const normalizedNumber = stringNumber.includes(".")
+		? normalizeFloat(originalCoefficient)
+		: normalizeInteger(originalCoefficient, preserveTrailingZeros);
+	if (splitNumber.length > 1) {
+		normalizedNumber.magnitude += parseInt(splitNumber[1], 10);
+	}
+
+	return normalizedNumber;
+}
+
+/**
+ * Checks that the user-intended base ten number equals the actual number after is has been converted to the Number type
+ * @param {Node} node the node being evaluated
+ * @returns {boolean} true if they do not match
+ */
+function baseTenLosesPrecision(node) {
+	const rawNumber = getRaw(node).toLowerCase();
+	const normalizedRawNumber = convertNumberToScientificNotation(
+		rawNumber,
+		false,
+	);
+	const requestedPrecision = normalizedRawNumber.coefficient.length;
+
+	if (requestedPrecision > 100) {
+		return true;
+	}
+	const storedNumber = node.value.toPrecision(requestedPrecision);
+	const normalizedStoredNumber = convertNumberToScientificNotation(
+		storedNumber,
+		true,
+	);
+
+	return (
+		normalizedRawNumber.magnitude !== normalizedStoredNumber.magnitude ||
+		normalizedRawNumber.coefficient !== normalizedStoredNumber.coefficient
+	);
+}
+
+/**
+ * Checks that the user-intended number equals the actual number after is has been converted to the Number type
+ * @param {Node} node the node being evaluated
+ * @returns {boolean} true if they do not match
+ */
+function losesPrecision(node) {
+	return isBaseTen(node)
+		? baseTenLosesPrecision(node)
+		: notBaseTenLosesPrecision(node);
+}
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -29,214 +232,6 @@ module.exports = {
 	},
 
 	create(context) {
-		/**
-		 * Returns whether the node is number literal
-		 * @param {Node} node the node literal being evaluated
-		 * @returns {boolean} true if the node is a number literal
-		 */
-		function isNumber(node) {
-			return typeof node.value === "number";
-		}
-
-		/**
-		 * Gets the source code of the given number literal. Removes `_` numeric separators from the result.
-		 * @param {Node} node the number `Literal` node
-		 * @returns {string} raw source code of the literal, without numeric separators
-		 */
-		function getRaw(node) {
-			return node.raw.replace(/_/gu, "");
-		}
-
-		/**
-		 * Checks whether the number is  base ten
-		 * @param {ASTNode} node the node being evaluated
-		 * @returns {boolean} true if the node is in base ten
-		 */
-		function isBaseTen(node) {
-			const prefixes = ["0x", "0X", "0b", "0B", "0o", "0O"];
-
-			return (
-				prefixes.every(prefix => !node.raw.startsWith(prefix)) &&
-				!/^0[0-7]+$/u.test(node.raw)
-			);
-		}
-
-		/**
-		 * Checks that the user-intended non-base ten number equals the actual number after is has been converted to the Number type
-		 * @param {Node} node the node being evaluated
-		 * @returns {boolean} true if they do not match
-		 */
-		function notBaseTenLosesPrecision(node) {
-			const rawString = getRaw(node).toUpperCase();
-			let base;
-
-			if (rawString.startsWith("0B")) {
-				base = 2;
-			} else if (rawString.startsWith("0X")) {
-				base = 16;
-			} else {
-				base = 8;
-			}
-
-			return !rawString.endsWith(node.value.toString(base).toUpperCase());
-		}
-
-		/**
-		 * Adds a decimal point to the numeric string at index 1
-		 * @param {string} stringNumber the numeric string without any decimal point
-		 * @returns {string} the numeric string with a decimal point in the proper place
-		 */
-		function addDecimalPointToNumber(stringNumber) {
-			return `${stringNumber[0]}.${stringNumber.slice(1)}`;
-		}
-
-		/**
-		 * Returns the number stripped of leading zeros
-		 * @param {string} numberAsString the string representation of the number
-		 * @returns {string} the stripped string
-		 */
-		function removeLeadingZeros(numberAsString) {
-			for (let i = 0; i < numberAsString.length; i++) {
-				if (numberAsString[i] !== "0") {
-					return numberAsString.slice(i);
-				}
-			}
-			return numberAsString;
-		}
-
-		/**
-		 * Returns the number stripped of trailing zeros
-		 * @param {string} numberAsString the string representation of the number
-		 * @returns {string} the stripped string
-		 */
-		function removeTrailingZeros(numberAsString) {
-			for (let i = numberAsString.length - 1; i >= 0; i--) {
-				if (numberAsString[i] !== "0") {
-					return numberAsString.slice(0, i + 1);
-				}
-			}
-			return numberAsString;
-		}
-
-		/**
-		 * Converts an integer to an object containing the integer's coefficient and order of magnitude
-		 * @param {string} stringInteger the string representation of the integer being converted
-		 * @returns {Object} the object containing the integer's coefficient and order of magnitude
-		 */
-		function normalizeInteger(stringInteger) {
-			const trimmedInteger = removeLeadingZeros(stringInteger);
-			const significantDigits = removeTrailingZeros(trimmedInteger);
-
-			return {
-				magnitude: trimmedInteger.length - 1,
-				coefficient: addDecimalPointToNumber(significantDigits),
-			};
-		}
-
-		/**
-		 *
-		 * Converts a float to an object containing the floats's coefficient and order of magnitude
-		 * @param {string} stringFloat the string representation of the float being converted
-		 * @returns {Object} the object containing the float's coefficient and order of magnitude
-		 */
-		function normalizeFloat(stringFloat) {
-			const trimmedFloat = removeLeadingZeros(stringFloat);
-
-			if (trimmedFloat.startsWith(".")) {
-				const decimalDigits = trimmedFloat.slice(1);
-				const significantDigits = removeLeadingZeros(decimalDigits);
-
-				return {
-					magnitude:
-						significantDigits.length - decimalDigits.length - 1,
-					coefficient: addDecimalPointToNumber(significantDigits),
-				};
-			}
-			return {
-				magnitude: trimmedFloat.indexOf(".") - 1,
-				coefficient: addDecimalPointToNumber(
-					trimmedFloat.replace(".", ""),
-				),
-			};
-		}
-
-		/**
-		 * Converts a base ten number to proper scientific notation
-		 * @param {string} stringNumber the string representation of the base ten number to be converted
-		 * @returns {string} the number converted to scientific notation
-		 */
-		function convertNumberToScientificNotation(stringNumber) {
-			const splitNumber = stringNumber.split("e");
-			const originalCoefficient = splitNumber[0];
-			const normalizedNumber = stringNumber.includes(".")
-				? normalizeFloat(originalCoefficient)
-				: normalizeInteger(originalCoefficient);
-			const normalizedCoefficient = normalizedNumber.coefficient;
-			const magnitude =
-				splitNumber.length > 1
-					? parseInt(splitNumber[1], 10) + normalizedNumber.magnitude
-					: normalizedNumber.magnitude;
-
-			return `${normalizedCoefficient}e${magnitude}`;
-		}
-
-		/**
-		 * Checks that the user-intended base ten number equals the actual number after is has been converted to the Number type
-		 * @param {Node} node the node being evaluated
-		 * @returns {boolean} true if they do not match
-		 */
-		function baseTenLosesPrecision(node) {
-			const rawNumber = getRaw(node).toLowerCase();
-
-			/*
-			 * If trailing zeros equal the exponent, this is a valid representation
-			 * like "9.00e2" where 00 = 2 (meaning 9.00 * 10^2 = 900)
-			 * https://github.com/eslint/eslint/issues/19957
-			 */
-			if (rawNumber.includes(".") && rawNumber.includes("e")) {
-				const parts = rawNumber.split("e");
-				const coefficient = parts[0];
-				const exponent = parseInt(parts[1], 10);
-
-				// Count trailing zeros after decimal
-				const decimalParts = coefficient.split(".");
-				if (decimalParts.length === 2) {
-					const decimalPart = decimalParts[1];
-					const trailingZeros = decimalPart.match(/0*$/u)[0].length;
-
-					if (trailingZeros === exponent) {
-						return false;
-					}
-				}
-			}
-
-			const normalizedRawNumber =
-				convertNumberToScientificNotation(rawNumber);
-			const requestedPrecision = normalizedRawNumber
-				.split("e")[0]
-				.replace(".", "").length;
-
-			if (requestedPrecision > 100) {
-				return true;
-			}
-			const storedNumber = node.value.toPrecision(requestedPrecision);
-			const normalizedStoredNumber =
-				convertNumberToScientificNotation(storedNumber);
-
-			return normalizedRawNumber !== normalizedStoredNumber;
-		}
-
-		/**
-		 * Checks that the user-intended number equals the actual number after is has been converted to the Number type
-		 * @param {Node} node the node being evaluated
-		 * @returns {boolean} true if they do not match
-		 */
-		function losesPrecision(node) {
-			return isBaseTen(node)
-				? baseTenLosesPrecision(node)
-				: notBaseTenLosesPrecision(node);
-		}
-
 		return {
 			Literal(node) {
 				if (node.value && isNumber(node) && losesPrecision(node)) {

--- a/tests/lib/rules/no-loss-of-precision.js
+++ b/tests/lib/rules/no-loss-of-precision.js
@@ -54,12 +54,15 @@ ruleTester.run("no-loss-of-precision", rule, {
 		"var x = 9.0000000000e10",
 		"var x = 9.00E2",
 		"var x = 9.000E3",
+		"var x = 9.100E3",
 		"var x = 9.0000000000E10",
 		"var x = 019.5",
 		"var x = 0195",
 		"var x = 00195",
 		"var x = 0008",
 		"var x = 0e5",
+		"var x = .42",
+		"var x = 42.",
 
 		{ code: "var x = 12_34_56", languageOptions: { ecmaVersion: 2021 } },
 		{ code: "var x = 12_3.4_56", languageOptions: { ecmaVersion: 2021 } },
@@ -183,6 +186,14 @@ ruleTester.run("no-loss-of-precision", rule, {
 		{
 			code: "var x = 9.0_0719925_474099_3e15",
 			languageOptions: { ecmaVersion: 2021 },
+			errors: [{ messageId: "noLossOfPrecision" }],
+		},
+		{
+			code: "var x = 90071992547409930e-1",
+			errors: [{ messageId: "noLossOfPrecision" }],
+		},
+		{
+			code: "var x = .9007199254740993e16",
 			errors: [{ messageId: "noLossOfPrecision" }],
 		},
 		{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**

`no-loss-of-precision`

**What change do you want to make (place an "X" next to just one item)?**

[ ] Generate more warnings
[X] Generate fewer warnings
[ ] Implement autofix
[ ] Implement suggestions

**How will the change be implemented (place an "X" next to just one item)?**

[ ] A new option
[X] A new default behavior
[ ] Other

**Please provide some example code that this change will affect:**

```js
const x = 0.50e2;
const y = 47.210e3;
const z = .2500000000e10;
```

[**Playground link**](https://eslint.org/play/#eyJ0ZXh0IjoiLyogZXNsaW50IG5vLWxvc3Mtb2YtcHJlY2lzaW9uOiBlcnJvciAqL1xuXG5jb25zdCB4ID0gMC41MGUyO1xuY29uc3QgeSA9IDQ3LjIxMGUzO1xuY29uc3QgeiA9IC4yNTAwMDAwMDAwZTEwOyIsIm9wdGlvbnMiOnsicnVsZXMiOnt9LCJsYW5ndWFnZU9wdGlvbnMiOnsic291cmNlVHlwZSI6Im1vZHVsZSIsInBhcnNlck9wdGlvbnMiOnsiZWNtYUZlYXR1cmVzIjp7fX19fX0=)

**What does the rule currently do for this code?**

Report errors.

**What will the rule do after it's changed?**

Report no errors.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR fixes an edge case that occurs when all of the following are given:

* The number is written using exponential notation (`e` or `E`).
* It contains a decimal point `.`.
* The exponent matches the number of digits between the decimal point and the `e`.
* The digit immediately before the `e` is `0`.

A partial fix for this issue was introduced in #20002, which handled cases where all digits between the decimal point and the `e` were zeros. This PR fixes the remaining cases where at least one nonzero digit appears between the decimal point and the `e`.

To fix this edge case, I added an option to preserve trailing zeros to the `convertNumberToScientificNotation` function. This ensures that when computing the _expected_ notation (based on the node's numeric _value_ property), the same number of decimal zeros as in the _actual_ notation are retained, even when the numeric value is an integer.

**Example:**

Consider the expression `90.10e2`, which evaluates to the integer 9010. The rule normalizes this to `9.010e3`, ensuring only one nonzero digit precedes the decimal point. This normalized form is then compared to the expected notation derived from the numeric value. Previously, the expected notation was calculated as `9.01e3`, omitting the trailing zero and causing a mismatch. After the fix, the expected notation correctly preserves the trailing zero in 9010 as `9.010e3`, aligning with the actual normalized form and preventing a false positive.

Other changes include:
* Moved closures to the top level of the file.
* Added a class to represent a number in scientific notation.
* Numbers in scientific notation are now compared by their components (coefficient and magnitude), without reformatting the numbers into strings.
* Removed no longer necessary logic.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
