### PR TITLE
docs: update CLI flags migration instructions

### DIFF
--- a/docs/src/use/configure/migration-guide.md
+++ b/docs/src/use/configure/migration-guide.md
@@ -639,11 +639,64 @@ export default defineConfig([
 
 The following CLI flags are no longer supported with the flat config file format:
 
-- `--rulesdir`
-- `--ext`
+- `--env`
+- `--ignore-path`
+- `--no-eslintrc`
 - `--resolve-plugins-relative-to`
+- `--rulesdir`
 
-The flag `--no-eslintrc` has been replaced with `--no-config-lookup`.
+#### `--env`
+
+The `--env` flag was used to enable environment-specific globals (for example, `browser`, or `node`). Flat config doesn't support this flag. Instead, define the relevant globals directly in your configuration. See [Specifying Globals](language-options#specifying-globals) for more details.
+
+For example, if you previously used `--env browser,node`, you’ll need to update your config file like this:
+
+```js
+// eslint.config.js
+import { defineConfig } from "eslint/config";
+import globals from "globals";
+
+export default defineConfig([
+	{
+		languageOptions: {
+			globals: {
+				...globals.browser,
+				...globals.node,
+			},
+		},
+	},
+]);
+```
+
+#### `--ignore-path`
+
+The `--ignore-path` flag was used to specify which file to use as your `.eslintignore`. Flat config doesn't load ignore patterns from `.eslintignore` files and does not support this flag. If you want to include patterns from a `.gitignore` file, use `includeIgnoreFile()` from `@eslint/compat`. See [Including `.gitignore` Files](ignore#including-gitignore-files) for more details.
+
+For example, if you previously used `--ignore-path .gitignore`:
+
+```js
+// eslint.config.js
+import { defineConfig } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import { fileURLToPath } from "node:url";
+
+const gitignorePath = fileURLToPath(new URL(".gitignore", import.meta.url));
+
+export default defineConfig([
+	includeIgnoreFile(gitignorePath, "Imported .gitignore patterns"),
+	// other configs
+]);
+```
+
+#### `--no-eslintrc`
+
+The `--no-eslintrc` flag has been replaced with `--no-config-lookup`.
+
+#### `--resolve-plugins-relative-to`
+
+The `--resolve-plugins-relative-to` flag was used to indicate which directory plugin references in your configuration file should be resolved relative to. This was necessary because shareable configs could only resolve plugins that were peer dependencies or dependencies of parent packages.
+
+With flat config, shareable configs can specify their dependencies directly, so this flag is no longer needed.
 
 #### `--rulesdir`
 
@@ -672,31 +725,6 @@ export default defineConfig([
 	},
 ]);
 ```
-
-#### `--ext`
-
-The `--ext` flag was used to specify additional file extensions ESLint should search for when a directory was passed on the command line, such as `npx eslint .`. This is no longer supported when using flat config. Instead, specify the file patterns you'd like ESLint to search for directly in your config. For example, if you previously were using `--ext .ts,.tsx`, then you will need to update your config file like this:
-
-```js
-// eslint.config.js
-import { defineConfig } from "eslint/config";
-
-export default defineConfig([
-	{
-		files: ["**/*.ts", "**/*.tsx"],
-
-		// any additional configuration for these file types here
-	},
-]);
-```
-
-ESLint uses the `files` keys from the config file to determine which files should be linted.
-
-#### `--resolve-plugins-relative-to`
-
-The `--resolve-plugins-relative-to` flag was used to indicate which directory plugin references in your configuration file should be resolved relative to. This was necessary because shareable configs could only resolve plugins that were peer dependencies or dependencies of parent packages.
-
-With flat config, shareable configs can specify their dependencies directly, so this flag is no longer needed.
 
 ### `package.json` Configuration No Longer Supported
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

This PR updates the "CLI Flag Changes" section of the flat config migration guide to include migration instructions for additional legacy CLI flags that are no longer supported when using flat config.

#### What changes did you make? (Give an overview)

- Added new migration instructions for:
  - `--env`
  - `--ignore-path`
  - `--no-eslintrc` (moved and clarified placement)
- Reordered sections alphabetically for consistency
- Removed outdated `--ext` section (the flag was reintroduced in ESLint v9.21.0)

Fixes #20085

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
