### PR TITLE
docs: fix correct tag of `no-useless-constructor`

### DIFF
--- a/docs/src/rules/no-useless-constructor.md
+++ b/docs/src/rules/no-useless-constructor.md
@@ -115,6 +115,8 @@ class C {
 }
 ```
 
+:::
+
 ## When Not To Use It
 
 If you don't want to be notified about unnecessary constructors, you can safely disable this rule.


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Fixed the correct tag of [no-useless-constructor](https://eslint.org/docs/latest/rules/no-useless-constructor) by closing it. It causes misplace of `open to playground` button.

<img width="403" height="298" alt="Screenshot 2025-10-29 133600" src="https://github.com/user-attachments/assets/d900a509-b021-4ee2-b2a4-e895923c0e20" />


#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
