### PR TITLE
fix: make for-direction consistent for statically false initial conditions

### DIFF
--- a/lib/rules/for-direction.js
+++ b/lib/rules/for-direction.js
@@ -118,6 +118,116 @@ module.exports = {
 			return 0;
 		}
 
+		/**
+		 * Converts static values into comparable numbers.
+		 * @param {unknown} value Value to normalize.
+		 * @returns {number|null} Comparable number or null if unsupported.
+		 */
+		function toComparableNumber(value) {
+			if (
+				typeof value !== "number" &&
+				typeof value !== "bigint" &&
+				typeof value !== "boolean"
+			) {
+				return null;
+			}
+
+			const result = Number(value);
+
+			return Number.isNaN(result) ? null : result;
+		}
+
+		/**
+		 * Gets a static comparable value for a node.
+		 * @param {ASTNode} node Node to evaluate.
+		 * @returns {number|null} Comparable number or null if not static.
+		 */
+		function getStaticComparableValue(node) {
+			const staticValue = getStaticValue(node, sourceCode.getScope(node));
+
+			if (!staticValue) {
+				return null;
+			}
+
+			return toComparableNumber(staticValue.value);
+		}
+
+		/**
+		 * Gets the initial counter value from the for-loop initializer.
+		 * @param {ASTNode} node The ForStatement node.
+		 * @param {string} counter The counter identifier name.
+		 * @returns {number|null} Comparable initial value or null if unknown.
+		 */
+		function getInitialCounterValue(node, counter) {
+			if (!node.init) {
+				return null;
+			}
+
+			if (node.init.type === "VariableDeclaration") {
+				for (const declarator of node.init.declarations) {
+					if (
+						declarator.id.type === "Identifier" &&
+						declarator.id.name === counter &&
+						declarator.init
+					) {
+						return getStaticComparableValue(declarator.init);
+					}
+				}
+
+				return null;
+			}
+
+			if (
+				node.init.type === "AssignmentExpression" &&
+				node.init.left.type === "Identifier" &&
+				node.init.left.name === counter
+			) {
+				return getStaticComparableValue(node.init.right);
+			}
+
+			return null;
+		}
+
+		/**
+		 * Checks if the loop condition is statically false on first evaluation.
+		 * @param {ASTNode} node The ForStatement node.
+		 * @param {"left"|"right"} counterPosition Position of the counter in the condition.
+		 * @param {string} counter The counter identifier name.
+		 * @returns {boolean} True if the condition is statically false.
+		 */
+		function isInitialConditionStaticallyFalse(
+			node,
+			counterPosition,
+			counter,
+		) {
+			const counterValue = getInitialCounterValue(node, counter);
+			const boundaryNode =
+				counterPosition === "left" ? node.test.right : node.test.left;
+			const boundaryValue = getStaticComparableValue(boundaryNode);
+
+			if (counterValue === null || boundaryValue === null) {
+				return false;
+			}
+
+			const leftValue =
+				counterPosition === "left" ? counterValue : boundaryValue;
+			const rightValue =
+				counterPosition === "left" ? boundaryValue : counterValue;
+
+			switch (node.test.operator) {
+				case "<":
+					return !(leftValue < rightValue);
+				case "<=":
+					return !(leftValue <= rightValue);
+				case ">":
+					return !(leftValue > rightValue);
+				case ">=":
+					return !(leftValue >= rightValue);
+				default:
+					return false;
+			}
+		}
+
 		return {
 			ForStatement(node) {
 				if (
@@ -133,6 +243,7 @@ module.exports = {
 						const counter = node.test[counterPosition].name;
 						const operator = node.test.operator;
 						const update = node.update;
+						let updateDirection = 0;
 
 						let wrongDirection;
 
@@ -147,18 +258,32 @@ module.exports = {
 						}
 
 						if (update.type === "UpdateExpression") {
-							if (
-								getUpdateDirection(update, counter) ===
-								wrongDirection
-							) {
-								report(node);
-							}
-						} else if (
-							update.type === "AssignmentExpression" &&
-							getAssignmentDirection(update, counter) ===
-								wrongDirection
+							updateDirection = getUpdateDirection(update, counter);
+						} else if (update.type === "AssignmentExpression") {
+							updateDirection = getAssignmentDirection(
+								update,
+								counter,
+							);
+						}
+
+						if (!updateDirection) {
+							continue;
+						}
+
+						if (
+							isInitialConditionStaticallyFalse(
+								node,
+								counterPosition,
+								counter,
+							)
 						) {
 							report(node);
+							return;
+						}
+
+						if (updateDirection === wrongDirection) {
+							report(node);
+							return;
 						}
 					}
 				}

--- a/tests/lib/rules/for-direction.js
+++ b/tests/lib/rules/for-direction.js
@@ -182,6 +182,14 @@ ruleTester.run("for-direction", rule, {
 				},
 			],
 		},
+		{
+			code: "for(var i = 0; i < 0; i++){}",
+			errors: [incorrectDirection],
+		},
+		{
+			code: "for(var i = 0; 0 > i; i++){}",
+			errors: [incorrectDirection],
+		},
 
 		// test if '+=', '-='
 		{


### PR DESCRIPTION
## Summary
- treat statically-never-entered or loops consistently in or-direction
- if the loop condition is statically false at initialization and the update mutates the counter, report it regardless of comparator side/orientation
- add regression tests for or (let i = 0; i < 0; i++) {} and or (let i = 0; 0 > i; i++) {}

## Testing
- node ./node_modules/mocha/bin/mocha.js tests/lib/rules/for-direction.js

Closes #20410
