### PR TITLE
feat: restrict RuleTester `data` type to primitives

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -1375,7 +1375,12 @@ export namespace RuleTester {
 	interface SuggestionOutput {
 		messageId?: string;
 		desc?: string;
-		data?: Record<string, unknown> | undefined;
+		data?:
+			| Record<
+					string,
+					string | number | boolean | bigint | null | undefined
+			  >
+			| undefined;
 		output: string;
 	}
 
@@ -1387,7 +1392,12 @@ export namespace RuleTester {
 	interface TestCaseError {
 		message?: string | RegExp;
 		messageId?: string;
-		data?: any;
+		data?:
+			| Record<
+					string,
+					string | number | boolean | bigint | null | undefined
+			  >
+			| undefined;
 		line?: number | undefined;
 		column?: number | undefined;
 		endLine?: number | undefined;

--- a/tests/lib/types/types.test.ts
+++ b/tests/lib/types/types.test.ts
@@ -1896,6 +1896,24 @@ ruleTester.run("my-rule", rule, {
 		{ code: "foo", errors: ["foo"] },
 		{ code: "foo", errors: [{ message: "foo" }] },
 		{ code: "foo", errors: [{ message: "foo", data: { foo: true } }] },
+		{
+			code: "foo",
+			errors: [
+				{
+					messageId: "bar",
+					data: {
+						a: "s",
+						b: 1,
+						c: false,
+						d: 1n,
+						e: null,
+						f: undefined,
+						// @ts-expect-error -- invalid `data` value type
+						g: Symbol("x"),
+					},
+				},
+			],
+		},
 		{ code: "foo", errors: [{ message: "foo", line: 0 }] },
 		{
 			code: "foo",
@@ -1909,6 +1927,20 @@ ruleTester.run("my-rule", rule, {
 						},
 						{
 							messageId: "foo",
+							output: "foo",
+						},
+						{
+							messageId: "foo",
+							data: {
+								a: "x",
+								b: 2,
+								c: true,
+								d: 3n,
+								e: null,
+								f: undefined,
+								// @ts-expect-error -- invalid suggestion `data` value type
+								g: Symbol("x"),
+							},
 							output: "foo",
 						},
 					],


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### Background

In the 2025-11-13 TSC meeting, it was decided to to change the type for both fix and suggestions data properties to:
```ts
string | number | boolean | bigint | null | undefined
```

Reference: https://github.com/eslint/rewrite/issues/310#issuecomment-3536736431

#### What changes did you make? (Give an overview)

This PR restricts the allowed types for `RuleTester` `data` to primitives, as defined above.  This applies to both error message `data` and suggestion message `data`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
