### PR TITLE
ci: declare explicit token permissions for docs automation workflows

### DIFF
--- a/.github/workflows/rebuild-docs-sites.yml
+++ b/.github/workflows/rebuild-docs-sites.yml
@@ -6,6 +6,9 @@ on:
         paths:
             - "docs/src/_data/versions.json"
 
+permissions:
+    contents: read
+
 jobs:
     rebuild:
         name: "Trigger rebuild on Netlify"

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -4,6 +4,8 @@ on:
     schedule:
         - cron: "0 8 * * *" # Every day at 1am PDT
 
+permissions: {}
+
 jobs:
     build:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary\n- add explicit `permissions: contents: read` to docs rebuild workflow\n- add explicit `permissions: {}` to README update workflow that uses a dedicated bot token\n\n## Changed files\n- `.github/workflows/rebuild-docs-sites.yml`\n- `.github/workflows/update-readme.yml`\n\n## Why\nThese workflows currently rely on implicit default token scopes. Explicit permissions make intended access clear and align with least-privilege guidance.\n\n## Notes\n- configuration-only change\n- no workflow logic changes\n