### PR TITLE
fix: Only pass node to JS lang visitor methods

### DIFF
--- a/lib/languages/js/source-code/source-code.js
+++ b/lib/languages/js/source-code/source-code.js
@@ -1303,7 +1303,7 @@ class SourceCode extends TokenStore {
 					new VisitNodeStep({
 						target: node,
 						phase: 1,
-						args: [node, node.parent],
+						args: [node],
 					}),
 				);
 			},
@@ -1312,7 +1312,7 @@ class SourceCode extends TokenStore {
 					new VisitNodeStep({
 						target: node,
 						phase: 2,
-						args: [node, node.parent],
+						args: [node],
 					}),
 				);
 			},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Switched the JS language so it only passes one argument to visitor methods. This restores the previous behavior.

I also added tests to verify this behavior as we didn't have any such tests before.

fixes #20272
refs #20253

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
