### PR TITLE
docs: improve web accessibility by hiding non-semantic character

### DIFF
--- a/docs/src/assets/scss/eslint-site-footer.scss
+++ b/docs/src/assets/scss/eslint-site-footer.scss
@@ -29,7 +29,7 @@
 			margin-inline-end: 0.5rem;
 
 			&:not(:last-of-type)::after {
-				content: "|";
+				content: "|" / "";
 				margin-left: 0.5rem;
 				margin-inline-start: 0.5rem;
 			}

--- a/docs/src/assets/scss/languages.scss
+++ b/docs/src/assets/scss/languages.scss
@@ -27,7 +27,7 @@
 			color: var(--link-color);
 
 			&::after {
-				content: " ✔️";
+				content: " ✔️" / "check mark";
 				white-space: pre;
 				color: rgba(100%, 0%, 0%, 0);
 				text-shadow: 0 0 0 var(--headings-color);

--- a/docs/src/assets/scss/versions.scss
+++ b/docs/src/assets/scss/versions.scss
@@ -28,7 +28,7 @@
 			color: var(--link-color);
 
 			&::after {
-				content: " ✔️";
+				content: " ✔️" / "check mark";
 				white-space: pre;
 				color: rgba(100%, 0%, 0%, 0);
 				text-shadow: 0 0 0 var(--headings-color);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR is a follow-up to https://github.com/eslint/eslint/pull/20181.

In this PR, I've added alternative text for the indicator `|` and emojis.

<img width="1156" height="58" alt="image" src="https://github.com/user-attachments/assets/c6e14707-a4f7-4f5a-b499-671e3e295f82" />

Previously, screen readers would read out the indicator `|`, which could be distracting.

(The MDN reference is here: https://developer.mozilla.org/en-US/docs/Web/CSS/content#try_it)

#### Is there anything you'd like reviewers to focus on?

Ref: https://github.com/eslint/eslint/pull/20181

<!-- markdownlint-disable-file MD004 -->
