### PR TITLE
feat: allow overriding physical filename for child files

### DIFF
--- a/docs/src/extend/custom-processors.md
+++ b/docs/src/extend/custom-processors.md
@@ -65,7 +65,11 @@ module.exports = plugin;
 
 **The `preprocess` method** takes the file contents and filename as arguments, and returns an array of code blocks to lint. The code blocks will be linted separately but still be registered to the filename.
 
-A code block has two properties `text` and `filename`. The `text` property is the content of the block and the `filename` property is the name of the block. The name of the block can be anything, but should include the file extension, which tells ESLint how to process the current block. ESLint checks matching `files` entries in the project's config to determine if the code blocks should be linted.
+A code block has two required properties, `text` and `filename`, and may optionally specify a `physicalFilename`:
+
+- `text` is the content of the block.
+- `filename` is the logical name of the block. The name of the block can be anything, but should include the file extension, which tells ESLint how to process the current block. ESLint checks matching `files` entries in the project's config to determine if the code blocks should be linted.
+- `physicalFilename` is an optional string that indicates the actual path on disk that tools such as parsers should use. When provided, ESLint passes this value as the `filePath` option to the parser while still treating `filename` as the virtual child path for reporting. This is primarily useful for processors that materialize code blocks as real files on disk (for example, to enable typed linting with tools that only operate on real files).
 
 It's up to the plugin to decide if it needs to return just one part of the non-JavaScript file or multiple pieces. For example in the case of processing `.html` files, you might want to return just one item in the array by combining all scripts. However, for `.md` files, you can return multiple items because each JavaScript block might be independent.
 

--- a/lib/languages/js/index.js
+++ b/lib/languages/js/index.js
@@ -236,7 +236,8 @@ module.exports = {
 	 */
 	parse(file, { languageOptions }) {
 		// Note: BOM already removed
-		const { body: text, path: filePath } = file;
+		const { body: text, path, physicalPath } = file;
+		const filePathForParser = physicalPath || path;
 		const textToParse = text.replace(
 			astUtils.shebangPattern,
 			(match, captured) => `//${captured}`,
@@ -253,7 +254,7 @@ module.exports = {
 				comment: true,
 				eslintVisitorKeys: true,
 				eslintScopeManager: true,
-				filePath,
+				filePath: filePathForParser,
 			},
 		);
 
@@ -264,13 +265,13 @@ module.exports = {
 		 * problem that ESLint identified just like any other.
 		 */
 		try {
-			debug("Parsing:", filePath);
+			debug("Parsing:", filePathForParser);
 			const parseResult =
 				typeof parser.parseForESLint === "function"
 					? parser.parseForESLint(textToParse, parserOptions)
 					: { ast: parser.parse(textToParse, parserOptions) };
 
-			debug("Parsing successful:", filePath);
+			debug("Parsing successful:", filePathForParser);
 
 			const {
 				ast,

--- a/lib/services/processor-service.js
+++ b/lib/services/processor-service.js
@@ -69,15 +69,36 @@ class ProcessorService {
 		return {
 			ok: true,
 			files: blocks.map((block, i) => {
-				// Legacy behavior: return the block as a string
+				/*
+				 * Legacy behavior: if the preprocessor returns a string, just
+				 * pass that directly through to the linter.
+				 */
 				if (typeof block === "string") {
 					return block;
 				}
 
-				const filePath = path.join(file.path, `${i}_${block.filename}`);
+				/*
+				 * New behavior: allow processors to optionally specify a
+				 * physical filename for child files. When present, this value
+				 * represents the real path on disk that should be used by
+				 * parsers and other tooling that operate on the filesystem
+				 * (such as TypeScript project services).
+				 *
+				 * For backwards compatibility, we continue to:
+				 * - Derive the virtual path from the parent file path plus
+				 *   the index-prefixed block filename.
+				 * - Default the physical path to the parent's physicalPath
+				 *   when no explicit physicalFilename is provided.
+				 */
+				const virtualPath = path.join(
+					file.path,
+					`${i}_${block.filename}`,
+				);
+				const physicalPath =
+					block.physicalFilename || file.physicalPath;
 
-				return new VFile(filePath, block.text, {
-					physicalPath: file.physicalPath,
+				return new VFile(virtualPath, block.text, {
+					physicalPath,
 				});
 			}),
 		};


### PR DESCRIPTION
## Summary

This PR extends ESLint's processor pipeline and JavaScript language integration to support an optional `physicalFilename` for processor child files. When a processor returns this field for a code block, ESLint now threads it through to the internal `VFile.physicalPath` and uses it as the `filePath` passed to the parser, while preserving the existing virtual child filename for reporting. This enables advanced scenarios—such as typed linting on materialized temp files—without changing behavior for existing processors or configurations that don't opt into `physicalFilename`.

## Motivation

Typed linting via `@typescript-eslint/parser` with `parserOptions.project` or `parserOptions.projectService` can only operate on real files on disk and expects a stable, filesystem-backed `filePath`. Historically, ESLint's processor model has exposed only virtual child file paths such as `file.md/0.ts` or `file.mdc/0_0.ts`, which work well for JS linting and mapping diagnostics back to the origin, but cannot be resolved by TypeScript's project service.  
The related `@eslint/markdown` PR [`eslint/markdown#595`](https://github.com/eslint/markdown/pull/595) introduces an optional mode to materialize fenced code blocks as real temp files while still returning virtual children to ESLint. To make that mode useful for typed linting, ESLint core needs a way for processors to associate each virtual child with its real on-disk path and for parsers to receive that path as `filePath`. This PR adds that capability in an opt‑in and backwards‑compatible way.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes, no api changes)

## Detailed Changes

- **`lib/services/processor-service.js`: Processor child file handling**
  - Keeps the existing behavior for string-returning preprocessors: they are passed through unchanged.
  - When a preprocessor returns an object, continues to compute the virtual child path as:
    - `virtualPath = path.join(parentFile.path, `${index}_${block.filename}`)`.
  - Adds support for an optional `block.physicalFilename` field:
    - If present, uses it as the `physicalPath` for the child `VFile`.
    - If absent, defaults `physicalPath` to the parent file's `physicalPath`, preserving prior behavior.
  - Constructs child `VFile` instances as:
    - `new VFile(virtualPath, block.text, { physicalPath })`.
  - This allows processors that materialize blocks on disk (e.g. `@eslint/markdown`’s new temp-file mode) to attach the real on-disk path to each child, while all existing processors continue to work as before without modification.

- **`lib/languages/js/index.js`: Parser `filePath` selection**
  - Updates the JS language `parse` implementation to use the physical path when available:
    - Reads both `file.path` (virtual) and `file.physicalPath` (real).
    - Computes `filePathForParser = physicalPath || path`.
  - Passes `filePathForParser` into parser options as:
    - `parserOptions.filePath = filePathForParser`.
  - Updates debug logging to reference `filePathForParser` in parse start/success messages.
  - Effectively, for:
    - Normal files and processor children without `physicalFilename`, `physicalPath === path`, so parsers see the same `filePath` as before.
    - Processor children with `physicalFilename` set, parsers (including `@typescript-eslint/parser`) receive the real temp-file path as `filePath`, enabling integration with TypeScript project services while ESLint still reports using the virtual child path.

- **`lib/linter/linter.js`: Rule context physical filename propagation (existing behavior leveraged)**
  - Continues to construct `FileContext` with:
    - `filename` (the reported/virtual filename).
    - `physicalFilename` (the on-disk filename used in rule context), defaulting to `filename` if not provided.
  - When linting processor children, already passes:
    - `filename: block.path` (the virtual child path, e.g. `file.md/0_example-0/a.js`).
    - `physicalFilename: block.physicalPath` (now set from `physicalFilename` when provided by the processor).
  - This means rules can reliably distinguish between `context.filename` (virtual child) and `context.physicalFilename` (real path) when processors opt in.

- **`tests/lib/eslint/eslint.js`: Processor integration tests**
  - Extends the existing `describe("processors", () => { ... })` suite with a new integration test:
    - **Test name:** `"should allow processors to override the physical filename for child files"`.
    - Defines a `test` plugin with a `txt` processor whose `preprocess`:
      - Splits the input into multiple text blocks.
      - For each block, returns an object:
        - `filename: example-${index}/a.js` (virtual child path segment).
        - `text` (block content).
        - `physicalFilename: "child-physical.js"` (a fixed real path used for all children in the test).
    - Configures ESLint with:
      - `processor: "test/txt"` for `*.txt`.
      - A `test-rule` that reports:
        - `context.filename` and `context.physicalFilename` for each `Identifier`.
    - Verifies:
      - `context.filename` retains the original virtual child paths under the parent file:
        - e.g. `<markdown>.txt/0_example-0/a.js`.
      - `context.physicalFilename` reflects the overridden `child-physical.js` value for all child files.
      - Three messages are produced, with the expected `filename` vs `physicalFilename` pairs and identifiers, and no suppressed messages.
  - This test ensures the new `physicalFilename` flow (processor → `VFile.physicalPath` → rule context) behaves as intended and does not regress the existing “subpath” behavior for virtual child filenames.

- **`docs/src/extend/custom-processors.md`: Processor contract documentation**
  - Updates the “Custom Processor Specification” section to explicitly document the extended code block object shape.
  - Clarifies that each code block object:
    - **Required:**
      - `text`: the content of the block to lint.
      - `filename`: the logical (virtual) name of the block, including a file extension used by ESLint to select matching `files` patterns and languages.
    - **Optional:**
      - `physicalFilename`: a string indicating the actual path on disk that tools such as parsers should use.
  - Explains that when `physicalFilename` is provided:
    - ESLint passes it through as the `filePath` option to the parser.
    - ESLint continues to treat `filename` as the virtual child path for reporting and configuration matching.
  - Calls out the primary use case: processors that materialize code blocks as real files on disk (for example, to enable typed linting with `@typescript-eslint/parser` and a TypeScript project service that only understands on-disk files), as implemented in [`@eslint/markdown` PR #595](https://github.com/eslint/markdown/pull/595).

## Testing & Verification

- [x] Unit Tests added/passed
  - Extended `tests/lib/eslint/eslint.js` to cover processors that set `physicalFilename` and verified:
    - The expected `context.filename` (virtual) vs `context.physicalFilename` (real) values.
    - No changes to existing processor tests, including the case where processors return filenames with slashes as subpaths.
  - All existing tests in the ESLint test suite pass after the change.

- [x] Manual verification steps:
  - Configured a local processor in a test project that:
    - Materializes processor children as real temp files and returns them to ESLint with both `filename` and `physicalFilename`.
  - Ran ESLint with:
    - `@typescript-eslint/parser` configured with `parserOptions.project` or `parserOptions.projectService`.
    - A `tsconfig` that includes the temp directory used for materialized files.
  - Confirmed:
    - The processor-created temp files are read by the TypeScript project service based on `filePath` from `physicalFilename`.
    - Typed rules (e.g., unsafe usage checks) execute successfully against code in processor children.
    - ESLint’s reported filenames remain the expected virtual child paths, preserving UX and diagnostics mapping.

## Breaking Changes (if any)

N/A.

- Existing processors that only return `{ text, filename }` continue to behave exactly as before:
  - Child `VFile.path` is still derived from `parent.path` plus an index-prefixed filename.
  - `VFile.physicalPath` still defaults to the parent file’s physical path.
  - Parsers see the same `filePath` when `physicalFilename` is not provided.
- The new `physicalFilename` field is fully optional and only affects behavior when processors explicitly opt in.