### PR TITLE
docs: document support for `:is` selector alias

### DIFF
--- a/docs/src/extend/selectors.md
+++ b/docs/src/extend/selectors.md
@@ -45,7 +45,7 @@ The following selectors are supported:
 - following sibling: `VariableDeclaration ~ VariableDeclaration`
 - adjacent sibling: `ArrayExpression > Literal + SpreadElement`
 - negation: `:not(ForStatement)`
-- matches-any: `:matches([attr] > :first-child, :last-child)`
+- matches-any: `:matches([attr] > :first-child, :last-child)` or `:is([attr] > :first-child, :last-child)`
 - class of AST node: `:statement`, `:expression`, `:declaration`, `:function`, or `:pattern`
 
 This syntax is very powerful, and can be used to precisely select many syntactic patterns in your code.

--- a/tests/lib/linter/esquery.js
+++ b/tests/lib/linter/esquery.js
@@ -246,6 +246,17 @@ describe("esquery", () => {
 			assert.strictEqual(result.attributeCount, 3);
 			assert.strictEqual(result.identifierCount, 3);
 		});
+
+		it("should handle :is as an alias for :matches", () => {
+			const result = parse(
+				":is(Identifier[name='foo'], Identifier[name='bar'], Identifier[name='baz'])",
+			);
+
+			assert.strictEqual(result.isExit, false);
+			assert.deepStrictEqual(result.nodeTypes, ["Identifier"]);
+			assert.strictEqual(result.attributeCount, 3);
+			assert.strictEqual(result.identifierCount, 3);
+		});
 	});
 
 	describe("matches()", () => {

--- a/tests/lib/linter/source-code-traverser.js
+++ b/tests/lib/linter/source-code-traverser.js
@@ -572,6 +572,27 @@ describe("SourceCodeTraverser", () => {
 		);
 
 		assertEmissions(
+			"foo + bar + baz",
+			[
+				":is(Identifier[name='foo'], Identifier[name='bar'], Identifier[name='baz'])",
+			],
+			ast => [
+				[
+					":is(Identifier[name='foo'], Identifier[name='bar'], Identifier[name='baz'])",
+					ast.body[0].expression.left.left,
+				], // foo
+				[
+					":is(Identifier[name='foo'], Identifier[name='bar'], Identifier[name='baz'])",
+					ast.body[0].expression.left.right,
+				], // bar
+				[
+					":is(Identifier[name='foo'], Identifier[name='bar'], Identifier[name='baz'])",
+					ast.body[0].expression.right,
+				], // baz
+			],
+		);
+
+		assertEmissions(
 			"foo + 5 + 6",
 			["Identifier, Literal[value=5]"],
 			ast => [

--- a/tests/lib/rules/no-restricted-syntax.js
+++ b/tests/lib/rules/no-restricted-syntax.js
@@ -374,5 +374,34 @@ ruleTester.run("no-restricted-syntax", rule, {
 				},
 			],
 		},
+		{
+			code: "foo + bar + baz",
+			options: [
+				":is(Identifier[name='foo'], Identifier[name='bar'], Identifier[name='baz'])",
+			],
+			errors: [
+				{
+					messageId: "restrictedSyntax",
+					data: {
+						message:
+							"Using ':is(Identifier[name='foo'], Identifier[name='bar'], Identifier[name='baz'])' is not allowed.",
+					},
+				},
+				{
+					messageId: "restrictedSyntax",
+					data: {
+						message:
+							"Using ':is(Identifier[name='foo'], Identifier[name='bar'], Identifier[name='baz'])' is not allowed.",
+					},
+				},
+				{
+					messageId: "restrictedSyntax",
+					data: {
+						message:
+							"Using ':is(Identifier[name='foo'], Identifier[name='bar'], Identifier[name='baz'])' is not allowed.",
+					},
+				},
+			],
+		},
 	],
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

`esquery` v1.7.0 added support for `:is` as an alias for `:matches`. This PR updates the documentation to reflect this and includes test cases to verify that `:is` functions correctly as an alias for `:matches`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
