### PR TITLE
test: add missing location data to no-template-curly-in-string tests

### DIFF
--- a/tests/lib/rules/no-template-curly-in-string.js
+++ b/tests/lib/rules/no-template-curly-in-string.js
@@ -40,31 +40,87 @@ ruleTester.run("no-template-curly-in-string", rule, {
 	invalid: [
 		{
 			code: "'Hello, ${name}'",
-			errors: [{ messageId }],
+			errors: [
+				{
+					messageId,
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 17,
+				},
+			],
 		},
 		{
 			code: '"Hello, ${name}"',
-			errors: [{ messageId }],
+			errors: [
+				{
+					messageId,
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 17,
+				},
+			],
 		},
 		{
 			code: "'${greeting}, ${name}'",
-			errors: [{ messageId }],
+			errors: [
+				{
+					messageId,
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 23,
+				},
+			],
 		},
 		{
 			code: "'Hello, ${index + 1}'",
-			errors: [{ messageId }],
+			errors: [
+				{
+					messageId,
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 22,
+				},
+			],
 		},
 		{
 			code: "'Hello, ${name + \" foo\"}'",
-			errors: [{ messageId }],
+			errors: [
+				{
+					messageId,
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 26,
+				},
+			],
 		},
 		{
 			code: "'Hello, ${name || \"foo\"}'",
-			errors: [{ messageId }],
+			errors: [
+				{
+					messageId,
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 26,
+				},
+			],
 		},
 		{
 			code: "'Hello, ${{foo: \"bar\"}.foo}'",
-			errors: [{ messageId }],
+			errors: [
+				{
+					messageId,
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 29,
+				},
+			],
 		},
 	],
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: Add missing location data to test cases


#### What changes did you make? (Give an overview)

Added `line`, `column`, `endLine`, and `endColumn` properties to 6 test cases in `tests/lib/rules/no-template-curly-in-string.js` that were missing this location information. 

#### Is there anything you'd like reviewers to focus on?

Verification that the `endColumn` values are correct.  

<!-- markdownlint-disable-file MD004 -->
