### PR TITLE
chore: ignore `/docs/v9.x` in link checker

### DIFF
--- a/docs/tools/validate-links.js
+++ b/docs/tools/validate-links.js
@@ -20,6 +20,7 @@ const skipPatterns = [
 	"/docs/latest",
 	"/docs/next",
 	"/docs/v8.x",
+	"/docs/v9.x",
 	'src="null"',
 ];
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

After we release v10.0.0 final, a `/docs/v9.x` link will appear on the [versions page](https://eslint.org/docs/latest/versions/), and then our link check (`npm run lint:links` in `docs/`, which we're running in CI) will fail.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added `"/docs/v9.x"` to `skipPatterns`.

#### Is there anything you'd like reviewers to focus on?

This should ideally be merged right before the final v10.0.0 release.

<!-- markdownlint-disable-file MD004 -->
