### PR TITLE
fix: correct `Rule` typings

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -630,7 +630,7 @@ export namespace Rule {
 	}
 
 	type NodeTypes = ESTree.Node["type"];
-	interface NodeListener extends RuleVisitor {
+	interface NodeListener {
 		ArrayExpression?:
 			| ((node: ESTree.ArrayExpression & NodeParentExtension) => void)
 			| undefined;

--- a/tests/lib/types/types.test.ts
+++ b/tests/lib/types/types.test.ts
@@ -971,6 +971,27 @@ type DeprecatedRuleContextKeys =
 	},
 });
 
+(): JSRuleDefinition => ({
+	create() {
+		return {
+			onCodePathStart(codePath, node) {},
+			onCodePathSegmentStart(segment, node) {},
+			onCodePathSegmentLoop(fromSegment, toSegment, node) {},
+			Program(node) {},
+			"Program:exit"(node) {},
+		} satisfies Rule.RuleListener;
+	},
+});
+
+(): JSRuleDefinition => ({
+	// @ts-expect-error invalid return type
+	create() {
+		return {
+			foo: null,
+		};
+	},
+});
+
 // #endregion
 
 // #region Linter


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

- Added `onUnreachableCodePathSegmentStart` and `onUnreachableCodePathSegmentEnd` to `Rule.RuleListener` to match emitted code-path events.
- Updated typing to use `RuleListener` as the visitor:
  - `Rule.RuleModule`’s `Visitor` is now `RuleListener`, and `create()` returns `RuleListener`.
  - `JSRuleDefinition`’s `Visitor` is also set to `Rule.RuleListener`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
