### PR TITLE
chore: update @typescript-eslint/parser to ^8.56.0

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -31,7 +31,7 @@
         "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
         "@munter/tap-render": "^0.2.0",
         "@types/markdown-it": "^12.2.3",
-        "@typescript-eslint/parser": "^8.54.0",
+        "@typescript-eslint/parser": "^8.56.0",
         "algoliasearch": "^4.12.1",
         "autoprefixer": "^10.4.13",
         "cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "@trunkio/launcher": "^1.3.4",
     "@types/esquery": "^1.5.4",
     "@types/node": "^22.13.14",
-    "@typescript-eslint/parser": "^8.54.0",
+    "@typescript-eslint/parser": "^8.56.0",
     "babel-loader": "^8.0.5",
     "c8": "^7.12.0",
     "chai": "^4.0.1",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

As of v8.56.0, typescript-eslint packages officially support ESLint v10.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated `@typescript-eslint/parser` dependency in package.json.

#### Is there anything you'd like reviewers to focus on?

We still can't remove `legacy-peer-deps` because eslint-plugin-jsdoc and eslint-plugin-eslint-comments still don't have eslint v10 in peer dependencies.

<!-- markdownlint-disable-file MD004 -->
