### PR TITLE
docs: link the types from the `custom-formatters` page to the `nodejs…

### DIFF
--- a/docs/src/extend/custom-formatters.md
+++ b/docs/src/extend/custom-formatters.md
@@ -44,7 +44,7 @@ The remainder of this section contains reference information on how to work with
 
 ### The `results` Argument
 
-The `results` object passed into a formatter is an array of [`result`](#the-result-object) objects containing the linting results for individual files. Here's an example output:
+The `results` object passed into a formatter is an array of [`LintResult`](../integrate/nodejs-api#-lintresult-type) objects containing the linting results for individual files. Here's an example output:
 
 ```js
 [
@@ -85,31 +85,9 @@ The `results` object passed into a formatter is an array of [`result`](#the-resu
 ];
 ```
 
-#### The `result` Object
+#### The `message` Object
 
-<!-- This section is copied from the "Node.js API" page. Changes to this section should
-also be manually applied to that page. -->
-
-Each object in the `results` array is a `result` object. Each `result` object contains the path of the file that was linted and information about linting issues that were encountered. Here are the properties available on each `result` object:
-
-- **filePath**: The absolute path to the file that was linted.
-- **messages**: An array of [`message`](#the-message-object) objects. See below for more info about messages.
-- **errorCount**: The number of errors for the given file.
-- **warningCount**: The number of warnings for the given file.
-- **stats**: The optional [`stats`](./stats#-stats-type) object that only exists when the `stats` option is used.
-- **source**: The source code for the given file. This property is omitted if this file has no errors/warnings or if the `output` property is present.
-- **output**: The source code for the given file with as many fixes applied as possible. This property is omitted if no fix is available.
-
-##### The `message` Object
-
-Each `message` object contains information about the ESLint rule that was triggered by some source code. The properties available on each `message` object are:
-
-- **ruleId**: the ID of the rule that produced the error or warning. If the error or warning was not produced by a rule (for example, if it's a parsing error), this is `null`.
-- **severity**: the severity of the failure, `1` for warnings and `2` for errors.
-- **message**: the human readable description of the error.
-- **line**: the line where the issue is located.
-- **column**: the column where the issue is located.
-- **nodeType**: (**Deprecated:** This property will be removed in a future version of ESLint.) the type of the node in the [AST](https://github.com/estree/estree/blob/master/es5.md#node-objects) or `null` if the issue isn't related to a particular AST node.
+Each `message` object contains information about the ESLint rule that was triggered by some source code; its type is [`LintMessage`](../integrate/nodejs-api#-lintmessage-type).
 
 ### The `context` Argument
 

--- a/docs/src/integrate/nodejs-api.md
+++ b/docs/src/integrate/nodejs-api.md
@@ -485,7 +485,7 @@ The `LintMessage` value is the information of each linting error. The `messages`
 - `fatal` (`boolean | undefined`)<br>
   `true` if this is a fatal error unrelated to a rule, like a parsing error.
 - `message` (`string`)<br>
-  The error message.
+  The human readable description of the error.
 - `messageId` (`string | undefined`)<br>
   The message ID of the lint error. This property is undefined if the rule does not use message IDs.
 - `line` (`number | undefined`)<br>
@@ -500,6 +500,8 @@ The `LintMessage` value is the information of each linting error. The `messages`
   The [EditInfo] object of autofix. This property is undefined if this message is not fixable.
 - `suggestions` (`{ desc: string; fix: EditInfo; messageId?: string; data?: object }[] | undefined`)<br>
   The list of suggestions. Each suggestion is the pair of a description and an [EditInfo] object to fix code. API users such as editor integrations can choose one of them to fix the problem of this message. This property is undefined if this message doesn't have any suggestions.
+- `nodeType` (`string | undefined`)<br>
+  (**Deprecated:** This property will be removed in a future version of ESLint.) the type of the node in the [AST](https://github.com/estree/estree/blob/master/es5.md#node-objects) or `null` if the issue isn't related to a particular AST node.
 
 ### ◆ SuppressedLintMessage type
 


### PR DESCRIPTION
…-api` page

<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Some types on the `custom-formatters` page are incomplete, and corresponding type definitions exist in `nodejs-api`. Merge them into `nodejs-api` page.

#### Is there anything you'd like reviewers to focus on?

Although I have already checked for similar cases where we explain the same type in multiple places, there may be pages I overlooked.

<!-- markdownlint-disable-file MD004 -->
