### PR TITLE
fix: minimatch security vulnerability patch for v9.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "is-glob": "^4.0.0",
     "json-stable-stringify-without-jsonify": "^1.0.1",
     "lodash.merge": "^4.6.2",
-    "minimatch": "^3.1.2",
+    "minimatch": "^3.1.3",
     "natural-compare": "^1.4.0",
     "optionator": "^0.9.3"
   },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

This PR fixes [minimatch](https://github.com/isaacs/minimatch/security/advisories/GHSA-3ppc-4f35-3m26) security vulnerability for v9.x Eslint versions.

see for more https://github.com/eslint/eslint/issues/20518#issuecomment-3935441657

@lumirlumir sorry LuMir I have created the first PR ([20546](https://github.com/eslint/eslint/pull/20546)) from the wrong email.

<!-- markdownlint-disable-file MD004 -->
