### PR TITLE
fix: avoid unsafe no-var autofix for pre-declaration reads

### DIFF
--- a/lib/rules/no-var.js
+++ b/lib/rules/no-var.js
@@ -190,6 +190,23 @@ function hasReferenceInTDZ(node) {
 }
 
 /**
+ * Checks whether a given variable has any references before its declaration.
+ * Converting such a variable from `var` to `let` would introduce TDZ runtime
+ * errors.
+ * @param {Variable} variable The variable to check.
+ * @returns {boolean} `true` if the variable is referenced before declaration.
+ */
+function hasReferencesBeforeDeclaration(variable) {
+	const declarationStart = variable.defs[0].name.range[0];
+
+	return variable.references.some(
+		reference =>
+			!reference.init &&
+			reference.identifier.range[0] < declarationStart,
+	);
+}
+
+/**
  * Checks whether a given variable has name that is allowed for 'var' declarations,
  * but disallowed for `let` declarations.
  * @param {Variable} variable The variable to check.
@@ -300,6 +317,7 @@ module.exports = {
 			if (
 				node.parent.type === "SwitchCase" ||
 				node.declarations.some(hasSelfReferenceInTDZ) ||
+				variables.some(hasReferencesBeforeDeclaration) ||
 				variables.some(isGlobal) ||
 				variables.some(isRedeclared) ||
 				variables.some(isUsedFromOutsideOf(scopeNode)) ||

--- a/tests/lib/rules/no-var.js
+++ b/tests/lib/rules/no-var.js
@@ -247,6 +247,14 @@ ruleTester.run("no-var", rule, {
 			errors: [{ messageId: "unexpectedVar" }],
 		},
 
+		// https://github.com/eslint/eslint/issues/20209
+		{
+			code: "export function a() { console.log(o); var o; return o; }",
+			output: null,
+			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+			errors: [{ messageId: "unexpectedVar" }],
+		},
+
 		// https://github.com/eslint/eslint/issues/7950
 		{
 			code: "var a = a",


### PR DESCRIPTION
## Summary
- prevent 
o-var from autofixing when a variable is referenced before its declaration
- this avoids introducing TDZ ReferenceError behavior changes when converting ar to let
- add a regression test for export function a() { console.log(o); var o; return o; }

## Testing
- node ./node_modules/mocha/bin/mocha.js tests/lib/rules/no-var.js

Closes #20209
