### PR TITLE
fix: remove fake `FlatESLint` and `LegacyESLint` exports

### DIFF
--- a/lib/unsupported-api.js
+++ b/lib/unsupported-api.js
@@ -18,9 +18,4 @@ const builtinRules = require("./rules");
 // Exports
 //-----------------------------------------------------------------------------
 
-module.exports = {
-	builtinRules,
-	FlatESLint: null,
-	LegacyESLint: null,
-	shouldUseFlatConfig,
-};
+module.exports = { builtinRules, shouldUseFlatConfig };

--- a/tests/lib/unsupported-api.js
+++ b/tests/lib/unsupported-api.js
@@ -21,19 +21,19 @@ const assert = require("chai").assert,
 
 describe("unsupported-api", () => {
 	it("should not have FileEnumerator exposed", () => {
-		assert.isUndefined(api.FileEnumerator);
+		assert(!("FileEnumerator" in api));
 	});
 
 	it("should not have FlatESLint exposed", () => {
-		assert(!api.FlatESLint);
+		assert(!("FlatESLint" in api));
 	});
 
 	it("should not have LegacyESLint exposed", () => {
-		assert(!api.LegacyESLint);
+		assert(!("LegacyESLint" in api));
 	});
 
 	it("should not have ESLint exposed", () => {
-		assert.isUndefined(api.ESLint);
+		assert(!("ESLint" in api));
 	});
 
 	it("should have shouldUseFlatConfig exposed", () => {
@@ -41,7 +41,7 @@ describe("unsupported-api", () => {
 	});
 
 	it("should not have FlatRuleTester exposed", () => {
-		assert.isUndefined(api.FlatRuleTester);
+		assert(!("FlatRuleTester" in api));
 	});
 
 	it("should have builtinRules exposed", () => {

--- a/tools/typescript-eslint-parser/package.json
+++ b/tools/typescript-eslint-parser/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@typescript-eslint/parser",
   "description": "@typescript-eslint/parser patch for ESLint v10",
-  "version": "8.44.0",
+  "version": "8.54.0",
   "private": true,
   "files": [],
   "dependencies": {
-    "@typescript-eslint/parser-original": "npm:@typescript-eslint/parser@^8.44.0"
+    "@typescript-eslint/parser-original": "npm:@typescript-eslint/parser@^8.54.0"
   }
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Remove exports from use-at-your-own-risk.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR removes the `FlatESLint` and `LegacyESLint` exports from `lib/usupported-api.js`. In #20037 both exports were left set to `null` in order not to break typescript-eslint, which is also used in our build tooling. As of version 8.54.0, typescript-eslint no longer requires these exports, so they can now be removed completely.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
