### PR TITLE
docs: update migration guide per Program range change

### DIFF
--- a/docs/src/use/migrate-to-10.0.0.md
+++ b/docs/src/use/migrate-to-10.0.0.md
@@ -290,7 +290,7 @@ Starting with ESLint v10.0.0, `Program.range` covers the entire source text, inc
 
 **To address:**
 
-- For rule and plugin authors: If your code depends on the previous `Program.range` behavior, or on `SourceCode` methods that assume it (such as `sourceCode.getCommentsBefore(programNode)` to retrieve all leading comments), update your logic. If your code report on the `Program` node, update your logic to report on the first statement within the `program` node, i.e. `node.body[0] ?? node`, to ensure the directive `/* eslint-disable your-rule */` can still work.
+- For rule and plugin authors: If your code depends on the previous `Program.range` behavior, or on `SourceCode` methods that assume it (such as `sourceCode.getCommentsBefore(programNode)` to retrieve all leading comments), update your logic. If your code reports on the `Program` node, update your logic to report on the first statement within the `Program` node, i.e. `node.body[0] ?? node`, to ensure the directive `/* eslint-disable your-rule */` can still work.
 - For custom parsers: Set `Program.range` to cover the full source text (typically `[0, code.length]`).
 
 **Related issue(s):** [eslint/js#648](https://github.com/eslint/js/issues/648)


### PR DESCRIPTION
Added additional guidance for rule authors regarding changes in Program.range behavior in ESLint v10.0.0.

<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated the migration guide. The program range change essentially makes `/* eslint-disable my-rule */` useless if `my-rule` reports an error at the Program node. As we have seen prior to 10.0.0-rc.2, some of our own rules were affected by this issue as well.

See also https://github.com/eslint/eslint/issues/20451.

Affected by this issue when updating the custom rules in the Node.js repo: https://github.com/nodejs/node/pull/61905

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
