### PR TITLE
fix: correct `no-restricted-import` messages

### DIFF
--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -11,6 +11,30 @@
 const astUtils = require("./utils/ast-utils");
 
 //------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Format import names for error messages.
+ * @param {string[]} importNames The import names to format.
+ * @returns {string} The formatted import names.
+ */
+function formatImportNames(importNames) {
+	return new Intl.ListFormat("en-US").format(
+		importNames.map(name => `'${name}'`),
+	);
+}
+
+/**
+ * Returns "is" or "are" based on the number of import names.
+ * @param {string[]} importNames The import names to check.
+ * @returns {string} "is" if one import name, otherwise "are".
+ */
+function isOrAre(importNames) {
+	return importNames.length === 1 ? "is" : "are";
+}
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -175,22 +199,22 @@ module.exports = {
 				"'{{importName}}' import from '{{importSource}}' is restricted from being used by a pattern. {{customMessage}}",
 
 			patternAndEverything:
-				"* import is invalid because '{{importNames}}' from '{{importSource}}' is restricted from being used by a pattern.",
+				"* import is invalid because {{importNames}} from '{{importSource}}' {{isOrAre}} restricted from being used by a pattern.",
 
 			patternAndEverythingWithRegexImportName:
 				"* import is invalid because import name matching '{{importNames}}' pattern from '{{importSource}}' is restricted from being used.",
 			patternAndEverythingWithCustomMessage:
 				// eslint-disable-next-line eslint-plugin/report-message-format -- Custom message might not end in a period
-				"* import is invalid because '{{importNames}}' from '{{importSource}}' is restricted from being used by a pattern. {{customMessage}}",
+				"* import is invalid because {{importNames}} from '{{importSource}}' {{isOrAre}} restricted from being used by a pattern. {{customMessage}}",
 			patternAndEverythingWithRegexImportNameAndCustomMessage:
 				// eslint-disable-next-line eslint-plugin/report-message-format -- Custom message might not end in a period
 				"* import is invalid because import name matching '{{importNames}}' pattern from '{{importSource}}' is restricted from being used. {{customMessage}}",
 
 			everything:
-				"* import is invalid because '{{importNames}}' from '{{importSource}}' is restricted.",
+				"* import is invalid because {{importNames}} from '{{importSource}}' {{isOrAre}} restricted.",
 			everythingWithCustomMessage:
 				// eslint-disable-next-line eslint-plugin/report-message-format -- Custom message might not end in a period
-				"* import is invalid because '{{importNames}}' from '{{importSource}}' is restricted. {{customMessage}}",
+				"* import is invalid because {{importNames}} from '{{importSource}}' {{isOrAre}} restricted. {{customMessage}}",
 
 			importName:
 				"'{{importName}}' import from '{{importSource}}' is restricted.",
@@ -199,16 +223,16 @@ module.exports = {
 				"'{{importName}}' import from '{{importSource}}' is restricted. {{customMessage}}",
 
 			allowedImportName:
-				"'{{importName}}' import from '{{importSource}}' is restricted because only '{{allowedImportNames}}' import(s) is/are allowed.",
+				"'{{importName}}' import from '{{importSource}}' is restricted because only {{allowedImportNames}} {{isOrAre}} allowed.",
 			allowedImportNameWithCustomMessage:
 				// eslint-disable-next-line eslint-plugin/report-message-format -- Custom message might not end in a period
-				"'{{importName}}' import from '{{importSource}}' is restricted because only '{{allowedImportNames}}' import(s) is/are allowed. {{customMessage}}",
+				"'{{importName}}' import from '{{importSource}}' is restricted because only {{allowedImportNames}} {{isOrAre}} allowed. {{customMessage}}",
 
 			everythingWithAllowImportNames:
-				"* import is invalid because only '{{allowedImportNames}}' from '{{importSource}}' is/are allowed.",
+				"* import is invalid because only {{allowedImportNames}} from '{{importSource}}' {{isOrAre}} allowed.",
 			everythingWithAllowImportNamesAndCustomMessage:
 				// eslint-disable-next-line eslint-plugin/report-message-format -- Custom message might not end in a period
-				"* import is invalid because only '{{allowedImportNames}}' from '{{importSource}}' is/are allowed. {{customMessage}}",
+				"* import is invalid because only {{allowedImportNames}} from '{{importSource}}' {{isOrAre}} allowed. {{customMessage}}",
 
 			allowedImportNamePattern:
 				"'{{importName}}' import from '{{importSource}}' is restricted because only imports that match the pattern '{{allowedImportNamePattern}}' are allowed from '{{importSource}}'.",
@@ -452,7 +476,10 @@ module.exports = {
 									loc: specifier.loc,
 									data: {
 										importSource,
-										importNames: restrictedImportNames,
+										importNames: formatImportNames(
+											restrictedImportNames,
+										),
+										isOrAre: isOrAre(restrictedImportNames),
 										customMessage,
 									},
 								});
@@ -465,7 +492,11 @@ module.exports = {
 									loc: specifier.loc,
 									data: {
 										importSource,
-										allowedImportNames,
+										allowedImportNames:
+											formatImportNames(
+												allowedImportNames,
+											),
+										isOrAre: isOrAre(allowedImportNames),
 										customMessage,
 									},
 								});
@@ -525,7 +556,11 @@ module.exports = {
 										importSource,
 										customMessage,
 										importName,
-										allowedImportNames,
+										allowedImportNames:
+											formatImportNames(
+												allowedImportNames,
+											),
+										isOrAre: isOrAre(allowedImportNames),
 									},
 								});
 							});
@@ -612,7 +647,10 @@ module.exports = {
 							loc: specifier.loc,
 							data: {
 								importSource,
-								importNames: restrictedImportNames,
+								importNames: formatImportNames(
+									restrictedImportNames,
+								),
+								isOrAre: isOrAre(restrictedImportNames),
 								customMessage,
 							},
 						});
@@ -625,7 +663,9 @@ module.exports = {
 							loc: specifier.loc,
 							data: {
 								importSource,
-								allowedImportNames,
+								allowedImportNames:
+									formatImportNames(allowedImportNames),
+								isOrAre: isOrAre(allowedImportNames),
 								customMessage,
 							},
 						});
@@ -713,7 +753,9 @@ module.exports = {
 								importSource,
 								customMessage,
 								importName,
-								allowedImportNames,
+								allowedImportNames:
+									formatImportNames(allowedImportNames),
+								isOrAre: isOrAre(allowedImportNames),
 							},
 						});
 					});

--- a/tests/lib/rules/no-restricted-imports.js
+++ b/tests/lib/rules/no-restricted-imports.js
@@ -1161,13 +1161,13 @@ ruleTester.run("no-restricted-imports", rule, {
 			options: [
 				{
 					name: "foo",
-					importNames: ["DisallowedObject1, DisallowedObject2"],
+					importNames: ["DisallowedObject1", "DisallowedObject2"],
 				},
 			],
 			errors: [
 				{
 					message:
-						"* import is invalid because 'DisallowedObject1, DisallowedObject2' from 'foo' is restricted.",
+						"* import is invalid because 'DisallowedObject1' and 'DisallowedObject2' from 'foo' are restricted.",
 					line: 1,
 					column: 8,
 					endColumn: 9,
@@ -1482,7 +1482,7 @@ ruleTester.run("no-restricted-imports", rule, {
 			errors: [
 				{
 					message:
-						"* import is invalid because 'DisallowedObject,DisallowedObjectTwo' from 'foo' is restricted. Please import 'DisallowedObject' and 'DisallowedObjectTwo' from /bar/ instead.",
+						"* import is invalid because 'DisallowedObject' and 'DisallowedObjectTwo' from 'foo' are restricted. Please import 'DisallowedObject' and 'DisallowedObjectTwo' from /bar/ instead.",
 					line: 1,
 					column: 23,
 					endColumn: 44,
@@ -2230,6 +2230,54 @@ ruleTester.run("no-restricted-imports", rule, {
 			],
 		},
 		{
+			/*
+			 * Star import should be reported for consistency with `paths` option (see: https://github.com/eslint/eslint/pull/16059#discussion_r908749964)
+			 * For example, import * as All allows for calling/referencing the restricted import All.Foo
+			 */
+			code: "import * as All from 'foo-bar-baz';",
+			options: [
+				{
+					patterns: [
+						{
+							group: ["**"],
+							importNames: ["Foo", "Bar"],
+						},
+					],
+				},
+			],
+			errors: [
+				{
+					message:
+						"* import is invalid because 'Foo' and 'Bar' from 'foo-bar-baz' are restricted from being used by a pattern.",
+				},
+			],
+		},
+		{
+			/*
+			 * Star import should be reported for consistency with `paths` option (see: https://github.com/eslint/eslint/pull/16059#discussion_r908749964)
+			 * For example, import * as All allows for calling/referencing the restricted import All.Foo
+			 */
+			code: "import * as AllWithCustomMessage from 'foo-bar-baz';",
+			options: [
+				{
+					patterns: [
+						{
+							group: ["**/*-*-baz"],
+							importNames: ["Foo", "Bar"],
+							message: "Use only 'Baz'.",
+						},
+					],
+				},
+			],
+			errors: [
+				{
+					message:
+						"* import is invalid because 'Foo' and 'Bar' from 'foo-bar-baz' are restricted from being used by a pattern. Use only 'Baz'.",
+				},
+			],
+		},
+		{
+			// 3
 			code: "import def, * as ns from 'mod';",
 			options: [
 				{
@@ -2804,7 +2852,7 @@ ruleTester.run("no-restricted-imports", rule, {
 			errors: [
 				{
 					message:
-						"'DisallowedObject' import from 'foo' is restricted because only 'AllowedObject' import(s) is/are allowed.",
+						"'DisallowedObject' import from 'foo' is restricted because only 'AllowedObject' is allowed.",
 					line: 1,
 					column: 25,
 					endColumn: 41,
@@ -2828,10 +2876,49 @@ ruleTester.run("no-restricted-imports", rule, {
 			errors: [
 				{
 					message:
-						"'DisallowedObject' import from 'foo' is restricted because only 'AllowedObject' import(s) is/are allowed. Only 'AllowedObject' is allowed to be imported from 'foo'.",
+						"'DisallowedObject' import from 'foo' is restricted because only 'AllowedObject' is allowed. Only 'AllowedObject' is allowed to be imported from 'foo'.",
 					line: 1,
 					column: 25,
 					endColumn: 41,
+				},
+			],
+		},
+		{
+			code: 'import { GoodThing, BadThing } from "foo";',
+			options: [
+				{
+					paths: [
+						{
+							name: "foo",
+							allowImportNames: ["GoodThing", "AlsoGood"],
+						},
+					],
+				},
+			],
+			errors: [
+				{
+					message:
+						"'BadThing' import from 'foo' is restricted because only 'GoodThing' and 'AlsoGood' are allowed.",
+				},
+			],
+		},
+		{
+			code: 'import { GoodThing, SomethingBad } from "foo";',
+			options: [
+				{
+					paths: [
+						{
+							name: "foo",
+							allowImportNames: ["GoodThing", "AlsoGood"],
+							message: "Only good stuff allowed.",
+						},
+					],
+				},
+			],
+			errors: [
+				{
+					message:
+						"'SomethingBad' import from 'foo' is restricted because only 'GoodThing' and 'AlsoGood' are allowed. Only good stuff allowed.",
 				},
 			],
 		},
@@ -2850,7 +2937,7 @@ ruleTester.run("no-restricted-imports", rule, {
 			errors: [
 				{
 					message:
-						"'DisallowedObject' import from 'foo' is restricted because only 'AllowedObject' import(s) is/are allowed.",
+						"'DisallowedObject' import from 'foo' is restricted because only 'AllowedObject' is allowed.",
 					line: 1,
 					column: 25,
 					endColumn: 41,
@@ -2874,10 +2961,55 @@ ruleTester.run("no-restricted-imports", rule, {
 			errors: [
 				{
 					message:
-						"'DisallowedObject' import from 'foo' is restricted because only 'AllowedObject' import(s) is/are allowed. Only 'AllowedObject' is allowed to be imported from 'foo'.",
+						"'DisallowedObject' import from 'foo' is restricted because only 'AllowedObject' is allowed. Only 'AllowedObject' is allowed to be imported from 'foo'.",
 					line: 1,
 					column: 25,
 					endColumn: 41,
+				},
+			],
+		},
+		{
+			code: 'import { foo, bar, baz, qux } from "foo-bar-baz";',
+			options: [
+				{
+					patterns: [
+						{
+							group: ["foo-bar-baz"],
+							allowImportNames: ["foo", "bar", "baz"],
+						},
+					],
+				},
+			],
+			errors: [
+				{
+					message:
+						"'qux' import from 'foo-bar-baz' is restricted because only 'foo', 'bar', and 'baz' are allowed.",
+					line: 1,
+					column: 25,
+					endColumn: 28,
+				},
+			],
+		},
+		{
+			code: 'import { Allowed1, Disallowed, Allowed2 } from "foo";',
+			options: [
+				{
+					patterns: [
+						{
+							group: ["foo"],
+							allowImportNames: ["Allowed1", "Allowed2"],
+							message: "Fix this please.",
+						},
+					],
+				},
+			],
+			errors: [
+				{
+					message:
+						"'Disallowed' import from 'foo' is restricted because only 'Allowed1' and 'Allowed2' are allowed. Fix this please.",
+					line: 1,
+					column: 20,
+					endColumn: 30,
 				},
 			],
 		},
@@ -2896,7 +3028,7 @@ ruleTester.run("no-restricted-imports", rule, {
 			errors: [
 				{
 					message:
-						"* import is invalid because only 'AllowedObject' from 'foo' is/are allowed.",
+						"* import is invalid because only 'AllowedObject' from 'foo' is allowed.",
 					line: 1,
 					column: 8,
 					endColumn: 26,
@@ -2920,7 +3052,58 @@ ruleTester.run("no-restricted-imports", rule, {
 			errors: [
 				{
 					message:
-						"* import is invalid because only 'AllowedObject' from 'foo' is/are allowed. Only 'AllowedObject' is allowed to be imported from 'foo'.",
+						"* import is invalid because only 'AllowedObject' from 'foo' is allowed. Only 'AllowedObject' is allowed to be imported from 'foo'.",
+					line: 1,
+					column: 8,
+					endColumn: 26,
+				},
+			],
+		},
+		{
+			code: 'import * as AllowedObject from "foo";',
+			options: [
+				{
+					paths: [
+						{
+							name: "foo",
+							allowImportNames: [
+								"AllowedObject",
+								"AnotherObject",
+							],
+						},
+					],
+				},
+			],
+			errors: [
+				{
+					message:
+						"* import is invalid because only 'AllowedObject' and 'AnotherObject' from 'foo' are allowed.",
+					line: 1,
+					column: 8,
+					endColumn: 26,
+				},
+			],
+		},
+		{
+			code: 'import * as AllowedObject from "foo";',
+			options: [
+				{
+					paths: [
+						{
+							name: "foo",
+							allowImportNames: [
+								"AllowedObject",
+								"AnotherObject",
+							],
+							message: "Nothing else.",
+						},
+					],
+				},
+			],
+			errors: [
+				{
+					message:
+						"* import is invalid because only 'AllowedObject' and 'AnotherObject' from 'foo' are allowed. Nothing else.",
 					line: 1,
 					column: 8,
 					endColumn: 26,
@@ -2942,7 +3125,7 @@ ruleTester.run("no-restricted-imports", rule, {
 			errors: [
 				{
 					message:
-						"* import is invalid because only 'AllowedObject' from 'foo/bar' is/are allowed.",
+						"* import is invalid because only 'AllowedObject' from 'foo/bar' is allowed.",
 					line: 1,
 					column: 8,
 					endColumn: 26,
@@ -2966,10 +3149,38 @@ ruleTester.run("no-restricted-imports", rule, {
 			errors: [
 				{
 					message:
-						"* import is invalid because only 'AllowedObject' from 'foo/bar' is/are allowed. Only 'AllowedObject' is allowed to be imported from 'foo'.",
+						"* import is invalid because only 'AllowedObject' from 'foo/bar' is allowed. Only 'AllowedObject' is allowed to be imported from 'foo'.",
 					line: 1,
 					column: 8,
 					endColumn: 26,
+				},
+			],
+		},
+		{
+			code: 'import * as AllFooBar from "foo/bar";',
+			options: [
+				{
+					patterns: [
+						{
+							group: ["foo/*"],
+							allowImportNames: ["Foo", "Bar"],
+						},
+						{
+							group: ["*/bar"],
+							allowImportNames: ["Foo", "Bar"],
+							message: "Good luck!",
+						},
+					],
+				},
+			],
+			errors: [
+				{
+					message:
+						"* import is invalid because only 'Foo' and 'Bar' from 'foo/bar' are allowed.",
+				},
+				{
+					message:
+						"* import is invalid because only 'Foo' and 'Bar' from 'foo/bar' are allowed. Good luck!",
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR fixes several violation messages in the `no-restricted-imports` rule to make them more grammatically correct, and to avoid formatting arrays as strings in the message data, which results in incorrect spacing and missing quotes.

**Example:**

```js
/* eslint no-restricted-imports: ["error", {
	name: "some-module",
	importNames: ["Foo", "Bar", "Baz"],
}] */

export * from "some-module";
```

[**Playground link**](https://eslint.org/play/#eyJ0ZXh0IjoiLyogZXNsaW50IG5vLXJlc3RyaWN0ZWQtaW1wb3J0czogW1wiZXJyb3JcIiwge1xuXHRuYW1lOiBcInNvbWUtbW9kdWxlXCIsXG5cdGltcG9ydE5hbWVzOiBbXCJGb29cIiwgXCJCYXJcIiwgXCJCYXpcIl0sXG59XSAqL1xuXG5leHBvcnQgKiBmcm9tIFwic29tZS1tb2R1bGVcIjtcbiIsIm9wdGlvbnMiOnsicnVsZXMiOnt9LCJsYW5ndWFnZU9wdGlvbnMiOnsic291cmNlVHlwZSI6Im1vZHVsZSIsInBhcnNlck9wdGlvbnMiOnsiZWNtYUZlYXR1cmVzIjp7fX19fX0=)

**Before:**

> import is invalid because 'Foo,Bar,Baz' from 'some-module' is restricted.

**After:**

> import is invalid because 'Foo', 'Bar', and 'Baz' from 'some-module' are restricted.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
