### PR TITLE
fix: improve error message for missing fix function in suggestions

### DIFF
--- a/lib/linter/file-report.js
+++ b/lib/linter/file-report.js
@@ -426,7 +426,7 @@ function validateSuggestions(suggest, messages) {
 
 			if (typeof suggestion.fix !== "function") {
 				throw new TypeError(
-					`context.report() called with a suggest option without a fix function. See: ${suggestion}`,
+					`context.report() called with a suggest option without a fix function. See: ${JSON.stringify(suggestion, null, 2)}`,
 				);
 			}
 		});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

When a rule's suggestion is missing a `fix` function, the error message displayed `[object Object]` instead of showing the actual suggestion object contents.

#### What changes did you make? (Give an overview)

Updated the error message in `validateSuggestions()` to use `JSON.stringify(suggestion, null, 2)` instead of string interpolation.

Before:
```
TypeError: context.report() called with a suggest option without a fix function. See: [object Object]
```

After:
```
TypeError: context.report() called with a suggest option without a fix function. See: {
  "desc": "Some suggestion description",
}
```

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
