### PR TITLE
docs: remove `Examples` headings from rule docs

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -695,7 +695,6 @@ target.checkRuleFiles = function () {
 		"Rule Details",
 		"Options",
 		"Environments",
-		"Examples",
 		"Known Limitations",
 		"When Not To Use It",
 		"Compatibility",

--- a/docs/src/rules/generator-star-spacing.md
+++ b/docs/src/rules/generator-star-spacing.md
@@ -94,8 +94,6 @@ In the example configuration above, the top level `"before"` and `"after"` optio
 the rule, while the `"anonymous"` and `"method"` options override the default behavior.
 Overrides can be either an object with `"before"` and `"after"`, or a shorthand string as above.
 
-## Examples
-
 ### before
 
 Examples of **correct** code for this rule with the `"before"` option:

--- a/docs/src/rules/no-new-symbol.md
+++ b/docs/src/rules/no-new-symbol.md
@@ -18,8 +18,6 @@ This throws a `TypeError` exception.
 
 This rule is aimed at preventing the accidental calling of `Symbol` with the `new` operator.
 
-## Examples
-
 Examples of **incorrect** code for this rule:
 
 ::: incorrect

--- a/docs/src/rules/no-restricted-modules.md
+++ b/docs/src/rules/no-restricted-modules.md
@@ -68,8 +68,6 @@ To restrict the use of all Node.js core modules (via <https://github.com/nodejs/
 }
 ```
 
-## Examples
-
 Examples of **incorrect** code for this rule  with sample `"fs", "cluster", "lodash"` restricted modules:
 
 ::: incorrect

--- a/docs/src/rules/object-property-newline.md
+++ b/docs/src/rules/object-property-newline.md
@@ -177,8 +177,6 @@ ESLint does not correct a violation of this rule if a comment immediately preced
 
 As illustrated above, the `--fix` option, applied to this rule, does not comply with other rules, such as `indent`, but, if those other rules are also in effect, the option applies them, too.
 
-## Examples
-
 Examples of **incorrect** code for this rule, with no object option or with `allowAllPropertiesOnSameLine` set to `false`:
 
 ::: incorrect

--- a/docs/src/rules/padding-line-between-statements.md
+++ b/docs/src/rules/padding-line-between-statements.md
@@ -85,8 +85,6 @@ You can supply any number of configurations. If a statement pair matches multipl
     * `"while"` is `while` loop statements.
     * `"with"` is `with` statements.
 
-## Examples
-
 This configuration would require blank lines before all `return` statements, like the [newline-before-return](newline-before-return) rule.
 
 Examples of **incorrect** code for the `[{ blankLine: "always", prev: "*", next: "return" }]` configuration:

--- a/docs/src/rules/sort-imports.md
+++ b/docs/src/rules/sort-imports.md
@@ -65,8 +65,6 @@ Default option settings are:
 }
 ```
 
-## Examples
-
 ### Default settings
 
 Examples of **correct** code for this rule when using default options:

--- a/docs/src/rules/space-in-parens.md
+++ b/docs/src/rules/space-in-parens.md
@@ -135,8 +135,6 @@ Empty parens exception and behavior:
 * `always` excepting `empty` requires `()`
 * `never` excepting `empty` requires `( )` (empty parens without a space is here forbidden)
 
-### Examples
-
 Examples of **incorrect** code for this rule with the `"never", { "exceptions": ["{}"] }` option:
 
 ::: incorrect

--- a/docs/src/rules/template-curly-spacing.md
+++ b/docs/src/rules/template-curly-spacing.md
@@ -27,8 +27,6 @@ This rule has one option which has either `"never"` or `"always"` as value.
 * `"never"` (by default) - Disallows spaces inside of the curly brace pair.
 * `"always"` - Requires one or more spaces inside of the curly brace pair.
 
-## Examples
-
 ### never
 
 Examples of **incorrect** code for this rule with the default `"never"` option:

--- a/docs/src/rules/template-tag-spacing.md
+++ b/docs/src/rules/template-tag-spacing.md
@@ -33,8 +33,6 @@ This rule has one option whose value can be set to `"never"` or `"always"`
 * `"never"` (default) - Disallows spaces between a tag function and its template literal.
 * `"always"` - Requires one or more spaces between a tag function and its template literal.
 
-## Examples
-
 ### never
 
 Examples of **incorrect** code for this rule with the default `"never"` option:

--- a/docs/src/rules/yield-star-spacing.md
+++ b/docs/src/rules/yield-star-spacing.md
@@ -36,8 +36,6 @@ The option also has a string shorthand:
 "yield-star-spacing": ["error", "after"]
 ```
 
-## Examples
-
 ### after
 
 Examples of **correct** code for this rule with the default `"after"` option:


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Refs https://github.com/eslint/eslint/issues/20331

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Removes `Examples` heading from several rule docs that still have it and disallows adding this heading (by `node Makefile.js checkRuleFiles` check).

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
