### PR TITLE
docs: add missing indentation space in rule example

### DIFF
--- a/docs/src/rules/handle-callback-err.md
+++ b/docs/src/rules/handle-callback-err.md
@@ -69,7 +69,7 @@ Examples of **correct** code for this rule with a sample `"error"` parameter nam
 
 function loadData (error, data) {
     if (error) {
-       console.log(error.stack);
+        console.log(error.stack);
     }
     doSomething();
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
The missing indentation space (7 spaces but indentation is 4 spaces per block) in a rule example of `handle-callback-err` was spotted in #20445 but they are not allowed to fill out the CLA.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
