### PR TITLE
fix: correct `Scope` typings

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -139,7 +139,7 @@ export namespace Scope {
 
 		getDeclaredVariables(node: ESTree.Node): Variable[];
 
-		addGlobals(names: string[]): void;
+		addGlobals(names: ReadonlyArray<string>): void;
 	}
 
 	interface Scope {
@@ -185,8 +185,8 @@ export namespace Scope {
 		identifier: ESTree.Identifier | JSXIdentifier;
 		from: Scope;
 		resolved: Variable | null;
-		writeExpr: ESTree.Node | null;
-		init: boolean;
+		writeExpr?: ESTree.Expression | null;
+		init?: boolean;
 
 		isWrite(): boolean;
 

--- a/tests/lib/types/types.test.ts
+++ b/tests/lib/types/types.test.ts
@@ -502,6 +502,8 @@ reference.from = scope;
 reference.identifier.type = "Identifier";
 reference.identifier.type = "JSXIdentifier";
 reference.resolved = variable;
+reference.writeExpr = { type: "Identifier", name: "foo" };
+// @ts-expect-error
 reference.writeExpr = AST;
 reference.init = true;
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

refs https://github.com/eslint/js/pull/709#discussion_r2627664606

#### What changes did you make? (Give an overview)

This PR updates TypeScript definitions in the `Scope` namespace to accurately reflect the implementation:

- Made `writeExpr` and `init` optional in `Reference` interface. These properties are conditionally set only when `isWrite()` returns `true`.
- Narrowed `writeExpr` type from `ESTree.Node` to `ESTree.Expression`.
- Updated `addGlobals` to accept `ReadonlyArray<string>`. This provides better type safety by indicating the parameter shouldn't be mutated.

**Questions for reviewers**:

1. Should we add deprecated methods/properties to the typings? For example, `Reference.isStatic()`, `Scope.taints` etc. Should we include them with `@deprecated` JSDoc?
2. `ScopeManager` has a couple of non-deprecated methods that are not documented and not added to typings: `release()` and `isGlobalReturn()`. Should we document these and add types for them?

<!-- markdownlint-disable-file MD004 -->