### PR TITLE
feat: add allowDeferredReferences option to no-use-before-define

### DIFF
--- a/docs/src/rules/no-use-before-define.md
+++ b/docs/src/rules/no-use-before-define.md
@@ -131,6 +131,7 @@ export { foo };
         "classes": true,
         "variables": true,
         "allowNamedExports": false,
+        "allowDeferredReferences": true,
         "enums": true,
         "typedefs": true,
         "ignoreTypeReferences": true
@@ -159,6 +160,10 @@ export { foo };
   If this flag is set to `true`, the rule always allows references in `export {};` declarations.
   These references are safe even if the variables are declared later in the code.
   Default is `false`.
+* `allowDeferredReferences` (`boolean`) -
+  If this flag is set to `true` (the default), the rule allows references to a variable inside any function within the variable's own initializer, assuming the function will be called after the variable is initialized.
+  If set to `false`, the rule only allows such references when the function is directly assigned as the variable's initializer value (e.g., `const x = () => x`). References inside functions that are passed as arguments, placed in arrays, or in object literals within the initializer will be reported, because they could potentially be invoked immediately during initialization, causing a `ReferenceError`.
+  Default is `true`.
 
 This rule additionally supports TypeScript type syntax. The following options enable checking for the references to `type`, `interface` and `enum` declarations:
 
@@ -173,7 +178,7 @@ This rule additionally supports TypeScript type syntax. The following options en
   Default is `true`.
 
 This rule accepts `"nofunc"` string as an option.
-`"nofunc"` is the same as `{ "functions": false, "classes": true, "variables": true, "allowNamedExports": false, "enums": true, "typedefs": true, "ignoreTypeReferences": true }`.
+`"nofunc"` is the same as `{ "functions": false, "classes": true, "variables": true, "allowNamedExports": false, "allowDeferredReferences": true, "enums": true, "typedefs": true, "ignoreTypeReferences": true }`.
 
 ### functions
 
@@ -362,6 +367,42 @@ export function foo() {
     return d;
 }
 const d = 1;
+```
+
+:::
+
+### allowDeferredReferences
+
+Examples of **incorrect** code for the `{ "allowDeferredReferences": false }` option:
+
+::: incorrect
+
+```js
+/*eslint no-use-before-define: ["error", { "allowDeferredReferences": false }]*/
+
+const a = foo(() => a);
+
+const b = [() => b];
+
+const c = { f: () => c };
+
+const d = (() => d)();
+```
+
+:::
+
+Examples of **correct** code for the `{ "allowDeferredReferences": false }` option:
+
+::: correct
+
+```js
+/*eslint no-use-before-define: ["error", { "allowDeferredReferences": false }]*/
+
+const x = () => x;
+
+const y = function() { return y; };
+
+var foo = function() { foo(); };
 ```
 
 :::

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -30,6 +30,7 @@ function parseOptions(options) {
 		classes: true,
 		variables: true,
 		allowNamedExports: false,
+		allowDeferredReferences: true,
 		enums: true,
 		typedefs: true,
 		ignoreTypeReferences: true,
@@ -139,6 +140,91 @@ function isFromSeparateExecutionContext(reference) {
 }
 
 /**
+ * Checks whether a reference from a separate execution context is in a function
+ * that is directly assigned as the variable's initializer value.
+ * In such cases, the function is guaranteed to be deferred (not immediately invoked
+ * during initialization), so the reference is safe.
+ *
+ * Examples of direct function assignments (safe):
+ *   const x = () => x;
+ *   const x = function() { return x; };
+ *
+ * Examples of non-direct function assignments (potentially unsafe):
+ *   const a = foo(() => a);       // function is an argument to a call
+ *   const a = [() => a];          // function is in an array
+ *   const a = { f: () => a };     // function is in an object
+ *   const a = (() => a)();        // IIFE
+ * @param {eslint-scope.Reference} reference A reference to check.
+ * @returns {boolean} `true` if the reference is in a directly assigned function.
+ */
+function isDirectlyDeferredReference(reference) {
+	const variable = reference.resolved;
+	const definition = variable.defs[0];
+
+	if (!definition || definition.type === "ClassName") {
+		/*
+		 * Class references have their own handling logic. Also, if
+		 * there's no definition, we can't determine anything.
+		 */
+		return false;
+	}
+
+	/*
+	 * Find the outermost function scope that separates the reference
+	 * from the variable's scope. This is the function we need to check
+	 * is directly assigned.
+	 */
+	let scope = reference.from;
+	let outermostFunctionNode = null;
+
+	while (variable.scope.variableScope !== scope.variableScope) {
+		if (isClassStaticInitializerScope(scope.variableScope)) {
+			scope = scope.variableScope.upper;
+		} else {
+			// scope.variableScope.block is the function node
+			outermostFunctionNode = scope.variableScope.block;
+			scope = scope.variableScope.upper;
+		}
+	}
+
+	if (!outermostFunctionNode) {
+		return false;
+	}
+
+	/*
+	 * Walk up from the function node to check if it's directly assigned
+	 * as the variable's initializer. We need to find a VariableDeclarator
+	 * for the same variable, where the init is the function node.
+	 */
+	const node = outermostFunctionNode.parent;
+
+	if (!node) {
+		return false;
+	}
+
+	/*
+	 * The function should be the direct init of the variable declarator.
+	 * e.g., `const x = () => x` means outermostFunctionNode is the
+	 * ArrowFunctionExpression, and its parent should be a VariableDeclarator
+	 * whose id is the variable's definition name.
+	 */
+	if (
+		node.type === "VariableDeclarator" &&
+		node.init === outermostFunctionNode
+	) {
+		const declaratorId = node.id;
+
+		// Check this declarator is for the same variable
+		return (
+			declaratorId.range[0] === definition.name.range[0] &&
+			declaratorId.range[1] === definition.name.range[1]
+		);
+	}
+
+	return false;
+}
+
+/**
  * Checks whether or not a given reference is evaluated during the initialization of its variable.
  *
  * This returns `true` in the following cases:
@@ -155,15 +241,35 @@ function isFromSeparateExecutionContext(reference) {
  *     class C extends (class { static foo = C; }) {}
  *     class C { [C]; }
  * @param {Reference} reference A reference to check.
+ * @param {boolean} allowDeferredReferences Whether to allow all deferred references or only direct ones.
  * @returns {boolean} `true` if the reference is evaluated during the initialization.
  */
-function isEvaluatedDuringInitialization(reference) {
+function isEvaluatedDuringInitialization(reference, allowDeferredReferences) {
 	if (isFromSeparateExecutionContext(reference)) {
+		if (allowDeferredReferences) {
+			/*
+			 * Even if the reference appears in the initializer, it isn't evaluated during the initialization.
+			 * For example, `const x = () => x;` is valid.
+			 */
+			return false;
+		}
+
 		/*
-		 * Even if the reference appears in the initializer, it isn't evaluated during the initialization.
-		 * For example, `const x = () => x;` is valid.
+		 * When allowDeferredReferences is false, only allow references in functions
+		 * that are directly assigned as the variable's initializer value.
+		 * For example, `const x = () => x;` is still valid, but
+		 * `const a = foo(() => a);` is not.
 		 */
-		return false;
+		if (isDirectlyDeferredReference(reference)) {
+			return false;
+		}
+
+		/*
+		 * The reference is from a separate execution context but is NOT in a
+		 * directly assigned function. We still need to check if it's in the
+		 * variable's initializer to determine if it should be reported.
+		 * Fall through to the normal initializer range checks below.
+		 */
 	}
 
 	const location = reference.identifier.range[1];
@@ -293,6 +399,7 @@ module.exports = {
 							classes: { type: "boolean" },
 							variables: { type: "boolean" },
 							allowNamedExports: { type: "boolean" },
+							allowDeferredReferences: { type: "boolean" },
 							enums: { type: "boolean" },
 							typedefs: { type: "boolean" },
 							ignoreTypeReferences: { type: "boolean" },
@@ -309,6 +416,7 @@ module.exports = {
 				functions: true,
 				variables: true,
 				allowNamedExports: false,
+				allowDeferredReferences: true,
 				enums: true,
 				typedefs: true,
 				ignoreTypeReferences: true,
@@ -423,7 +531,10 @@ module.exports = {
 				if (
 					reference.identifier.range[1] <
 						definitionIdentifier.range[1] ||
-					(isEvaluatedDuringInitialization(reference) &&
+					(isEvaluatedDuringInitialization(
+						reference,
+						options.allowDeferredReferences,
+					) &&
 						reference.identifier.parent.type !== "TSTypeReference")
 				) {
 					context.report({

--- a/tests/lib/rules/no-use-before-define.js
+++ b/tests/lib/rules/no-use-before-define.js
@@ -453,6 +453,39 @@ ruleTester.run("no-use-before-define", rule, {
 				parserOptions: { ecmaFeatures: { jsx: true } },
 			},
 		},
+
+		// allowDeferredReferences: false - direct function assignments are still valid
+		{
+			code: "const x = () => x;",
+			options: [{ allowDeferredReferences: false }],
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "const x = function() { return x; };",
+			options: [{ allowDeferredReferences: false }],
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "var foo = function() { foo(); };",
+			options: [{ allowDeferredReferences: false }],
+		},
+		{
+			code: "const x = () => { const y = () => x; };",
+			options: [{ allowDeferredReferences: false }],
+			languageOptions: { ecmaVersion: 6 },
+		},
+
+		// allowDeferredReferences: true (default) - all deferred references allowed
+		{
+			code: "const a = foo(() => a);",
+			options: [{ allowDeferredReferences: true }],
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "const a = [() => a];",
+			options: [{ allowDeferredReferences: true }],
+			languageOptions: { ecmaVersion: 6 },
+		},
 	],
 	invalid: [
 		{
@@ -3260,6 +3293,95 @@ type StringOrNumber = string | number;
 			errors: [
 				{
 					data: { name: "C" },
+					messageId: "usedBeforeDefined",
+				},
+			],
+		},
+
+		// allowDeferredReferences: false - functions as call arguments
+		{
+			code: "const a = foo(() => a);",
+			options: [{ allowDeferredReferences: false }],
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					data: { name: "a" },
+					messageId: "usedBeforeDefined",
+				},
+			],
+		},
+		{
+			code: "const a = TestFunction(arr, (T) => { console.log(a); return T; });",
+			options: [{ allowDeferredReferences: false }],
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					data: { name: "a" },
+					messageId: "usedBeforeDefined",
+				},
+			],
+		},
+
+		// allowDeferredReferences: false - functions in arrays
+		{
+			code: "const a = [() => a];",
+			options: [{ allowDeferredReferences: false }],
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					data: { name: "a" },
+					messageId: "usedBeforeDefined",
+				},
+			],
+		},
+
+		// allowDeferredReferences: false - functions in object literals
+		{
+			code: "const a = { f: () => a };",
+			options: [{ allowDeferredReferences: false }],
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					data: { name: "a" },
+					messageId: "usedBeforeDefined",
+				},
+			],
+		},
+
+		// allowDeferredReferences: false - IIFE
+		{
+			code: "const a = (() => a)();",
+			options: [{ allowDeferredReferences: false }],
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					data: { name: "a" },
+					messageId: "usedBeforeDefined",
+				},
+			],
+		},
+
+		// allowDeferredReferences: false - new expression
+		{
+			code: "const a = new Foo(() => a);",
+			options: [{ allowDeferredReferences: false }],
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					data: { name: "a" },
+					messageId: "usedBeforeDefined",
+				},
+			],
+		},
+
+		// allowDeferredReferences: false - function expression as argument
+		{
+			code: "const a = foo(function() { return a; });",
+			options: [{ allowDeferredReferences: false }],
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					data: { name: "a" },
 					messageId: "usedBeforeDefined",
 				},
 			],


### PR DESCRIPTION
## Summary

Fixes #20014

Functions passed as arguments, placed in arrays, or in object literals within a variable's initializer may be invoked immediately during initialization, causing a `ReferenceError` at runtime. Currently, `no-use-before-define` treats all functions in initializers as "deferred" and does not report these cases:

```js
const a = TestFunction(arr, (T) => {
    console.log(a); // ReferenceError at runtime, but not reported
    return T;
});
```

This PR adds a new `allowDeferredReferences` option (default: `true` for backward compatibility). When set to `false`, only functions **directly assigned** as a variable's initializer value are treated as safely deferred. Functions in call arguments, arrays, object literals, IIFEs, etc. are reported.

### How it works

A new helper `isDirectlyDeferredReference()` walks up the scope chain to find the outermost function separating the reference from the variable, then walks up the AST to check if that function is directly assigned as the variable's init:

- `const x = () => x` -- **safe** (direct assignment, not reported)
- `const x = function() { return x; }` -- **safe** (direct assignment, not reported)
- `const a = fn(() => a)` -- **reported** (argument to call)
- `const a = [() => a]` -- **reported** (array element)
- `const a = { f: () => a }` -- **reported** (object property)
- `const a = (() => a)()` -- **reported** (IIFE)

### Changes

- `lib/rules/no-use-before-define.js`: Added `isDirectlyDeferredReference` helper, `allowDeferredReferences` option in schema/defaults, modified `isEvaluatedDuringInitialization` to use the option
- `tests/lib/rules/no-use-before-define.js`: Added valid and invalid test cases
- `docs/src/rules/no-use-before-define.md`: Added option documentation and examples

## Test plan

- [x] All existing tests pass (no regressions)
- [x] New valid tests: direct function assignment patterns still allowed with `allowDeferredReferences: false`
- [x] New valid tests: all deferred references allowed with default `allowDeferredReferences: true`
- [x] New invalid tests: call arguments, arrays, objects, IIFEs, new expressions reported with `allowDeferredReferences: false`
- [x] Default behavior preserved (backward compatible)
- [x] Pre-commit hooks pass (lint, rule examples check, type generation)


🤖 Generated with [Claude Code](https://claude.com/claude-code)