### PR TITLE
feat: update error loc to key in `no-dupe-class-members`

### DIFF
--- a/lib/rules/no-dupe-class-members.js
+++ b/lib/rules/no-dupe-class-members.js
@@ -106,7 +106,7 @@ module.exports = {
 
 				if (isDuplicate) {
 					context.report({
-						node,
+						loc: node.key.loc,
 						messageId: "unexpected",
 						data: { name },
 					});

--- a/tests/lib/rules/no-dupe-class-members.js
+++ b/tests/lib/rules/no-dupe-class-members.js
@@ -65,6 +65,8 @@ ruleTester.run("no-dupe-class-members", rule, {
 				{
 					line: 1,
 					column: 20,
+					endLine: 1,
+					endColumn: 23,
 					messageId: "unexpected",
 					data: { name: "foo" },
 				},
@@ -76,6 +78,8 @@ ruleTester.run("no-dupe-class-members", rule, {
 				{
 					line: 1,
 					column: 21,
+					endLine: 1,
+					endColumn: 24,
 					messageId: "unexpected",
 					data: { name: "foo" },
 				},
@@ -87,6 +91,8 @@ ruleTester.run("no-dupe-class-members", rule, {
 				{
 					line: 1,
 					column: 22,
+					endLine: 1,
+					endColumn: 27,
 					messageId: "unexpected",
 					data: { name: "foo" },
 				},
@@ -98,6 +104,8 @@ ruleTester.run("no-dupe-class-members", rule, {
 				{
 					line: 1,
 					column: 19,
+					endLine: 1,
+					endColumn: 22,
 					messageId: "unexpected",
 					data: { name: "10" },
 				},
@@ -108,7 +116,9 @@ ruleTester.run("no-dupe-class-members", rule, {
 			errors: [
 				{
 					line: 1,
-					column: 24,
+					column: 25,
+					endLine: 1,
+					endColumn: 30,
 					messageId: "unexpected",
 					data: { name: "foo" },
 				},
@@ -119,7 +129,9 @@ ruleTester.run("no-dupe-class-members", rule, {
 			errors: [
 				{
 					line: 1,
-					column: 31,
+					column: 38,
+					endLine: 1,
+					endColumn: 41,
 					messageId: "unexpected",
 					data: { name: "foo" },
 				},
@@ -130,7 +142,9 @@ ruleTester.run("no-dupe-class-members", rule, {
 			errors: [
 				{
 					line: 1,
-					column: 31,
+					column: 36,
+					endLine: 1,
+					endColumn: 41,
 					messageId: "unexpected",
 					data: { name: "foo" },
 				},
@@ -141,7 +155,9 @@ ruleTester.run("no-dupe-class-members", rule, {
 			errors: [
 				{
 					line: 1,
-					column: 19,
+					column: 20,
+					endLine: 1,
+					endColumn: 22,
 					messageId: "unexpected",
 					data: { name: "" },
 				},
@@ -152,7 +168,9 @@ ruleTester.run("no-dupe-class-members", rule, {
 			errors: [
 				{
 					line: 1,
-					column: 24,
+					column: 25,
+					endLine: 1,
+					endColumn: 30,
 					messageId: "unexpected",
 					data: { name: "foo" },
 				},
@@ -163,7 +181,9 @@ ruleTester.run("no-dupe-class-members", rule, {
 			errors: [
 				{
 					line: 1,
-					column: 35,
+					column: 47,
+					endLine: 1,
+					endColumn: 52,
 					messageId: "unexpected",
 					data: { name: "foo" },
 				},
@@ -174,7 +194,9 @@ ruleTester.run("no-dupe-class-members", rule, {
 			errors: [
 				{
 					line: 1,
-					column: 20,
+					column: 21,
+					endLine: 1,
+					endColumn: 26,
 					messageId: "unexpected",
 					data: { name: "foo" },
 				},
@@ -186,6 +208,8 @@ ruleTester.run("no-dupe-class-members", rule, {
 				{
 					line: 1,
 					column: 28,
+					endLine: 1,
+					endColumn: 33,
 					messageId: "unexpected",
 					data: { name: "foo" },
 				},
@@ -196,7 +220,9 @@ ruleTester.run("no-dupe-class-members", rule, {
 			errors: [
 				{
 					line: 1,
-					column: 29,
+					column: 37,
+					endLine: 1,
+					endColumn: 42,
 					messageId: "unexpected",
 					data: { name: "foo" },
 				},
@@ -207,7 +233,9 @@ ruleTester.run("no-dupe-class-members", rule, {
 			errors: [
 				{
 					line: 1,
-					column: 32,
+					column: 33,
+					endLine: 1,
+					endColumn: 46,
 					messageId: "unexpected",
 					data: { name: "constructor" },
 				},
@@ -218,7 +246,9 @@ ruleTester.run("no-dupe-class-members", rule, {
 			errors: [
 				{
 					line: 1,
-					column: 39,
+					column: 46,
+					endLine: 1,
+					endColumn: 57,
 					messageId: "unexpected",
 					data: { name: "constructor" },
 				},
@@ -229,7 +259,9 @@ ruleTester.run("no-dupe-class-members", rule, {
 			errors: [
 				{
 					line: 1,
-					column: 35,
+					column: 42,
+					endLine: 1,
+					endColumn: 55,
 					messageId: "unexpected",
 					data: { name: "constructor" },
 				},
@@ -240,7 +272,9 @@ ruleTester.run("no-dupe-class-members", rule, {
 			errors: [
 				{
 					line: 1,
-					column: 22,
+					column: 23,
+					endLine: 1,
+					endColumn: 26,
 					messageId: "unexpected",
 					data: { name: "123" },
 				},
@@ -252,6 +286,8 @@ ruleTester.run("no-dupe-class-members", rule, {
 				{
 					line: 1,
 					column: 23,
+					endLine: 1,
+					endColumn: 25,
 					messageId: "unexpected",
 					data: { name: "16" },
 				},
@@ -262,7 +298,9 @@ ruleTester.run("no-dupe-class-members", rule, {
 			errors: [
 				{
 					line: 1,
-					column: 22,
+					column: 23,
+					endLine: 1,
+					endColumn: 26,
 					messageId: "unexpected",
 					data: { name: "100" },
 				},
@@ -273,7 +311,9 @@ ruleTester.run("no-dupe-class-members", rule, {
 			errors: [
 				{
 					line: 1,
-					column: 25,
+					column: 26,
+					endLine: 1,
+					endColumn: 31,
 					messageId: "unexpected",
 					data: { name: "123" },
 				},
@@ -284,7 +324,9 @@ ruleTester.run("no-dupe-class-members", rule, {
 			errors: [
 				{
 					line: 1,
-					column: 28,
+					column: 36,
+					endLine: 1,
+					endColumn: 41,
 					messageId: "unexpected",
 					data: { name: "65" },
 				},
@@ -297,6 +339,8 @@ ruleTester.run("no-dupe-class-members", rule, {
 				{
 					line: 1,
 					column: 23,
+					endLine: 1,
+					endColumn: 26,
 					messageId: "unexpected",
 					data: { name: "123" },
 				},
@@ -308,6 +352,8 @@ ruleTester.run("no-dupe-class-members", rule, {
 				{
 					line: 1,
 					column: 23,
+					endLine: 1,
+					endColumn: 29,
 					messageId: "unexpected",
 					data: { name: "null" },
 				},
@@ -319,12 +365,16 @@ ruleTester.run("no-dupe-class-members", rule, {
 				{
 					line: 1,
 					column: 20,
+					endLine: 1,
+					endColumn: 23,
 					messageId: "unexpected",
 					data: { name: "foo" },
 				},
 				{
 					line: 1,
 					column: 29,
+					endLine: 1,
+					endColumn: 32,
 					messageId: "unexpected",
 					data: { name: "foo" },
 				},
@@ -335,7 +385,9 @@ ruleTester.run("no-dupe-class-members", rule, {
 			errors: [
 				{
 					line: 1,
-					column: 27,
+					column: 34,
+					endLine: 1,
+					endColumn: 37,
 					messageId: "unexpected",
 					data: { name: "foo" },
 				},
@@ -346,7 +398,9 @@ ruleTester.run("no-dupe-class-members", rule, {
 			errors: [
 				{
 					line: 1,
-					column: 20,
+					column: 24,
+					endLine: 1,
+					endColumn: 27,
 					messageId: "unexpected",
 					data: { name: "foo" },
 				},
@@ -358,6 +412,8 @@ ruleTester.run("no-dupe-class-members", rule, {
 				{
 					line: 1,
 					column: 29,
+					endLine: 1,
+					endColumn: 32,
 					messageId: "unexpected",
 					data: { name: "foo" },
 				},
@@ -369,6 +425,8 @@ ruleTester.run("no-dupe-class-members", rule, {
 				{
 					line: 1,
 					column: 16,
+					endLine: 1,
+					endColumn: 19,
 					messageId: "unexpected",
 					data: { name: "foo" },
 				},
@@ -474,10 +532,12 @@ ruleTesterTypeScript.run("no-dupe-class-members", rule, {
 		`,
 			errors: [
 				{
-					column: 5,
 					data: { name: "foo" },
-					line: 4,
 					messageId: "unexpected",
+					line: 4,
+					column: 5,
+					endLine: 4,
+					endColumn: 8,
 				},
 			],
 		},
@@ -490,10 +550,12 @@ ruleTesterTypeScript.run("no-dupe-class-members", rule, {
 				`,
 			errors: [
 				{
-					column: 4,
 					data: { name: "foo" },
-					line: 4,
 					messageId: "unexpected",
+					line: 4,
+					column: 4,
+					endLine: 4,
+					endColumn: 7,
 				},
 			],
 		},
@@ -506,10 +568,12 @@ ruleTesterTypeScript.run("no-dupe-class-members", rule, {
 				`,
 			errors: [
 				{
-					column: 4,
 					data: { name: "foo" },
-					line: 4,
 					messageId: "unexpected",
+					line: 4,
+					column: 4,
+					endLine: 4,
+					endColumn: 9,
 				},
 			],
 		},
@@ -522,10 +586,12 @@ ruleTesterTypeScript.run("no-dupe-class-members", rule, {
 				`,
 			errors: [
 				{
-					column: 4,
 					data: { name: "10" },
-					line: 4,
 					messageId: "unexpected",
+					line: 4,
+					column: 4,
+					endLine: 4,
+					endColumn: 7,
 				},
 			],
 		},
@@ -539,16 +605,20 @@ ruleTesterTypeScript.run("no-dupe-class-members", rule, {
 				`,
 			errors: [
 				{
-					column: 4,
 					data: { name: "foo" },
-					line: 4,
 					messageId: "unexpected",
+					line: 4,
+					column: 4,
+					endLine: 4,
+					endColumn: 7,
 				},
 				{
-					column: 4,
 					data: { name: "foo" },
+					messageId: "unexpected",
 					line: 5,
-					messageId: "unexpected",
+					column: 4,
+					endLine: 5,
+					endColumn: 7,
 				},
 			],
 		},
@@ -561,10 +631,12 @@ ruleTesterTypeScript.run("no-dupe-class-members", rule, {
 				`,
 			errors: [
 				{
-					column: 4,
 					data: { name: "foo" },
-					line: 4,
 					messageId: "unexpected",
+					line: 4,
+					column: 11,
+					endLine: 4,
+					endColumn: 14,
 				},
 			],
 		},
@@ -577,10 +649,12 @@ ruleTesterTypeScript.run("no-dupe-class-members", rule, {
 				`,
 			errors: [
 				{
-					column: 4,
 					data: { name: "foo" },
-					line: 4,
 					messageId: "unexpected",
+					line: 4,
+					column: 8,
+					endLine: 4,
+					endColumn: 11,
 				},
 			],
 		},
@@ -593,10 +667,12 @@ ruleTesterTypeScript.run("no-dupe-class-members", rule, {
 				`,
 			errors: [
 				{
-					column: 4,
 					data: { name: "foo" },
-					line: 4,
 					messageId: "unexpected",
+					line: 4,
+					column: 4,
+					endLine: 4,
+					endColumn: 7,
 				},
 			],
 		},
@@ -609,10 +685,12 @@ ruleTesterTypeScript.run("no-dupe-class-members", rule, {
 				`,
 			errors: [
 				{
-					column: 4,
 					data: { name: "foo" },
-					line: 4,
 					messageId: "unexpected",
+					line: 4,
+					column: 4,
+					endLine: 4,
+					endColumn: 7,
 				},
 			],
 		},
@@ -625,10 +703,12 @@ ruleTesterTypeScript.run("no-dupe-class-members", rule, {
 				`,
 			errors: [
 				{
-					column: 4,
 					data: { name: "foo" },
-					line: 4,
 					messageId: "unexpected",
+					line: 4,
+					column: 4,
+					endLine: 4,
+					endColumn: 7,
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Updated the error location of `no-dupe-class-members` rule to the identifier instead of the whole expression so that it will only highlight the place where we need to change the code to fix the error.

#### Is there anything you'd like reviewers to focus on?
Similar to PR https://github.com/eslint/eslint/pull/20258

<!-- markdownlint-disable-file MD004 -->
