### PR TITLE
feat: add `self` to `no-implied-eval` rule

### DIFF
--- a/lib/rules/no-implied-eval.js
+++ b/lib/rules/no-implied-eval.js
@@ -41,6 +41,7 @@ module.exports = {
 			"global",
 			"window",
 			"globalThis",
+			"self",
 		]);
 		const EVAL_LIKE_FUNC_PATTERN =
 			/^(?:set(?:Interval|Timeout)|execScript)$/u;

--- a/tests/lib/rules/no-implied-eval.js
+++ b/tests/lib/rules/no-implied-eval.js
@@ -83,6 +83,22 @@ ruleTester.run("no-implied-eval", rule, {
 			code: "globalThis['setTimeout'] = foo;",
 			languageOptions: { ecmaVersion: 2020 },
 		},
+		{
+			code: "self.setTimeout;",
+			languageOptions: { globals: globals.browser },
+		},
+		{
+			code: "self.setTimeout = foo;",
+			languageOptions: { globals: globals.browser },
+		},
+		{
+			code: "self['setTimeout'];",
+			languageOptions: { globals: globals.browser },
+		},
+		{
+			code: "self['setTimeout'] = foo;",
+			languageOptions: { globals: globals.browser },
+		},
 
 		"window.setTimeout('foo')",
 		"window.setInterval('foo')",
@@ -155,6 +171,10 @@ ruleTester.run("no-implied-eval", rule, {
 		{
 			code: "globalThis[`setTimeout${foo}`]('foo', 100);",
 			languageOptions: { ecmaVersion: 2020 },
+		},
+		{
+			code: "self[`SetTimeOut`]('foo', 100);",
+			languageOptions: { ecmaVersion: 6, globals: globals.browser },
 		},
 
 		// normal usage
@@ -233,6 +253,30 @@ ruleTester.run("no-implied-eval", rule, {
 		{
 			code: "globalThis.setTimeout(foo, 100);",
 			languageOptions: { ecmaVersion: 2020 },
+		},
+		{
+			code: "self.setTimeout(function() { x = 1; }, 100);",
+			languageOptions: { globals: globals.browser },
+		},
+		{
+			code: "self.setInterval(function() { x = 1; }, 100);",
+			languageOptions: { globals: globals.browser },
+		},
+		{
+			code: "self.execScript(function() { x = 1; }, 100);",
+			languageOptions: { globals: globals.browser },
+		},
+		{
+			code: "self.setTimeout(foo, 100);",
+			languageOptions: { globals: globals.browser },
+		},
+		{
+			code: "self.setInterval(foo, 100);",
+			languageOptions: { globals: globals.browser },
+		},
+		{
+			code: "self.execScript(foo, 100);",
+			languageOptions: { globals: globals.browser },
 		},
 
 		// only checks on top-level statements or window.*
@@ -329,6 +373,10 @@ ruleTester.run("no-implied-eval", rule, {
 			},
 		},
 		{
+			code: "foo.self.setTimeout('foo', 100);",
+			languageOptions: { globals: globals.browser },
+		},
+		{
 			code: "var window; window.setTimeout('foo', 100);",
 			languageOptions: { globals: globals.browser },
 		},
@@ -337,6 +385,10 @@ ruleTester.run("no-implied-eval", rule, {
 			languageOptions: {
 				sourceType: "commonjs",
 			},
+		},
+		{
+			code: "var self; self.setTimeout('foo', 100);",
+			languageOptions: { globals: globals.browser },
 		},
 		{
 			code: "function foo(window) { window.setTimeout('foo', 100); }",
@@ -349,12 +401,20 @@ ruleTester.run("no-implied-eval", rule, {
 			},
 		},
 		{
+			code: "function foo(self) { self.setTimeout('foo', 100); }",
+			languageOptions: { globals: globals.browser },
+		},
+		{
 			code: "foo('', window.setTimeout);",
 			languageOptions: { globals: globals.browser },
 		},
 		{
 			code: "foo('', global.setTimeout);",
 			languageOptions: { sourceType: "commonjs" },
+		},
+		{
+			code: "foo('', self.setTimeout);",
+			languageOptions: { globals: globals.browser },
 		},
 
 		// https://github.com/eslint/eslint/issues/19923
@@ -676,6 +736,72 @@ ruleTester.run("no-implied-eval", rule, {
 				},
 			],
 		},
+		{
+			code: "self.setTimeout('foo')",
+			languageOptions: { globals: globals.browser },
+			errors: [expectedError],
+		},
+		{
+			code: "self.setInterval('foo')",
+			languageOptions: { globals: globals.browser },
+			errors: [expectedError],
+		},
+		{
+			code: "self.execScript('foo')",
+			languageOptions: { globals: globals.browser },
+			errors: [
+				{
+					messageId: "execScript",
+				},
+			],
+		},
+		{
+			code: "self['setTimeout']('foo')",
+			languageOptions: { globals: globals.browser },
+			errors: [expectedError],
+		},
+		{
+			code: "self['setInterval']('foo')",
+			languageOptions: { globals: globals.browser },
+			errors: [expectedError],
+		},
+		{
+			code: "self[`setInterval`]('foo')",
+			languageOptions: { ecmaVersion: 6, globals: globals.browser },
+			errors: [expectedError],
+		},
+		{
+			code: "self['execScript']('foo')",
+			languageOptions: { globals: globals.browser },
+			errors: [
+				{
+					messageId: "execScript",
+				},
+			],
+		},
+		{
+			code: "self[`execScript`]('foo')",
+			languageOptions: { ecmaVersion: 6, globals: globals.browser },
+			errors: [
+				{
+					messageId: "execScript",
+				},
+			],
+		},
+		{
+			code: "self.self['setInterval']('foo')",
+			languageOptions: { globals: globals.browser },
+			errors: [expectedError],
+		},
+		{
+			code: "self.self['execScript']('foo')",
+			languageOptions: { globals: globals.browser },
+			errors: [
+				{
+					messageId: "execScript",
+				},
+			],
+		},
 
 		// template literals
 		{
@@ -696,6 +822,16 @@ ruleTester.run("no-implied-eval", rule, {
 		{
 			code: "global.global.setTimeout(`foo${bar}`)",
 			languageOptions: { ecmaVersion: 6, globals: globals.node },
+			errors: [expectedError],
+		},
+		{
+			code: "self.setTimeout(`foo${bar}`)",
+			languageOptions: { ecmaVersion: 6, globals: globals.browser },
+			errors: [expectedError],
+		},
+		{
+			code: "self.self.setTimeout(`foo${bar}`)",
+			languageOptions: { ecmaVersion: 6, globals: globals.browser },
 			errors: [expectedError],
 		},
 
@@ -773,6 +909,31 @@ ruleTester.run("no-implied-eval", rule, {
 		{
 			code: "globalThis.setTimeout('foo' + bar)",
 			languageOptions: { ecmaVersion: 2020 },
+			errors: [expectedError],
+		},
+		{
+			code: "self.setTimeout('foo' + bar)",
+			languageOptions: { globals: globals.browser },
+			errors: [expectedError],
+		},
+		{
+			code: "self.setTimeout(foo + 'bar')",
+			languageOptions: { globals: globals.browser },
+			errors: [expectedError],
+		},
+		{
+			code: "self.setTimeout(`foo` + bar)",
+			languageOptions: { ecmaVersion: 6, globals: globals.browser },
+			errors: [expectedError],
+		},
+		{
+			code: "self.setTimeout(1 + ';' + 1)",
+			languageOptions: { globals: globals.browser },
+			errors: [expectedError],
+		},
+		{
+			code: "self.self.setTimeout(1 + ';' + 1)",
+			languageOptions: { globals: globals.browser },
 			errors: [expectedError],
 		},
 
@@ -876,6 +1037,38 @@ ruleTester.run("no-implied-eval", rule, {
 			languageOptions: {
 				ecmaVersion: 2020,
 				globals: { window: "readonly" },
+			},
+			errors: [{ messageId: "execScript" }],
+		},
+		{
+			code: "self?.setTimeout('code', 0)",
+			languageOptions: {
+				ecmaVersion: 2020,
+				globals: { self: "readonly" },
+			},
+			errors: [{ messageId: "impliedEval" }],
+		},
+		{
+			code: "(self?.setTimeout)('code', 0)",
+			languageOptions: {
+				ecmaVersion: 2020,
+				globals: { self: "readonly" },
+			},
+			errors: [{ messageId: "impliedEval" }],
+		},
+		{
+			code: "self?.execScript('code')",
+			languageOptions: {
+				ecmaVersion: 2020,
+				globals: { self: "readonly" },
+			},
+			errors: [{ messageId: "execScript" }],
+		},
+		{
+			code: "(self?.execScript)('code')",
+			languageOptions: {
+				ecmaVersion: 2020,
+				globals: { self: "readonly" },
 			},
 			errors: [{ messageId: "execScript" }],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

Fixes #19950

#### What changes did you make? (Give an overview)
Added `self` to the list of global object candidates in the `no-implied-eval` rule.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
