### PR TITLE
test: replace deprecated rules in `linter` tests

### DIFF
--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -1667,12 +1667,12 @@ describe("Linter with FlatConfigArray", () => {
 
 	describe("verify()", () => {
 		it("should report warnings in order by line and column when called", () => {
-			const code = "foo()\n    alert('test')";
+			const code = "var foo\n    alert('t\\est')";
 			const config = {
 				rules: {
-					"no-mixed-spaces-and-tabs": 1, // TODO
-					"eol-last": 1, // TODO
-					semi: [1, "always"], // TODO
+					"no-var": 1,
+					"no-alert": 1,
+					"no-useless-escape": 1,
 				},
 			};
 
@@ -1681,22 +1681,22 @@ describe("Linter with FlatConfigArray", () => {
 
 			assert.strictEqual(messages.length, 3);
 			assert.strictEqual(messages[0].line, 1);
-			assert.strictEqual(messages[0].column, 6);
+			assert.strictEqual(messages[0].column, 1);
 			assert.strictEqual(messages[1].line, 2);
-			assert.strictEqual(messages[1].column, 18);
+			assert.strictEqual(messages[1].column, 5);
 			assert.strictEqual(messages[2].line, 2);
-			assert.strictEqual(messages[2].column, 18);
+			assert.strictEqual(messages[2].column, 13);
 
 			assert.strictEqual(suppressedMessages.length, 0);
 		});
 
 		it("should report ignored file when filename isn't matched in the config array", () => {
-			const code = "foo()\n    alert('test')";
+			const code = "var foo\n    alert('t\\est')";
 			const config = {
 				rules: {
-					"no-mixed-spaces-and-tabs": 1, // TODO
-					"eol-last": 1, // TODO
-					semi: [1, "always"], // TODO
+					"no-var": 1,
+					"no-alert": 1,
+					"no-useless-escape": 1,
 				},
 			};
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

In this PR, I replaced deprecated rules in the `linter` tests — `semi`, `quotes`, `no-mixed-spaces-and-tabs`, and `eol-last` — with non-deprecated alternatives: `no-var`, `no-useless-escape`, `no-inline-comments`, and `eqeqeq`.

Those deprecated rules are scheduled for removal (like the references below), so if they are removed in the future the tests may no longer behave as expected.

- Related Issue: https://github.com/eslint/eslint/issues/20097

https://github.com/eslint/eslint/blob/eafd727a060131f7fc79b2eb5698d8d27683c3a2/lib/rules/quotes.js#L104

I've tried to preserve the original intent of the test code and minimize the git diff.

#### Is there anything you'd like reviewers to focus on?

N/A

<!-- markdownlint-disable-file MD004 -->
