### PR TITLE
docs: handle empty flags sections on the feature flags page

### DIFF
--- a/docs/src/pages/flags.md
+++ b/docs/src/pages/flags.md
@@ -34,6 +34,7 @@ The following policies apply to `unstable_` flags.
 
 ## Active Flags
 
+{% if flags.active | length %}
 The following flags are currently available for use in ESLint.
 
 <table>
@@ -49,9 +50,13 @@ The following flags are currently available for use in ESLint.
 {%- endfor -%}
     </tbody>
 </table>
+{% else %}
+There are currently no active flags.
+{% endif %}
 
 ## Inactive Flags
 
+{% if flags.inactive | length %}
 The following flags were once used but are no longer active.
 
 <table>
@@ -68,6 +73,9 @@ The following flags were once used but are no longer active.
 {%- endfor -%}
     </tbody>
 </table>
+{% else %}
+There are currently no inactive flags.
+{% endif %}
 
 ## How to Use Feature Flags
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

The feature flags documentation page was updated to handle cases where there are no active or inactive flags.

#### What changes did you make? (Give an overview)

Added conditional logic in `flags.md` so that if `flags.active` or `flags.inactive` is empty, the page no longer renders an empty table. Instead, it shows a short message: “There are currently no active/inactive flags.”

#### Rationale

ESLint v10 removes all currently inactive flags (`unstable_ts_config`, `unstable_config_lookup_from_file`), so the page would otherwise render an empty table.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
