### PR TITLE
chore: remove legacy eslintrc usage from flat-config-schema test

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,6 @@
     "@babel/preset-env": "^7.4.3",
     "@cypress/webpack-preprocessor": "^6.0.2",
     "@eslint/json": "^0.14.0",
-    "@eslint/eslintrc": "^3.3.1",
     "@trunkio/launcher": "^1.3.4",
     "@types/esquery": "^1.5.4",
     "@types/node": "^22.13.14",

--- a/tests/lib/config/flat-config-schema.js
+++ b/tests/lib/config/flat-config-schema.js
@@ -7,30 +7,6 @@
 
 const { flatConfigSchema } = require("../../../lib/config/flat-config-schema");
 const { assert } = require("chai");
-const {
-	Legacy: { ConfigArray },
-} = require("@eslint/eslintrc");
-
-/**
- * This function checks the result of merging two values in eslintrc config.
- * It uses deep strict equality to compare the actual and the expected results.
- * This is useful to ensure that the flat config merge logic behaves similarly to the old logic.
- * When eslintrc is removed, this function and its invocations can be also removed.
- * @param {Object} [first] The base object.
- * @param {Object} [second] The overrides object.
- * @param {Object} [expectedResult] The expected results of merging first and second values.
- * @returns {void}
- */
-function confirmLegacyMergeResult(first, second, expectedResult) {
-	const configArray = new ConfigArray(
-		{ settings: first },
-		{ settings: second },
-	);
-	const config = configArray.extractConfig("/file");
-	const actualResult = config.settings;
-
-	assert.deepStrictEqual(actualResult, expectedResult);
-}
 
 describe("merge", () => {
 	const { merge } = flatConfigSchema.settings;
@@ -41,14 +17,12 @@ describe("merge", () => {
 		const result = merge(first, second);
 
 		assert.deepStrictEqual(result, { ...first, ...second });
-		confirmLegacyMergeResult(first, second, result);
 	});
 
 	it("returns an empty object if both values are undefined", () => {
 		const result = merge(void 0, void 0);
 
 		assert.deepStrictEqual(result, {});
-		confirmLegacyMergeResult(void 0, void 0, result);
 	});
 
 	it("returns an object equal to the first one if the second one is undefined", () => {
@@ -57,7 +31,6 @@ describe("merge", () => {
 
 		assert.deepStrictEqual(result, first);
 		assert.notStrictEqual(result, first);
-		confirmLegacyMergeResult(first, void 0, result);
 	});
 
 	it("returns an object equal to the second one if the first one is undefined", () => {
@@ -66,7 +39,6 @@ describe("merge", () => {
 
 		assert.deepStrictEqual(result, second);
 		assert.notStrictEqual(result, second);
-		confirmLegacyMergeResult(void 0, second, result);
 	});
 
 	it("does not preserve the type of merged objects", () => {
@@ -75,7 +47,6 @@ describe("merge", () => {
 		const result = merge(first, second);
 
 		assert.deepStrictEqual(result, {});
-		confirmLegacyMergeResult(first, second, result);
 	});
 
 	it("merges two objects in a property", () => {
@@ -84,7 +55,6 @@ describe("merge", () => {
 		const result = merge(first, second);
 
 		assert.deepStrictEqual(result, { foo: { bar: "baz", qux: 42 } });
-		confirmLegacyMergeResult(first, second, result);
 	});
 
 	it("overwrites an object in a property with an array", () => {
@@ -121,7 +91,6 @@ describe("merge", () => {
 
 		assert.deepStrictEqual(result, first);
 		assert.notStrictEqual(result, first);
-		confirmLegacyMergeResult(first, second, result);
 	});
 
 	it("does not change the prototype of a merged object", () => {
@@ -130,7 +99,6 @@ describe("merge", () => {
 		const result = merge(first, second);
 
 		assert.strictEqual(Object.getPrototypeOf(result), Object.prototype);
-		confirmLegacyMergeResult(first, second, result);
 	});
 
 	it("does not merge the '__proto__' property", () => {
@@ -139,7 +107,6 @@ describe("merge", () => {
 		const result = merge(first, second);
 
 		assert.deepStrictEqual(result, {});
-		confirmLegacyMergeResult(first, second, result);
 	});
 
 	it("overrides a value in a property with null", () => {
@@ -149,7 +116,6 @@ describe("merge", () => {
 
 		assert.deepStrictEqual(result, second);
 		assert.notStrictEqual(result, second);
-		confirmLegacyMergeResult(first, second, result);
 	});
 
 	it("overrides a value in a property with a non-nullish primitive", () => {
@@ -159,7 +125,6 @@ describe("merge", () => {
 
 		assert.deepStrictEqual(result, second);
 		assert.notStrictEqual(result, second);
-		confirmLegacyMergeResult(first, second, result);
 	});
 
 	it("overrides an object in a property with a string", () => {
@@ -169,7 +134,6 @@ describe("merge", () => {
 
 		assert.deepStrictEqual(result, second);
 		assert.notStrictEqual(result, first);
-		confirmLegacyMergeResult(first, second, result);
 	});
 
 	it("overrides a value in a property with a function", () => {
@@ -179,7 +143,6 @@ describe("merge", () => {
 
 		assert.deepStrictEqual(result, second);
 		assert.notProperty(result.someProperty, "foo");
-		confirmLegacyMergeResult(first, second, result);
 	});
 
 	it("overrides a function in a property with an object", () => {
@@ -189,7 +152,6 @@ describe("merge", () => {
 
 		assert.deepStrictEqual(result, second);
 		assert.notProperty(result.someProperty, "foo");
-		confirmLegacyMergeResult(first, second, result);
 	});
 
 	it("sets properties to undefined", () => {
@@ -234,7 +196,6 @@ describe("merge", () => {
 			notMerged1: { first: true },
 			notMerged2: { second: true },
 		});
-		confirmLegacyMergeResult(first, second, result);
 	});
 
 	it("merges objects with self-references", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What does this PR do?

Now that legacy `.eslintrc` support has been removed, this PR removes the `@eslint/eslintrc` dependency and related helper function from the `flat-config-schema` test.

#### What changes did you make? (Give an overview)

- Removed `@eslint/eslintrc` from `package.json`.
- Deleted the `confirmLegacyMergeResult` helper function and all invocations in `tests/lib/config/flat-config-schema.js`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
