### PR TITLE
docs: no-unsafe-finally note for generator functions

### DIFF
--- a/docs/src/rules/no-unsafe-finally.md
+++ b/docs/src/rules/no-unsafe-finally.md
@@ -169,4 +169,4 @@ let foo = function(a) {
 If you want to allow control flow operations in `finally` blocks, you can turn this rule off.
 
 Note that [using `return` with `try`/`finally` in generator functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator/return#using_return_with_try...finally) can be used to override the value returned.
-That use case is treated as an exception to this rule.
+If you want to use this feature of generator functions, you can disable this rule using an `eslint-disable` comment.


### PR DESCRIPTION
Adds a note regarding a canonical use case for `return` within a `finally` block. Awaiting potential loosening of the rule.

Fixes #20313

<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Update documentation for `no-unsafe-finally` to caveat a canonical use case for [`return` within a `finally` of generator functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator/return) as an acceptable exception to the rule.

As per issue, potentially a precursor to loosening the rule innately when used within generators. 

#### Is there anything you'd like reviewers to focus on?

Nothing in particular.

<!-- markdownlint-disable-file MD004 -->
