### PR TITLE
feat: fix handling of function and class expression names in `no-shadow`

### DIFF
--- a/docs/src/rules/no-shadow.md
+++ b/docs/src/rules/no-shadow.md
@@ -47,6 +47,34 @@ d(a);
 if (true) {
     const a = 5;
 }
+
+const f = wrap(function f() {});
+
+const C = wrap(class C {});
+```
+
+:::
+
+Function and class names are allowed to shadow a variable if the function/class expression is assigned to the variable as its initializer or default value.
+
+Examples of **correct** code for this rule:
+
+::: correct
+
+```js
+/*eslint no-shadow: "error"*/
+
+const a = function a() {};
+
+const C = class C {};
+
+const b = foo || function b() {};
+
+var c = foo ? function c() {} : bar;
+
+const { d = function d() {} } = foo;
+
+function baz(e = function e() {}) {}
 ```
 
 :::

--- a/docs/src/rules/no-shadow.md
+++ b/docs/src/rules/no-shadow.md
@@ -55,7 +55,6 @@ const C = wrap(class C {});
 
 :::
 
-Function and class names are allowed to shadow a variable if the function/class expression is assigned to the variable as its initializer or default value.
 
 Examples of **correct** code for this rule:
 
@@ -64,17 +63,24 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-shadow: "error"*/
 
-const a = function a() {};
+const a = 3;
+function b(c) {
+    const d = 10;
+    if (c) {
+        const e = 20;
+    }
+}
 
+/*
+ * Function and class names are allowed to shadow a variable
+ * if the function/class expression is assigned to the variable
+ * as its initializer or default value.
+ */
+const f = function f() {};
+const g = foo ? (bar || function g() {}) : baz;
+const { h = function h() {} } = obj;
+function qux(i = function i() {}) {}
 const C = class C {};
-
-const b = foo || function b() {};
-
-var c = foo ? function c() {} : bar;
-
-const { d = function d() {} } = foo;
-
-function baz(e = function e() {}) {}
 ```
 
 :::

--- a/docs/src/rules/no-shadow.md
+++ b/docs/src/rules/no-shadow.md
@@ -55,7 +55,6 @@ const C = wrap(class C {});
 
 :::
 
-
 Examples of **correct** code for this rule:
 
 ::: correct

--- a/lib/rules/no-shadow.js
+++ b/lib/rules/no-shadow.js
@@ -346,17 +346,31 @@ module.exports = {
 		}
 
 		/**
-		 * Checks if a variable is inside the initializer of scopeVar.
+		 * Checks if inner variable is the name of a function or class
+		 * that is assigned to outer variable as its initializer.
 		 *
-		 * To avoid reporting at declarations such as `var a = function a() {};`.
-		 * But it should report `var a = function(a) {};` or `var a = function() { function a() {} };`.
-		 * @param {Object} variable The variable to check.
-		 * @param {Object} scopeVar The scope variable to look for.
-		 * @returns {boolean} Whether or not the variable is inside initializer of scopeVar.
+		 * To avoid reporting at declarations such as:
+		 *    var a = function a() {};
+		 *    var A = class A {};
+		 *    var a = foo || function a() {};
+		 *    var a = foo ? function a() {} : bar;
+		 *    var { a = function a() {} } = foo;
+		 *
+		 * But it should report at declarations such as:
+		 *    var a = function(a) {};
+		 *    var a = function() { function a() {} };
+		 *    var a = wrap(function a() {});
+		 * @param {Object} innerVariable The inner variable to check.
+		 * @param {Object} outerVariable The outer variable.
+		 * @returns {boolean} Whether or not inner variable is the name of a
+		 *   function or class that is assigned to outer variable as its initializer.
 		 */
-		function isOnInitializer(variable, scopeVar) {
-			const outerDef = scopeVar.defs[0];
-			const innerDef = variable.defs[0];
+		function isFunctionNameInitializerException(
+			innerVariable,
+			outerVariable,
+		) {
+			const outerDef = outerVariable.defs[0];
+			const innerDef = innerVariable.defs[0];
 
 			if (!outerDef || !innerDef) {
 				return false;
@@ -373,7 +387,7 @@ module.exports = {
 				return false;
 			}
 
-			const outerIdentifier = scopeVar.defs[0].name;
+			const outerIdentifier = outerDef.name;
 			let initializerNode;
 
 			if (outerIdentifier.parent.type === "VariableDeclarator") {
@@ -627,7 +641,7 @@ module.exports = {
 					shadowed &&
 					(shadowed.identifiers.length > 0 ||
 						(builtinGlobals && "writeable" in shadowed)) &&
-					!isOnInitializer(variable, shadowed) &&
+					!isFunctionNameInitializerException(variable, shadowed) &&
 					!(
 						ignoreOnInitialization &&
 						isInitPatternNode(variable, shadowed)

--- a/lib/rules/no-shadow.js
+++ b/lib/rules/no-shadow.js
@@ -355,23 +355,72 @@ module.exports = {
 		 * @returns {boolean} Whether or not the variable is inside initializer of scopeVar.
 		 */
 		function isOnInitializer(variable, scopeVar) {
-			const outerScope = scopeVar.scope;
 			const outerDef = scopeVar.defs[0];
-			const outer = outerDef && outerDef.parent && outerDef.parent.range;
-			const innerScope = variable.scope;
 			const innerDef = variable.defs[0];
-			const inner = innerDef && innerDef.name.range;
 
-			return (
-				outer &&
-				inner &&
-				outer[0] < inner[0] &&
-				inner[1] < outer[1] &&
-				((innerDef.type === "FunctionName" &&
-					innerDef.node.type === "FunctionExpression") ||
-					innerDef.node.type === "ClassExpression") &&
-				outerScope === innerScope.upper
-			);
+			if (!outerDef || !innerDef) {
+				return false;
+			}
+
+			if (
+				!(
+					(innerDef.type === "FunctionName" &&
+						innerDef.node.type === "FunctionExpression") ||
+					innerDef.node.type === "ClassExpression"
+				)
+			) {
+				return false;
+			}
+
+			const outerIdentifier = scopeVar.defs[0].name;
+			let initializerNode;
+
+			if (outerIdentifier.parent.type === "VariableDeclarator") {
+				initializerNode = outerIdentifier.parent.init;
+			} else if (outerIdentifier.parent.type === "AssignmentPattern") {
+				initializerNode = outerIdentifier.parent.right;
+			}
+
+			if (!initializerNode) {
+				return false;
+			}
+
+			const [start, end] = initializerNode.range;
+
+			let nodeToCheck = innerDef.node; // FunctionExpression or ClassExpression node
+
+			while (
+				start <= nodeToCheck.range[0] &&
+				nodeToCheck.range[1] <= end
+			) {
+				if (nodeToCheck === initializerNode) {
+					return true;
+				}
+
+				const { parent } = nodeToCheck;
+
+				switch (parent.type) {
+					case "LogicalExpression":
+						nodeToCheck = parent;
+						break;
+
+					case "ConditionalExpression":
+						if (
+							nodeToCheck === parent.consequent ||
+							nodeToCheck === parent.alternate
+						) {
+							nodeToCheck = parent;
+							break;
+						} else {
+							return false;
+						}
+
+					default:
+						return false;
+				}
+			}
+
+			return false;
 		}
 
 		/**

--- a/lib/rules/no-shadow.js
+++ b/lib/rules/no-shadow.js
@@ -366,7 +366,8 @@ module.exports = {
 				!(
 					(innerDef.type === "FunctionName" &&
 						innerDef.node.type === "FunctionExpression") ||
-					innerDef.node.type === "ClassExpression"
+					(innerDef.type === "ClassName" &&
+						innerDef.node.type === "ClassExpression")
 				)
 			) {
 				return false;

--- a/lib/rules/no-shadow.js
+++ b/lib/rules/no-shadow.js
@@ -346,6 +346,30 @@ module.exports = {
 		}
 
 		/**
+		 * Finds the uppermost expression node that can evaluate to the given one.
+		 *
+		 * Examples:
+		 *    If given `a` in `a || foo`, it returns the `a || foo` node.
+		 *    If given `a` in `foo ? a : bar`, it returns the `foo ? a : bar` node.
+		 *    If given `a` in `foo ? bar : (baz && a)`, it returns the `foo ? bar : (baz && a)` node.
+		 *    If given `a` in `a ? foo : bar`, it returns the `a` node.
+		 *    If given `a` in `foo(a)`, it returns the `a` node.
+		 * @param {ASTNode} expression The expression node to unwrap.
+		 * @returns {ASTNode} The uppermost ancestor that can evaluate to the given node
+		 *     or the given node if there is no such ancestor.
+		 */
+		function unwrapExpression(expression) {
+			const { parent } = expression;
+
+			const shouldUnwrap =
+				parent.type === "LogicalExpression" ||
+				(parent.type === "ConditionalExpression" &&
+					parent.test !== expression);
+
+			return shouldUnwrap ? unwrapExpression(parent) : expression;
+		}
+
+		/**
 		 * Checks if inner variable is the name of a function or class
 		 * that is assigned to outer variable as its initializer.
 		 *
@@ -400,42 +424,19 @@ module.exports = {
 				return false;
 			}
 
-			const [start, end] = initializerNode.range;
+			const nodeToCheck = innerDef.node; // FunctionExpression or ClassExpression node
 
-			let nodeToCheck = innerDef.node; // FunctionExpression or ClassExpression node
-
-			while (
-				start <= nodeToCheck.range[0] &&
-				nodeToCheck.range[1] <= end
+			// Exit early if the node to check isn't inside the initializer
+			if (
+				!(
+					initializerNode.range[0] <= nodeToCheck.range[0] &&
+					nodeToCheck.range[1] <= initializerNode.range[1]
+				)
 			) {
-				if (nodeToCheck === initializerNode) {
-					return true;
-				}
-
-				const { parent } = nodeToCheck;
-
-				switch (parent.type) {
-					case "LogicalExpression":
-						nodeToCheck = parent;
-						break;
-
-					case "ConditionalExpression":
-						if (
-							nodeToCheck === parent.consequent ||
-							nodeToCheck === parent.alternate
-						) {
-							nodeToCheck = parent;
-							break;
-						} else {
-							return false;
-						}
-
-					default:
-						return false;
-				}
+				return false;
 			}
 
-			return false;
+			return initializerNode === unwrapExpression(nodeToCheck);
 		}
 
 		/**

--- a/tests/lib/rules/no-shadow.js
+++ b/tests/lib/rules/no-shadow.js
@@ -28,6 +28,59 @@ ruleTester.run("no-shadow", rule, {
 	valid: [
 		"var a=3; function b(x) { a++; return x + a; }; setTimeout(function() { b(a); }, 0);",
 		"(function() { var doSomething = function doSomething() {}; doSomething() }())",
+		"(function() { var doSomething = foo || function doSomething() {}; doSomething() }())",
+		"(function() { var doSomething = function doSomething() {} || foo; doSomething() }())",
+		"(function() { var doSomething = foo && function doSomething() {}; doSomething() }())",
+		{
+			code: "(function() { var doSomething = foo ?? function doSomething() {}; doSomething() }())",
+			languageOptions: { ecmaVersion: 2020 },
+		},
+		"(function() { var doSomething = foo || (bar || function doSomething() {}); doSomething() }())",
+		"(function() { var doSomething = foo || (bar && function doSomething() {}); doSomething() }())",
+		"(function() { var doSomething = foo ? function doSomething() {} : bar; doSomething() }())",
+		"(function() { var doSomething = foo ? bar: function doSomething() {}; doSomething() }())",
+		"(function() { var doSomething = foo ? bar: (baz || function doSomething() {}); doSomething() }())",
+		"(function() { var doSomething = (foo ? bar: function doSomething() {}) || baz; doSomething() }())",
+		{
+			code: "(function() { var { doSomething = function doSomething() {} } = obj; doSomething() }())",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "(function() { var { doSomething = function doSomething() {} || foo } = obj; doSomething() }())",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "(function() { var { doSomething = foo ? function doSomething() {} : bar } = obj; doSomething() }())",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "(function() { var { doSomething = foo ? bar : function doSomething() {} } = obj; doSomething() }())",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "(function() { var { doSomething = foo || (bar ? baz : (qux || function doSomething() {})) || quux } = obj; doSomething() }())",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "function foo(doSomething = function doSomething() {}) { doSomething(); }",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "function foo(doSomething = function doSomething() {} || foo) { doSomething(); }",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "function foo(doSomething = foo ? function doSomething() {} : bar) { doSomething(); }",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "function foo(doSomething = foo ? bar : function doSomething() {}) { doSomething(); }",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "function foo(doSomething = foo || (bar ? baz : (qux || function doSomething() {})) || quux) { doSomething(); }",
+			languageOptions: { ecmaVersion: 6 },
+		},
 		"var arguments;\nfunction bar() { }",
 		{
 			code: "var a=3; var b = (x) => { a++; return x + a; }; setTimeout(() => { b(a); }, 0);",
@@ -40,6 +93,86 @@ ruleTester.run("no-shadow", rule, {
 		},
 		{
 			code: "(function() { var A = class A {}; })()",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "(function() { var A = foo || class A {}; })()",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "(function() { var A = class A {} || foo; })()",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "(function() { var A = foo && class A {} || foo; })()",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "(function() { var A = foo ?? class A {}; })()",
+			languageOptions: { ecmaVersion: 2020 },
+		},
+		{
+			code: "(function() { var A = foo || (bar || class A {}); })()",
+			languageOptions: { ecmaVersion: 2020 },
+		},
+		{
+			code: "(function() { var A = foo || (bar && class A {}); })()",
+			languageOptions: { ecmaVersion: 2020 },
+		},
+		{
+			code: "(function() { var A = foo ? class A {} : bar; })()",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "(function() { var A = foo ? bar : class A {}; })()",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "(function() { var A = foo ? bar: (baz || class A {}); })()",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "(function() { var A = (foo ? bar: class A {}) || baz; })()",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "(function() { var { A = class A {} } = obj; }())",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "(function() { var { A = class A {} || foo } = obj; }())",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "(function() { var { A = foo ? class A {} : bar } = obj; }())",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "(function() { var { A = foo ? bar : class A {} } = obj; }())",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "(function() { var { A = foo || (bar ? baz : (qux || class A {})) || quux } = obj; }())",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "function foo(A = class A {}) { doSomething(); }",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "function foo(A = class A {} || foo) { doSomething(); }",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "function foo(A = foo ? class A {} : bar) { doSomething(); }",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "function foo(A = foo ? bar : class A {}) { doSomething(); }",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "function foo(A = foo || (bar ? baz : (qux || class A {})) || quux) { doSomething(); }",
 			languageOptions: { ecmaVersion: 6 },
 		},
 		{ code: "{ var a; } var a;", languageOptions: { ecmaVersion: 6 } }, // this case reports `no-redeclare`, not shadowing.
@@ -1415,6 +1548,217 @@ ruleTester.run("no-shadow", rule, {
 					},
 					line: 1,
 					column: 20,
+				},
+			],
+		},
+
+		// https://github.com/eslint/eslint/issues/20425
+		{
+			code: "let x = false; export const a = wrap(function a() { if (!x) { x = true; a(); } });",
+			options: [{ hoist: "all" }],
+			languageOptions: { ecmaVersion: 6, sourceType: "module" },
+			errors: [
+				{
+					messageId: "noShadow",
+					data: {
+						name: "a",
+						shadowedLine: 1,
+						shadowedColumn: 29,
+					},
+					line: 1,
+					column: 47,
+				},
+			],
+		},
+		{
+			code: "const a = wrap(function a() {});",
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "noShadow",
+					data: {
+						name: "a",
+						shadowedLine: 1,
+						shadowedColumn: 7,
+					},
+					line: 1,
+					column: 25,
+				},
+			],
+		},
+		{
+			code: "const a = foo || wrap(function a() {});",
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "noShadow",
+					data: {
+						name: "a",
+						shadowedLine: 1,
+						shadowedColumn: 7,
+					},
+					line: 1,
+					column: 32,
+				},
+			],
+		},
+		{
+			code: "const { a = wrap(function a() {}) } = obj;",
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "noShadow",
+					data: {
+						name: "a",
+						shadowedLine: 1,
+						shadowedColumn: 9,
+					},
+					line: 1,
+					column: 27,
+				},
+			],
+		},
+		{
+			code: "const { a = foo || wrap(function a() {}) } = obj;",
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "noShadow",
+					data: {
+						name: "a",
+						shadowedLine: 1,
+						shadowedColumn: 9,
+					},
+					line: 1,
+					column: 34,
+				},
+			],
+		},
+		{
+			code: "function foo(a = wrap(function a() {})) {}",
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "noShadow",
+					data: {
+						name: "a",
+						shadowedLine: 1,
+						shadowedColumn: 14,
+					},
+					line: 1,
+					column: 32,
+				},
+			],
+		},
+		{
+			code: "function foo(a = foo || wrap(function a() {})) {}",
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "noShadow",
+					data: {
+						name: "a",
+						shadowedLine: 1,
+						shadowedColumn: 14,
+					},
+					line: 1,
+					column: 39,
+				},
+			],
+		},
+		{
+			code: "const A = wrap(class A {});",
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "noShadow",
+					data: {
+						name: "A",
+						shadowedLine: 1,
+						shadowedColumn: 7,
+					},
+					line: 1,
+					column: 22,
+				},
+			],
+		},
+		{
+			code: "const A = foo || wrap(class A {});",
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "noShadow",
+					data: {
+						name: "A",
+						shadowedLine: 1,
+						shadowedColumn: 7,
+					},
+					line: 1,
+					column: 29,
+				},
+			],
+		},
+		{
+			code: "const { A = wrap(class A {}) } = obj;",
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "noShadow",
+					data: {
+						name: "A",
+						shadowedLine: 1,
+						shadowedColumn: 9,
+					},
+					line: 1,
+					column: 24,
+				},
+			],
+		},
+		{
+			code: "const { A = foo || wrap(class A {}) } = obj;",
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "noShadow",
+					data: {
+						name: "A",
+						shadowedLine: 1,
+						shadowedColumn: 9,
+					},
+					line: 1,
+					column: 31,
+				},
+			],
+		},
+		{
+			code: "function foo(A = wrap(class A {})) {}",
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "noShadow",
+					data: {
+						name: "A",
+						shadowedLine: 1,
+						shadowedColumn: 14,
+					},
+					line: 1,
+					column: 29,
+				},
+			],
+		},
+		{
+			code: "function foo(A = foo || wrap(class A {})) {}",
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "noShadow",
+					data: {
+						name: "A",
+						shadowedLine: 1,
+						shadowedColumn: 14,
+					},
+					line: 1,
+					column: 36,
 				},
 			],
 		},

--- a/tests/lib/rules/no-shadow.js
+++ b/tests/lib/rules/no-shadow.js
@@ -1762,6 +1762,42 @@ ruleTester.run("no-shadow", rule, {
 				},
 			],
 		},
+		{
+			code: "(function Array() {})",
+			options: [{ builtinGlobals: true }],
+			languageOptions: {
+				ecmaVersion: 6,
+				sourceType: "module",
+			},
+			errors: [
+				{
+					messageId: "noShadowGlobal",
+					data: {
+						name: "Array",
+					},
+					line: 1,
+					column: 11,
+				},
+			],
+		},
+		{
+			code: "let a; { let b = (function a() {}) }",
+			languageOptions: {
+				ecmaVersion: 6,
+			},
+			errors: [
+				{
+					messageId: "noShadow",
+					data: {
+						name: "a",
+						shadowedLine: 1,
+						shadowedColumn: 5,
+					},
+					line: 1,
+					column: 28,
+				},
+			],
+		},
 	],
 });
 

--- a/tests/lib/rules/no-shadow.js
+++ b/tests/lib/rules/no-shadow.js
@@ -1635,6 +1635,38 @@ ruleTester.run("no-shadow", rule, {
 			],
 		},
 		{
+			code: "const { a = foo, b = function a() {} } = {}",
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "noShadow",
+					data: {
+						name: "a",
+						shadowedLine: 1,
+						shadowedColumn: 9,
+					},
+					line: 1,
+					column: 31,
+				},
+			],
+		},
+		{
+			code: "const { A = Foo, B = class A {} } = {}",
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "noShadow",
+					data: {
+						name: "A",
+						shadowedLine: 1,
+						shadowedColumn: 9,
+					},
+					line: 1,
+					column: 28,
+				},
+			],
+		},
+		{
 			code: "function foo(a = wrap(function a() {})) {}",
 			languageOptions: { ecmaVersion: 6 },
 			errors: [
@@ -1763,6 +1795,39 @@ ruleTester.run("no-shadow", rule, {
 			],
 		},
 		{
+			code: "var a = function a() {} ? foo : bar",
+			errors: [
+				{
+					messageId: "noShadow",
+					data: {
+						name: "a",
+						shadowedLine: 1,
+						shadowedColumn: 5,
+					},
+					line: 1,
+					column: 18,
+				},
+			],
+		},
+		{
+			code: "var A = class A {} ? foo : bar",
+			languageOptions: {
+				ecmaVersion: 6,
+			},
+			errors: [
+				{
+					messageId: "noShadow",
+					data: {
+						name: "A",
+						shadowedLine: 1,
+						shadowedColumn: 5,
+					},
+					line: 1,
+					column: 15,
+				},
+			],
+		},
+		{
 			code: "(function Array() {})",
 			options: [{ builtinGlobals: true }],
 			languageOptions: {
@@ -1795,6 +1860,24 @@ ruleTester.run("no-shadow", rule, {
 					},
 					line: 1,
 					column: 28,
+				},
+			],
+		},
+		{
+			code: "let a = foo; { let b = (function a() {}) }",
+			languageOptions: {
+				ecmaVersion: 6,
+			},
+			errors: [
+				{
+					messageId: "noShadow",
+					data: {
+						name: "a",
+						shadowedLine: 1,
+						shadowedColumn: 5,
+					},
+					line: 1,
+					column: 34,
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #20425, plus some more false negatives and false positives related to it.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Renamed `function isOnInitializer` to `function isFunctionNameInitializerException` for clarity, and updated it to fix false negatives such as:

```js
/*eslint no-shadow: "error"*/

const a = wrap(function a() {}); // false negative on `a`

const A = wrap(class A {}); // false negative on `A`

const { b = foo, bar = function b() {} } = baz; // false negative on `b`

```

This also fixes what I believe are false positives with default values of function parameters:

```js
/*eslint no-shadow: "error"*/

function foo(a = function a() {}) {} // false positive on `a`

function bar(A = class A {}) {} // false positive on `A`
```



#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
