### PR TITLE
chore: remove eslint v10 prereleases from eslint-config-eslint deps

### DIFF
--- a/packages/eslint-config-eslint/package.json
+++ b/packages/eslint-config-eslint/package.json
@@ -63,7 +63,7 @@
   "bugs": "https://github.com/eslint/eslint/issues/",
   "dependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
-    "@eslint/js": ">=10.0.0-alpha.0 <10.0.0 || ^10.0.1",
+    "@eslint/js": "^10.0.1",
     "eslint-plugin-jsdoc": "^48.2.3",
     "eslint-plugin-n": "^17.11.1",
     "eslint-plugin-regexp": "^2.10.0",
@@ -71,11 +71,11 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.0",
-    "eslint": ">=10.0.0-alpha.0",
+    "eslint": "^10.0.0",
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "eslint": ">=10.0.0-alpha.0"
+    "eslint": "^10.0.0"
   },
   "peerDependenciesMeta": {
     "eslint": {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Refs https://github.com/eslint/eslint/issues/20326, removes ESLint v10 prereleases from dependencies of eslint-config-eslint.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated packages/eslint-config-eslint/package.json:

1. `eslint` peer and dev dependencies to `^10.0.0`.
2. `@eslint/js` dependency to `^10.0.1`.

#### Is there anything you'd like reviewers to focus on?

We still can't release a new version of eslint-config-eslint because `eslint-plugin-jsdoc` does not yet support ESLint v10.

<!-- markdownlint-disable-file MD004 -->
