### PR TITLE
fix: remove `ecmaVersion` and `sourceType` from `ParserOptions` type

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -53,7 +53,6 @@ import type {
 	EcmaVersion as CoreEcmaVersion,
 	ConfigOverride as CoreConfigOverride,
 	ProcessorFile as CoreProcessorFile,
-	JavaScriptParserOptionsConfig,
 	RulesMeta,
 	RuleConfig,
 	RuleTextEditor,
@@ -933,7 +932,43 @@ export namespace Linter {
 	 *
 	 * @see [Specifying Parser Options](https://eslint.org/docs/latest/use/configure/language-options#specifying-parser-options)
 	 */
-	type ParserOptions = JavaScriptParserOptionsConfig;
+	interface ParserOptions {
+		/**
+		 * Allow the use of reserved words as identifiers (if `ecmaVersion` is 3).
+		 *
+		 * @default false
+		 */
+		allowReserved?: boolean | undefined;
+		/**
+		 * An object indicating which additional language features you'd like to use.
+		 *
+		 * @see https://eslint.org/docs/latest/use/configure/language-options#specifying-parser-options
+		 */
+		ecmaFeatures?:
+			| {
+					/**
+					 * Allow `return` statements in the global scope.
+					 *
+					 * @default false
+					 */
+					globalReturn?: boolean | undefined;
+					/**
+					 * Enable global [strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) (if `ecmaVersion` is 5 or greater).
+					 *
+					 * @default false
+					 */
+					impliedStrict?: boolean | undefined;
+					/**
+					 * Enable [JSX](https://facebook.github.io/jsx/).
+					 *
+					 * @default false
+					 */
+					jsx?: boolean | undefined;
+					[key: string]: any;
+			  }
+			| undefined;
+		[key: string]: any;
+	}
 
 	/**
 	 * Options used for linting code with `Linter#verify` and `Linter#verifyAndFix`.


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR updates the `Linter.ParserOptions` type definition to remove the `ecmaVersion` and `sourceType` properties, as they are configured at the `languageOptions` level, not within `parserOptions`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
