### PR TITLE
fix: detect default `this` binding in `Array.fromAsync` callbacks

### DIFF
--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -527,6 +527,15 @@ function isArrayFromMethod(node) {
 }
 
 /**
+ * Checks whether or not a node is `Array.fromAsync`.
+ * @param {ASTNode} node A node to check.
+ * @returns {boolean} Whether or not the node is a `Array.fromAsync`.
+ */
+function isArrayFromAsyncMethod(node) {
+	return isSpecificMemberAccess(node, "Array", "fromAsync");
+}
+
+/**
  * Checks whether or not a node is a method which expects a function as a first argument, and `thisArg` as a second argument.
  * @param {ASTNode} node A node to check.
  * @returns {boolean} Whether or not the node is a method which expects a function as a first argument, and `thisArg` as a second argument.
@@ -1462,6 +1471,7 @@ module.exports = {
 	isLoop,
 	isInLoop,
 	isArrayFromMethod,
+	isArrayFromAsyncMethod,
 	isParenthesised,
 	createGlobalLinebreakMatcher,
 	equalTokens,
@@ -1793,7 +1803,10 @@ module.exports = {
 							isNullOrUndefined(parent.arguments[1])
 						);
 					}
-					if (isArrayFromMethod(parent.callee)) {
+					if (
+						isArrayFromMethod(parent.callee) ||
+						isArrayFromAsyncMethod(parent.callee)
+					) {
 						return (
 							parent.arguments.length !== 3 ||
 							parent.arguments[1] !== currentNode ||

--- a/tests/lib/rules/no-eval.js
+++ b/tests/lib/rules/no-eval.js
@@ -135,6 +135,10 @@ ruleTester.run("no-eval", rule, {
 		"array.findLast(function (x) { return this.eval.includes(x); }, { eval: ['foo', 'bar'] });",
 		"callbacks.findLastIndex(function (cb) { return cb(this.eval); }, this);",
 		"['1+1'].flatMap(function (str) { return this.eval(str); }, new Evaluator);",
+		{
+			code: "Array.fromAsync(values, async function (value) { return this.eval(await value); }, context);",
+			languageOptions: { ecmaVersion: 2017 },
+		},
 
 		// Allows indirect eval
 		{ code: "(0, eval)('foo')", options: [{ allowIndirect: true }] },

--- a/tests/lib/rules/no-invalid-this.js
+++ b/tests/lib/rules/no-invalid-this.js
@@ -481,13 +481,13 @@ const patterns = [
 	},
 
 	// Array methods.
-	{
-		code: "Array.from([], function() { console.log(this); z(x => console.log(x, this)); });",
+	...["from", "fromAsync"].map(methodName => ({
+		code: `Array.${methodName}([], function() { console.log(this); z(x => console.log(x, this)); });`,
 		languageOptions: { ecmaVersion: 6 },
 		errors,
 		valid: [NORMAL],
 		invalid: [USE_STRICT, IMPLIED_STRICT, MODULES],
-	},
+	})),
 	...[
 		"every",
 		"filter",
@@ -506,12 +506,12 @@ const patterns = [
 		valid: [NORMAL],
 		invalid: [USE_STRICT, IMPLIED_STRICT, MODULES],
 	})),
-	{
-		code: "Array.from([], function() { console.log(this); z(x => console.log(x, this)); }, obj);",
+	...["from", "fromAsync"].map(methodName => ({
+		code: `Array.${methodName}([], function() { console.log(this); z(x => console.log(x, this)); }, obj);`,
 		languageOptions: { ecmaVersion: 6 },
 		valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
 		invalid: [],
-	},
+	})),
 	...[
 		"every",
 		"filter",
@@ -1124,6 +1124,17 @@ ruleTesterTypeScript.run("no-invalid-this", rule, {
         `,
 
 		`
+    Array.fromAsync(
+      [],
+      function () {
+        console.log(this);
+        z(x => console.log(x, this));
+      },
+      obj,
+    );
+        `,
+
+		`
     foo.every(function () {
       console.log(this);
       z(x => console.log(x, this));
@@ -1598,6 +1609,15 @@ ruleTesterTypeScript.run("no-invalid-this", rule, {
 		{
 			code: `
     Array.from([], function () {
+      console.log(this);
+      z(x => console.log(x, this));
+    });
+          `,
+			errors,
+		},
+		{
+			code: `
+    Array.fromAsync([], function () {
       console.log(this);
       z(x => console.log(x, this));
     });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #20437

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR updates the `isDefaultThisBinding` function in `ast-utils` to detect cases where `this` inside callbacks of 
`Array.fromAsync` refers to a value that is not the global object. This change fixes #20437 and will also report less problems in the `no-eval` rule is some cases, for example:

```js
// script
Array.fromAsync(
  foo,
  function (bar) {
    return this.eval(bar);
  },
  baz,
);
```

[**Playground link**](https://eslint.org/play/#eyJ0ZXh0IjoiLyogZXNsaW50IG5vLWV2YWw6IFtcImVycm9yXCJdICovXG5cbkFycmF5LmZyb21Bc3luYyhcbiAgZm9vLFxuICBmdW5jdGlvbiAoYmFyKSB7XG4gICAgcmV0dXJuIHRoaXMuZXZhbChiYXIpO1xuICB9LFxuICBiYXosXG4pO1xuIiwib3B0aW9ucyI6eyJydWxlcyI6e30sImxhbmd1YWdlT3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFGZWF0dXJlcyI6e319LCJzb3VyY2VUeXBlIjoic2NyaXB0In19fQ==)

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
