### PR TITLE
feat: update `complexity` rule to highlight only static block header

### DIFF
--- a/lib/rules/complexity.js
+++ b/lib/rules/complexity.js
@@ -177,15 +177,8 @@ module.exports = {
 					if (codePath.origin === "class-field-initializer") {
 						name = "class field initializer";
 					} else if (codePath.origin === "class-static-block") {
-						const openingBrace = sourceCode.getFirstToken(node, {
-							skip: 1,
-						});
-
 						name = "class static block";
-						loc = {
-							start: node.loc.start,
-							end: openingBrace.loc.start,
-						};
+						loc = sourceCode.getFirstToken(node).loc;
 					} else {
 						name = astUtils.getFunctionNameWithKind(node);
 						loc = astUtils.getFunctionHeadLoc(node, sourceCode);

--- a/tests/lib/rules/complexity.js
+++ b/tests/lib/rules/complexity.js
@@ -805,7 +805,7 @@ ruleTester.run("complexity", rule, {
 				{
 					...makeError("Class static block", 4, 3),
 					column: 11,
-					endColumn: 18,
+					endColumn: 17,
 				},
 			],
 		},
@@ -817,7 +817,7 @@ ruleTester.run("complexity", rule, {
 				{
 					...makeError("Class static block", 4, 3),
 					column: 35,
-					endColumn: 42,
+					endColumn: 41,
 				},
 			],
 		},
@@ -829,12 +829,12 @@ ruleTester.run("complexity", rule, {
 				{
 					...makeError("Class static block", 4, 3),
 					column: 11,
-					endColumn: 18,
+					endColumn: 17,
 				},
 				{
 					...makeError("Class static block", 4, 3),
 					column: 40,
-					endColumn: 47,
+					endColumn: 46,
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

This pull request refines the `complexity` rule’s reporting location for class static blocks, so that only the *header* portion (i.e. before the opening brace) is highlighted.
This makes the rule visually consistent with recent updates that reduced the visual disruption of complexity warnings for functions.

#### What changes did you make? (Give an overview)

- Updated `complexity` rule to compute the report location for class static blocks using the token before the opening brace.
This ensures the highlight covers only the header (`static {`) instead of the entire block body.
- Adjusted related test expectations for ranges.

#### Related Issues

#19984

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
