### PR TITLE
chore: remove `category` from type test fixtures

### DIFF
--- a/tests/lib/types/types.test.ts
+++ b/tests/lib/types/types.test.ts
@@ -573,7 +573,6 @@ rule = {
 	meta: {
 		docs: {
 			description: "disallow the use of `console`",
-			category: "Possible Errors",
 			recommended: true,
 			url: "https://eslint.org/docs/rules/no-console",
 		},
@@ -685,7 +684,6 @@ rule = {
 	meta: {
 		docs: {
 			description: "disallow the use of `console`",
-			category: "Possible Errors",
 			recommended: true,
 			url: "https://eslint.org/docs/rules/no-console",
 		},
@@ -1597,7 +1595,6 @@ linterWithEslintrcConfig.verify(
 		type: "suggestion",
 		docs: {
 			description: "disallow unnecessary semicolons",
-			category: "Possible Errors",
 			recommended: true,
 			url: "https://eslint.org/docs/rules/no-extra-semi",
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR updates our type tests to align with https://github.com/eslint/rewrite/pull/345, which removes the `category` property from the `RulesMetaDocs` interface.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
