### PR TITLE
fix: forward traversal `step.args` to visitors

### DIFF
--- a/lib/linter/source-code-traverser.js
+++ b/lib/linter/source-code-traverser.js
@@ -17,8 +17,9 @@ const vk = require("eslint-visitor-keys");
 //-----------------------------------------------------------------------------
 
 /**
- * @import { ESQueryParsedSelector } from "./esquery.js";
  * @import { Language, SourceCode } from "@eslint/core";
+ * @import { ESQueryOptions } from "esquery";
+ * @import { ESQueryParsedSelector } from "./esquery.js";
  * @import { SourceCodeVisitor } from "./source-code-visitor.js";
  */
 
@@ -47,11 +48,10 @@ class ESQueryHelper {
 	 * Creates a new instance.
 	 * @param {SourceCodeVisitor} visitor The visitor containing the functions to call.
 	 * @param {ESQueryOptions} esqueryOptions `esquery` options for traversing custom nodes.
-	 * @returns {NodeEventGenerator} new instance
 	 */
 	constructor(visitor, esqueryOptions) {
 		/**
-		 * The emitter to use during traversal.
+		 * The visitor to use during traversal.
 		 * @type {SourceCodeVisitor}
 		 */
 		this.visitor = visitor;
@@ -288,7 +288,10 @@ class SourceCodeTraverser {
 									false,
 								)
 								.forEach(selector => {
-									visitor.callSync(selector, step.target);
+									visitor.callSync(
+										selector,
+										...(step.args ?? [step.target]),
+									);
 								});
 							currentAncestry.unshift(step.target);
 						} else {
@@ -300,7 +303,10 @@ class SourceCodeTraverser {
 									true,
 								)
 								.forEach(selector => {
-									visitor.callSync(selector, step.target);
+									visitor.callSync(
+										selector,
+										...(step.args ?? [step.target]),
+									);
 								});
 						}
 					} catch (err) {

--- a/tests/lib/linter/source-code-traverser.js
+++ b/tests/lib/linter/source-code-traverser.js
@@ -232,6 +232,47 @@ describe("SourceCodeTraverser", () => {
 			);
 		});
 
+		it("should pass step.args to visitor", () => {
+			const dummyParent = { type: "Parent", value: 0 };
+			const dummyNode = { type: "Foo", value: 1 };
+			const sourceCode = {
+				ast: dummyNode,
+				visitorKeys: vk.KEYS,
+				*traverse() {
+					yield {
+						kind: STEP_KIND_VISIT,
+						target: dummyNode,
+						phase: 1,
+						args: [dummyNode, dummyParent],
+					};
+					yield {
+						kind: STEP_KIND_VISIT,
+						target: dummyNode,
+						phase: 2,
+						args: [dummyNode, dummyParent],
+					};
+				},
+			};
+
+			traverser.traverseSync(sourceCode, visitor);
+
+			assert(visitor.callSync.calledTwice);
+			assert(
+				visitor.callSync.firstCall.calledWith(
+					"Foo",
+					dummyNode,
+					dummyParent,
+				),
+			);
+			assert(
+				visitor.callSync.secondCall.calledWith(
+					"Foo:exit",
+					dummyNode,
+					dummyParent,
+				),
+			);
+		});
+
 		it("should use provided steps instead of source code traverse", () => {
 			// Create a source code object with normal traverse behavior
 			const fooNode = { type: "Foo", value: 1 };


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

The purpose of this pull request is to enable visitors to receive the full set of arguments provided by traversal steps, not just the node. Specifically, `SourceCodeTraverser.traverseSync()` now forwards `step.args` to `visitor.callSync()` for both enter and exit phases, falling back to `[node]` when `args` are not provided. For non-JS languages, the parent node is commonly included as the second element in `step.args` (i.e., `[node, parent]`).

fixes https://github.com/eslint/eslint/issues/20261

#### What changes did you make? (Give an overview)

- Forward `step.args` to visitors in `SourceCodeTraverser.traverseSync()` for enter/exit phases.
- Add unit test to verify that `step.args` is forwarded.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
