### PR TITLE
fix: prevent using both max and maximum options in max-params rule

### DIFF
--- a/lib/rules/max-params.js
+++ b/lib/rules/max-params.js
@@ -55,6 +55,9 @@ module.exports = {
 							},
 						},
 						additionalProperties: false,
+						not: {
+							required: ["maximum", "max"],
+						},
 					},
 				],
 			},
@@ -75,6 +78,7 @@ module.exports = {
 				Object.hasOwn(option, "maximum") ||
 				Object.hasOwn(option, "max")
 			) {
+				// Note: If both "max" and "maximum" are provided, "maximum" takes priority.
 				numParams = option.maximum || option.max;
 			}
 			countVoidThis = option.countVoidThis;


### PR DESCRIPTION
Fixes #20322

### Description
This PR adds schema validation to the `max-params` rule to prevent both `max` and `maximum` options from being specified together in the configuration.

### Changes
- Added `not: { required: ["maximum", "max"] }` to the rule schema to ensure only one of these options can be used at a time

### Details
Previously, the rule allowed configurations like `{ "max": 2, "maximum": 3 }` without any validation error. Now, ESLint will properly reject such configurations with a schema validation error, as users should specify either `max` OR `maximum`, but not both.

The rule logic already handled both options (using `||` to pick one), but the schema didn't prevent confusion by allowing both simultaneously.