### PR TITLE
feat: add `self` to `no-implied-eval` rule

### DIFF
--- a/lib/rules/no-implied-eval.js
+++ b/lib/rules/no-implied-eval.js
@@ -41,6 +41,7 @@ module.exports = {
 			"global",
 			"window",
 			"globalThis",
+			"self",
 		]);
 		const EVAL_LIKE_FUNC_PATTERN =
 			/^(?:set(?:Interval|Timeout)|execScript)$/u;

--- a/tests/lib/rules/no-implied-eval.js
+++ b/tests/lib/rules/no-implied-eval.js
@@ -485,6 +485,78 @@ ruleTester.run("no-implied-eval", rule, {
 				globals: {}, // No window global defined
 			},
 		},
+		{
+			code: "self.setTimeout;",
+			languageOptions: { globals: globals.browser },
+		},
+		{
+			code: "self.setTimeout = foo;",
+			languageOptions: { globals: globals.browser },
+		},
+		{
+			code: "self['setTimeout'];",
+			languageOptions: { globals: globals.browser },
+		},
+		{
+			code: "self['setTimeout'] = foo;",
+			languageOptions: { globals: globals.browser },
+		},
+		{
+			code: "self[`SetTimeOut`]('foo', 100);",
+			languageOptions: { ecmaVersion: 6, globals: globals.browser },
+		},
+		{
+			code: "self[`setTimeout${foo}`]('foo', 100);",
+			languageOptions: { ecmaVersion: 6, globals: globals.browser },
+		},
+		{
+			code: "self.setTimeout(function() { x = 1; }, 100);",
+			languageOptions: { globals: globals.browser },
+		},
+		{
+			code: "self.setInterval(function() { x = 1; }, 100);",
+			languageOptions: { globals: globals.browser },
+		},
+		{
+			code: "self.execScript(function() { x = 1; }, 100);",
+			languageOptions: { globals: globals.browser },
+		},
+		{
+			code: "self.setTimeout(foo, 100);",
+			languageOptions: { globals: globals.browser },
+		},
+		{
+			code: "foo.self.setTimeout('foo', 100);",
+			languageOptions: { globals: globals.browser },
+		},
+		{
+			code: "var self; self.setTimeout('foo', 100);",
+			languageOptions: { globals: globals.browser },
+		},
+		{
+			code: "function foo(self) { self.setTimeout('foo', 100); }",
+			languageOptions: { globals: globals.browser },
+		},
+		{
+			code: "foo('', self.setTimeout);",
+			languageOptions: { globals: globals.browser },
+		},
+		{
+			code: `
+			function outer() {
+				function self() {
+					console.log("Shadowed self");
+				}
+				self.setTimeout('code');
+			}`,
+			languageOptions: { globals: globals.browser },
+		},
+		{
+			code: "self.setTimeout('code');",
+			languageOptions: {
+				globals: {}, // No globals defined
+			},
+		},
 	],
 
 	invalid: [
@@ -876,6 +948,139 @@ ruleTester.run("no-implied-eval", rule, {
 			languageOptions: {
 				ecmaVersion: 2020,
 				globals: { window: "readonly" },
+			},
+			errors: [{ messageId: "execScript" }],
+		},
+		{
+			code: "self.setTimeout('foo')",
+			languageOptions: { globals: globals.browser },
+			errors: [expectedError],
+		},
+		{
+			code: "self.setInterval('foo')",
+			languageOptions: { globals: globals.browser },
+			errors: [expectedError],
+		},
+		{
+			code: "self.execScript('foo')",
+			languageOptions: { globals: globals.browser },
+			errors: [
+				{
+					messageId: "execScript",
+				},
+			],
+		},
+		{
+			code: "self['setTimeout']('foo')",
+			languageOptions: { globals: globals.browser },
+			errors: [expectedError],
+		},
+		{
+			code: "self['setInterval']('foo')",
+			languageOptions: { globals: globals.browser },
+			errors: [expectedError],
+		},
+		{
+			code: "self[`setInterval`]('foo')",
+			languageOptions: { ecmaVersion: 6, globals: globals.browser },
+			errors: [expectedError],
+		},
+		{
+			code: "self['execScript']('foo')",
+			languageOptions: { globals: globals.browser },
+			errors: [
+				{
+					messageId: "execScript",
+				},
+			],
+		},
+		{
+			code: "self[`execScript`]('foo')",
+			languageOptions: { ecmaVersion: 6, globals: globals.browser },
+			errors: [
+				{
+					messageId: "execScript",
+				},
+			],
+		},
+		{
+			code: "self.self['setInterval']('foo')",
+			languageOptions: { globals: globals.browser },
+			errors: [expectedError],
+		},
+		{
+			code: "self.self['execScript']('foo')",
+			languageOptions: { globals: globals.browser },
+			errors: [
+				{
+					messageId: "execScript",
+				},
+			],
+		},
+		{
+			code: "self.setTimeout(`foo${bar}`)",
+			languageOptions: { ecmaVersion: 6, globals: globals.browser },
+			errors: [expectedError],
+		},
+		{
+			code: "self.self.setTimeout(`foo${bar}`)",
+			languageOptions: { ecmaVersion: 6, globals: globals.browser },
+			errors: [expectedError],
+		},
+		{
+			code: "self.setTimeout('foo' + bar)",
+			languageOptions: { globals: globals.browser },
+			errors: [expectedError],
+		},
+		{
+			code: "self.setTimeout(foo + 'bar')",
+			languageOptions: { globals: globals.browser },
+			errors: [expectedError],
+		},
+		{
+			code: "self.setTimeout(`foo` + bar)",
+			languageOptions: { ecmaVersion: 6, globals: globals.browser },
+			errors: [expectedError],
+		},
+		{
+			code: "self.setTimeout(1 + ';' + 1)",
+			languageOptions: { globals: globals.browser },
+			errors: [expectedError],
+		},
+		{
+			code: "self.self.setTimeout(1 + ';' + 1)",
+			languageOptions: { globals: globals.browser },
+			errors: [expectedError],
+		},
+		{
+			code: "self?.setTimeout('code', 0)",
+			languageOptions: {
+				ecmaVersion: 2020,
+				globals: { self: "readonly" },
+			},
+			errors: [{ messageId: "impliedEval" }],
+		},
+		{
+			code: "(self?.setTimeout)('code', 0)",
+			languageOptions: {
+				ecmaVersion: 2020,
+				globals: { self: "readonly" },
+			},
+			errors: [{ messageId: "impliedEval" }],
+		},
+		{
+			code: "self?.execScript('code')",
+			languageOptions: {
+				ecmaVersion: 2020,
+				globals: { self: "readonly" },
+			},
+			errors: [{ messageId: "execScript" }],
+		},
+		{
+			code: "(self?.execScript)('code')",
+			languageOptions: {
+				ecmaVersion: 2020,
+				globals: { self: "readonly" },
 			},
 			errors: [{ messageId: "execScript" }],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

- Added "self" to the `GLOBAL_CANDIDATES` array so the `no-implied-eval` rule now catches patterns like `self.setTimeout('evilCode()')` and `self.execScript('string')`
- Added comprehensive tests

Closes #19950

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
