### PR TITLE
test: remove use of `nodejsScope` option of eslint-scope from tests

### DIFF
--- a/tests/fixtures/parsers/enhanced-parser3.js
+++ b/tests/fixtures/parsers/enhanced-parser3.js
@@ -29,7 +29,6 @@ function analyzeScope(ast) {
     const options = {
         optimistic: false,
         directive: false,
-        nodejsScope: false,
         impliedStrict: false,
         sourceType: "script",
         ecmaVersion: 6,

--- a/tests/lib/languages/js/source-code/source-code.js
+++ b/tests/lib/languages/js/source-code/source-code.js
@@ -3749,8 +3749,8 @@ describe("SourceCode", () => {
 			const ast = espree.parse(code, DEFAULT_CONFIG);
 			const scopeManager = eslintScope.analyze(ast, {
 				ignoreEval: true,
-				nodejsScope: true,
 				ecmaVersion: 6,
+				sourceType: "commonjs",
 			});
 			const sourceCode = new SourceCode({
 				text: code,
@@ -4012,8 +4012,8 @@ describe("SourceCode", () => {
 			const ast = espree.parse(code, DEFAULT_CONFIG);
 			const scopeManager = eslintScope.analyze(ast, {
 				ignoreEval: true,
-				nodejsScope: true,
 				ecmaVersion: 6,
+				sourceType: "commonjs",
 			});
 			const sourceCode = new SourceCode({
 				text: code,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Removes use of the `nodejsScope` option of eslint-scope from tests, as this option is going to be removed in the upcoming major version of eslint-scope (https://github.com/eslint/js/issues/697).

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Removed `nodejsScope: false`, and replaced `nodejsScope: true` with `sourceType: "commonjs"`.

#### Is there anything you'd like reviewers to focus on?

Using this particular option over `sourceType: "commonjs"` is not crucial for these tests. I'd like to merge this now to reduce merge conflicts when we start merging PRs for ESLint v11.

<!-- markdownlint-disable-file MD004 -->
