### PR TITLE
fix: error location should not modify error message in RuleTester

### DIFF
--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -1708,7 +1708,7 @@ class RuleTester {
 										error.scenarioType = "valid";
 										error.scenarioIndex = index;
 										error.stack = error.stack.replace(
-											/ +at /u,
+											/^ +at /mu,
 											[
 												`    at RuleTester.run.valid[${index}]`,
 												`    at RuleTester.run.valid`,
@@ -1750,7 +1750,7 @@ class RuleTester {
 										error.scenarioIndex = index;
 										const errorIndex = error.errorIndex;
 										error.stack = error.stack.replace(
-											/ +at /u,
+											/^ +at /mu,
 											[
 												...(typeof errorIndex ===
 												"number"

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -6213,7 +6213,7 @@ describe("RuleTester", () => {
 			} catch (error) {
 				const normalizedStack = normalizeStack(error);
 				assert.include(normalizedStack, "at RuleTester.run.valid[0]");
-				assert.include(normalizedStack, "at RuleTester.run.valid");
+				assert.include(normalizedStack, "at RuleTester.run.valid\n");
 				assert.include(
 					normalizedStack,
 					"at RuleTester.run (tests/lib/rule-tester/rule-tester.js:<lines>)",
@@ -6251,7 +6251,57 @@ describe("RuleTester", () => {
 					"at RuleTester.run.invalid[0].error[1]",
 				);
 				assert.include(normalizedStack, "at RuleTester.run.invalid[0]");
-				assert.include(normalizedStack, "at RuleTester.run.invalid");
+				assert.include(normalizedStack, "at RuleTester.run.invalid\n");
+				assert.include(
+					normalizedStack,
+					"at RuleTester.run (tests/lib/rule-tester/rule-tester.js:<lines>)",
+				);
+			}
+		});
+
+		it("should report the correct location for errors in invalid test cases when a suggestion assertion fails", () => {
+			try {
+				ruleTester.run(
+					"suggestions-basic",
+					require("../../fixtures/testers/rule-tester/suggestions")
+						.basic,
+					{
+						valid: ["var boo;"],
+						invalid: [
+							{
+								code: "var foo;",
+								errors: [
+									{
+										message:
+											"Avoid using identifiers named 'foo'.",
+										suggestions: [
+											{
+												desc: "Rename identifier 'foo' to 'bar'",
+												output: "var baz;", // wrong output
+											},
+										],
+									},
+								],
+							},
+						],
+					},
+				);
+				assert.fail("Expected an error to be thrown");
+			} catch (error) {
+				const normalizedStack = normalizeStack(error);
+
+				// The error message should not be modified although it contains "at"
+				assert.include(
+					normalizedStack,
+					"Expected the applied suggestion fix to match the test suggestion output for suggestion at index: 0",
+				);
+
+				assert.include(
+					normalizedStack,
+					"at RuleTester.run.invalid[0].error[0]",
+				);
+				assert.include(normalizedStack, "at RuleTester.run.invalid[0]");
+				assert.include(normalizedStack, "at RuleTester.run.invalid\n");
 				assert.include(
 					normalizedStack,
 					"at RuleTester.run (tests/lib/rule-tester/rule-tester.js:<lines>)",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:** 22.14.0
- **npm version:** 10.9.2
- **Local ESLint version:** HEAD
- **Global ESLint version:**
- **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

N/A, I'm running RuleTester.

**What did you do? Please include the actual source code causing the issue.**

Modified `output` in a suggestion object in a test case for `no-useless-escape` to a wrong text. Then run:

```
node node_modules/mocha/bin/_mocha tests/lib/rules/no-useless-escape.js
```

**What did you expect to happen?**

```
  1) no-useless-escape
       invalid
         var foo = /\#/;:

      AssertionError [ERR_ASSERTION]: Expected the applied suggestion fix to match the test suggestion output for suggestion at index: 0 on error with message: "Unnecessary escape character: \#."
actual expected

'var foo1 = /#/;'

      + expected - actual

      -var foo = /#/;
      +var foo1 = /#/;

      at RuleTester.run.invalid[0].error[0]
      at RuleTester.run.invalid[0]
      at RuleTester.run.invalid
      at RuleTester.run (tests\lib\rules\no-useless-escape.js:26:12)
      at C:\projects\eslint\lib\rule-tester\rule-tester.js:1628:20
      at Array.forEach (<anonymous>)
      at testInvalidTemplate (lib\rule-tester\rule-tester.js:1469:29)
      at Context.<anonymous> (lib\rule-tester\rule-tester.js:1746:10)
      at process.processImmediate (node:internal/timers:491:21)
```

**What actually happened? Please include the actual, raw output from ESLint.**

The error stack modification for location info mistakenly changes the error message because it contains the word "at", and the output appears broken:

```
  1) no-useless-escape
       invalid
         var foo = /\#/;:

      Expected the applied suggestion fix to match the test suggestion output for suggestion at index: 0 on error with message: "Unnecessary escape character: \#."
actual expected

'var foo1 = /#/;'

      + expected - actual

      -var foo = /#/;
      +var foo1 = /#/;

  AssertionError [ERR_ASSERTION]: Expected the applied suggestion fix to match the test suggestion output for suggestion    at RuleTester.run.invalid[0].error[0]
      at RuleTester.run.invalid[0]
      at RuleTester.run.invalid
      at RuleTester.run (tests\lib\rules\no-useless-escape.js:26:12)
      at index: 0 on error with message: "Unnecessary escape character: \#."
  actual expected

  'var foo1 = /#/;'

      at C:\projects\eslint\lib\rule-tester\rule-tester.js:1628:20
      at Array.forEach (<anonymous>)
      at testInvalidTemplate (lib\rule-tester\rule-tester.js:1469:29)
      at Context.<anonymous> (lib\rule-tester\rule-tester.js:1746:10)
      at process.processImmediate (node:internal/timers:491:21)
```

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Modified the regex that searches for "at" to search for separate lines only.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
