### PR TITLE
chore: remove `category` from formatter test fixtures

### DIFF
--- a/tests/lib/cli-engine/formatters/html.js
+++ b/tests/lib/cli-engine/formatters/html.js
@@ -112,7 +112,6 @@ describe("formatter:html", () => {
 
 				docs: {
 					description: "This is rule 'foo'",
-					category: "error",
 					recommended: true,
 					url: "https://eslint.org/docs/rules/foo",
 				},
@@ -226,7 +225,6 @@ describe("formatter:html", () => {
 
 				docs: {
 					description: "This is rule 'foo'",
-					category: "error",
 					recommended: true,
 					url: "https://eslint.org/docs/rules/foo",
 				},
@@ -303,7 +301,6 @@ describe("formatter:html", () => {
 
 				docs: {
 					description: "This is rule 'foo'",
-					category: "error",
 					recommended: true,
 					url: "https://eslint.org/docs/rules/foo",
 				},
@@ -414,7 +411,6 @@ describe("formatter:html", () => {
 
 				docs: {
 					description: "This is rule 'foo'",
-					category: "error",
 					recommended: true,
 					url: "https://eslint.org/docs/rules/foo",
 				},
@@ -430,7 +426,6 @@ describe("formatter:html", () => {
 
 				docs: {
 					description: "This is rule 'bar'",
-					category: "error",
 					recommended: false,
 				},
 
@@ -519,7 +514,6 @@ describe("formatter:html", () => {
 
 				docs: {
 					description: "This is rule 'foo'",
-					category: "error",
 					recommended: true,
 					url: "https://eslint.org/docs/rules/foo",
 				},
@@ -535,7 +529,6 @@ describe("formatter:html", () => {
 
 				docs: {
 					description: "This is rule 'bar'",
-					category: "error",
 					recommended: false,
 				},
 
@@ -637,7 +630,6 @@ describe("formatter:html", () => {
 
 				docs: {
 					description: "This is rule 'foo'",
-					category: "error",
 					recommended: true,
 					url: "https://eslint.org/docs/rules/foo",
 				},
@@ -653,7 +645,6 @@ describe("formatter:html", () => {
 
 				docs: {
 					description: "This is rule 'bar'",
-					category: "error",
 					recommended: false,
 				},
 
@@ -755,7 +746,6 @@ describe("formatter:html", () => {
 
 				docs: {
 					description: "This is rule 'foo'",
-					category: "error",
 					recommended: true,
 					url: "https://eslint.org/docs/rules/foo",
 				},
@@ -839,7 +829,6 @@ describe("formatter:html", () => {
 
 				docs: {
 					description: "This is rule 'foo'",
-					category: "error",
 					recommended: true,
 					url: "https://eslint.org/docs/rules/foo",
 				},

--- a/tests/lib/cli-engine/formatters/json-with-metadata.js
+++ b/tests/lib/cli-engine/formatters/json-with-metadata.js
@@ -23,7 +23,6 @@ describe("formatter:json", () => {
 
 			docs: {
 				description: "This is rule 'foo'",
-				category: "error",
 				recommended: true,
 				url: "https://eslint.org/docs/rules/foo",
 			},
@@ -39,7 +38,6 @@ describe("formatter:json", () => {
 
 			docs: {
 				description: "This is rule 'bar'",
-				category: "error",
 				recommended: false,
 			},
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Removed all instances of the `category` property from rule metadata in formatter test fixtures

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
