### PR TITLE
fix: enhance formatter loading to support default exports

### DIFF
--- a/lib/eslint/legacy-eslint.js
+++ b/lib/eslint/legacy-eslint.js
@@ -700,7 +700,11 @@ class LegacyESLint {
 		}
 
 		const { cliEngine, options } = privateMembersMap.get(this);
-		const formatter = cliEngine.getFormatter(name);
+		let formatter = cliEngine.getFormatter(name);
+
+		if (typeof formatter === "object" && "default" in formatter) {
+			formatter = formatter.default;
+		}
 
 		if (typeof formatter !== "function") {
 			throw new Error(

--- a/tests/fixtures/formatters/default_export.js
+++ b/tests/fixtures/formatters/default_export.js
@@ -1,0 +1,18 @@
+/*global module*/
+const formatterFunction = function (results) {
+
+	var output = "";
+
+	results.forEach(function (result) {
+
+		var messages = result.messages;
+		messages.forEach(function (message) {
+			output += "Problem on line " + (message.line || 0) + "\n";
+		});
+
+	});
+
+	return output;
+};
+
+export default formatterFunction;

--- a/tests/lib/eslint/legacy-eslint.js
+++ b/tests/lib/eslint/legacy-eslint.js
@@ -7028,6 +7028,16 @@ describe("LegacyESLint", () => {
 			assert.strictEqual(typeof formatter.format, "function");
 		});
 
+		it("should return a formatter object when a custom formatter is requested with a default export", async () => {
+			const engine = new LegacyESLint();
+			const formatter = await engine.loadFormatter(
+				getFixturePath("formatters", "default_export.js"),
+			);
+
+			assert.strictEqual(typeof formatter, "object");
+			assert.strictEqual(typeof formatter.format, "function");
+		});
+
 		it("should return a formatter object when a custom formatter is requested, also if the path has backslashes", async () => {
 			const engine = new LegacyESLint({
 				cwd: path.join(fixtureDir, ".."),


### PR DESCRIPTION
- Updated the formatter loading logic in LegacyESLint to handle cases where the formatter is an object with a default export.
- Added a new test to verify that a formatter object is returned when a custom formatter with a default export is requested.

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:** v24.1.0
- **npm version:** v11.3.0
- **Local ESLint version:** v9.37.0
- **Global ESLint version:** N/A
- **Operating System:** macOS

**What parser are you using (place an "X" next to just one item)?**

[ ] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**What did you do? Please include the actual source code causing the issue.**

Using the `esling-formatter-gitlab` while setting ESLINT_USE_FLAT_CONFIG to false

**What did you expect to happen?**

eslint is using the gitlab formatter

**What actually happened? Please include the actual, raw output from ESLint.**

Formatter must be a function, but got a object.

#### What changes did you make? (Give an overview)

I added a check to see if the formatter is not a function but a default export. Then `f.default` is returned.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
