### PR TITLE
docs: Add messages property to rule meta documentation

### DIFF
--- a/docs/src/extend/custom-rules.md
+++ b/docs/src/extend/custom-rules.md
@@ -53,6 +53,7 @@ The source file for a rule exports an object with the following properties. Both
     - `recommended`: (`unknown`) For core rules, this is a boolean value specifying whether the rule is enabled by the `recommended` config from `@eslint/js`.
     - `url`: (`string`) Specifies the URL at which the full documentation can be accessed. Code editors often use this to provide a helpful link on highlighted rule violations.
 
+- `messages`: (`object`) An object containing violation and suggestion messages for the rule. Required for core rules and optional for custom rules. Messages can be referenced by their keys (`messageId`s) in `context.report()` calls. See [`messageId`s](#messageids) for more information.
 - `fixable`: (`string`) Either `"code"` or `"whitespace"` if the `--fix` option on the [command line](../use/command-line-interface#--fix) automatically fixes problems reported by the rule.
 
     **Important:** the `fixable` property is mandatory for fixable rules. If this property isn't specified, ESLint will throw an error whenever the rule attempts to produce a fix. Omit the `fixable` property if the rule is not fixable.


### PR DESCRIPTION
Adds the messages property to the meta object description in the custom rules documentation. The messages property is used to define violation and suggestion messages that can be referenced by messageIds in context.report() calls.

Fixes #20311

<!--

    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).

-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

Added the `messages` property to the `meta` object description in the custom rules documentation (`docs/src/extend/custom-rules.md`). The `messages` property was already being used in examples throughout the documentation but was missing from the initial `meta` object description. This change adds a clear description of the property with a link to the [messageIds](#messageids) section where it's discussed in detail.

#### Is there anything you'd like reviewers to focus on?

No specific focus needed. This is a straightforward documentation update that adds the missing `messages` property description to match the existing examples in the documentation.