### PR TITLE
docs: add jiti example for TypeScript eslint.config.ts in MCP docs

### DIFF
--- a/docs/src/use/mcp.md
+++ b/docs/src/use/mcp.md
@@ -71,20 +71,13 @@ Example configuration:
 
 ```json
 {
-  "servers": {
-    "ESLint": {
-      "type": "stdio",
-      "command": "npx",
-      "args": [
-        "-p",
-        "@eslint/mcp@latest",
-        "-p",
-        "jiti",
-        "-c",
-        "mcp"
-      ]
-    }
-  }
+	"servers": {
+		"ESLint": {
+			"type": "stdio",
+			"command": "npx",
+			"args": ["-p", "@eslint/mcp@latest", "-p", "jiti", "-c", "mcp"]
+		}
+	}
 }
 ```
 


### PR DESCRIPTION
This adds documentation for using the ESLint MCP server when a project uses `eslint.config.ts`. 
Since `jiti` is required to evaluate TypeScript config files, this documents how to invoke MCP with:

npx -p @eslint/mcp@latest -p jiti -c mcp

Closes #20290.
