### PR TITLE
test: add regression tests for message placeholder interpolation

### DIFF
--- a/tests/lib/linter/interpolate.js
+++ b/tests/lib/linter/interpolate.js
@@ -63,7 +63,7 @@ describe("interpolate()", () => {
 	});
 
 	const values = [
-		// Expected
+		// Expected (officially supported)
 		[1, "1"],
 		[100n, "100"],
 		[true, "true"],
@@ -73,6 +73,7 @@ describe("interpolate()", () => {
 
 		// Unexpected
 		[{ prop: "value" }, "[object Object]"],
+		[{ toString: () => "stringified" }, "stringified"],
 		[[1, 2, 3], "1,2,3"],
 		[new Set([1, 2, 3]), "[object Set]"],
 		[new Map([["prop", "value"]]), "[object Map]"],


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: Regression tests

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Add regression tests for the message placeholder interpolation.
The expected types will be changed in eslint/rewrite#310 which will allow `string | number | bigint | boolean | undefined | null`.
I also included values with non-matching types such as objects and arrays.

#### Is there anything you'd like reviewers to focus on?
Mocha unfortunately does not have support parameterised test cases (`it.each`), so I manually iterate an array to create the test cases, as the implementation for each test case is the same.

<!-- markdownlint-disable-file MD004 -->
