### PR TITLE
docs: link rule type explanation to CLI option --fix-type

### DIFF
--- a/docs/src/extend/custom-rules.md
+++ b/docs/src/extend/custom-rules.md
@@ -47,7 +47,7 @@ The source file for a rule exports an object with the following properties. Both
     - `"suggestion"`: The rule is identifying something that could be done in a better way but no errors will occur if the code isn't changed.
     - `"layout"`: The rule cares primarily about whitespace, semicolons, commas, and parentheses, all the parts of the program that determine how the code looks rather than how it executes. These rules work on parts of the code that aren't specified in the AST.
 
-    The type of rule can be used with the CLI option [--fix-type](../use/command-line-interface#--fix-type) to specify the type of fixes to apply.
+    The type of rule can be used with the CLI option [`--fix-type`](../use/command-line-interface#--fix-type) to specify the type of fixes to apply.
 
 - `docs`: (`object`) Properties often used for documentation generation and tooling. Required for core rules and optional for custom rules. Custom rules can include additional properties here as needed.
 


### PR DESCRIPTION
- closes https://github.com/eslint/eslint/issues/20532

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [X] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

Include a link in [Rule Structure](https://eslint.org/docs/latest/extend/custom-rules#rule-structure) to the CLI [`--fix-type`](https://eslint.org/docs/latest/use/command-line-interface#--fix-type) option so that the reason for having different types of rules -  `problem` / `suggestion` / `layout` - is explained.

#### Is there anything you'd like reviewers to focus on?

No

<!-- markdownlint-disable-file MD004 -->
