### PR TITLE
chore: add JSX language tag validation to `check-rule-examples`

### DIFF
--- a/docs/src/rules/space-before-keywords.md
+++ b/docs/src/rules/space-before-keywords.md
@@ -69,7 +69,7 @@ Examples of **correct** code for this rule with the default `"always"` option:
 
 ::: correct { "parserOptions": { "ecmaFeatures": { "jsx": true } } }
 
-```js
+```jsx
 /*eslint space-before-keywords: ["error", "always"]*/
 
 if (foo) {

--- a/tests/fixtures/bad-examples.md
+++ b/tests/fixtures/bad-examples.md
@@ -134,3 +134,35 @@ const foo = [bar];
 ```
 
 :::
+
+:::correct
+
+```jsx
+/* eslint no-restricted-syntax: ["error", "ArrayPattern"] */
+```
+
+:::
+
+:::correct
+
+```tsx
+/* eslint no-restricted-syntax: ["error", "ArrayPattern"] */
+```
+
+:::
+
+:::correct { "parserOptions": { "ecmaFeatures": { "jsx": false } } }
+
+```jsx
+/* eslint no-restricted-syntax: ["error", "ArrayPattern"] */
+```
+
+:::
+
+:::correct { "parserOptions": { "ecmaFeatures": { "jsx": true } } }
+
+```js
+/* eslint no-restricted-syntax: ["error", "ArrayPattern"] */
+```
+
+:::

--- a/tests/fixtures/good-examples.md
+++ b/tests/fixtures/good-examples.md
@@ -17,6 +17,14 @@ const foo = <bar></bar>;
 
 :::
 
+::: correct { "parserOptions": { "ecmaFeatures": { "jsx": true } } }
+
+```tsx
+const foo = <bar></bar>;
+```
+
+:::
+
 A test with multiple spaces after 'correct':
 <!-- markdownlint-disable-next-line no-trailing-spaces -->
 :::correct  

--- a/tests/tools/check-rule-examples.js
+++ b/tests/tools/check-rule-examples.js
@@ -97,8 +97,13 @@ describe("check-rule-examples", () => {
 				'\tExpected severity of "off", 0, "warn", 1, "error", or 2. You passed "errorr,ArrayPattern". \x1B[2mno-restricted-syntax\x1B[22m\n' +
 				'  \x1B[2m122:1\x1B[22m  \x1B[31merror\x1B[39m  "sourceType": "module" is the default and can be omitted\n' +
 				'  \x1B[2m130:1\x1B[22m  \x1B[31merror\x1B[39m  "jsx": false is the default and can be omitted\n' +
+				'  \x1B[2m140:4\x1B[22m  \x1B[31merror\x1B[39m  The "jsx" language tag requires JSX to be enabled\n' +
+				'  \x1B[2m148:4\x1B[22m  \x1B[31merror\x1B[39m  The "tsx" language tag requires JSX to be enabled\n' +
+				'  \x1B[2m156:4\x1B[22m  \x1B[31merror\x1B[39m  The "jsx" language tag requires JSX to be enabled\n' +
+				'  \x1B[2m154:1\x1B[22m  \x1B[31merror\x1B[39m  "jsx": false is the default and can be omitted\n' +
+				'  \x1B[2m164:4\x1B[22m  \x1B[31merror\x1B[39m  JSX is enabled, but the code block is tagged as "js". Use "jsx" or "tsx"\n' +
 				"\n" +
-				"\x1B[31m\x1B[1m✖ 20 problems (20 errors, 0 warnings)\x1B[22m\x1B[39m\n" +
+				"\x1B[31m\x1B[1m✖ 25 problems (25 errors, 0 warnings)\x1B[22m\x1B[39m\n" +
 				"\x1B[0m\n";
 
 			assert.strictEqual(normalizedStderr, expectedStderr);

--- a/tools/check-rule-examples.js
+++ b/tools/check-rule-examples.js
@@ -139,6 +139,30 @@ async function findProblems(filename) {
 				});
 			}
 
+			const isJsxTag = languageTag === "jsx" || languageTag === "tsx";
+			const jsxEnabled =
+				languageOptions.parserOptions?.ecmaFeatures?.jsx === true;
+
+			if (jsxEnabled && !isJsxTag) {
+				problems.push({
+					fatal: false,
+					severity: 2,
+					message: `JSX is enabled, but the code block is tagged as "${languageTag}". Use "jsx" or "tsx".`,
+					line: codeBlockToken.map[0] + 1,
+					column: codeBlockToken.markup.length + 1,
+				});
+			}
+
+			if (!jsxEnabled && isJsxTag) {
+				problems.push({
+					fatal: false,
+					severity: 2,
+					message: `The "${languageTag}" language tag requires JSX to be enabled.`,
+					line: codeBlockToken.map[0] + 1,
+					column: codeBlockToken.markup.length + 1,
+				});
+			}
+
 			validateLanguageOptions(
 				languageOptions,
 				codeBlockToken.map[0] - 1,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR adds validation to `check-rule-examples.js` to ensure consistency between JSX language tags (`jsx`/`tsx`) and the `jsx` parser option in rule examples. The validation catches mismatches where JSX is enabled but the language tag doesn't indicate JSX syntax, or where JSX language tags are used without JSX being enabled.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
