### PR TITLE
docs: fix typo in no-await-in-loop rule docs

### DIFF
--- a/docs/src/rules/no-await-in-loop.md
+++ b/docs/src/rules/no-await-in-loop.md
@@ -163,7 +163,7 @@ the loop is correct. As a few examples:
     ```js
     async function checkFiles() {
         for (let i = 0; i < 10000; i++) {
-            // Here some concurrency may be desireable to reduce I/O bottlenecks,
+            // Here some concurrency may be desirable to reduce I/O bottlenecks,
             // but not unbounded concurrency as that will fail,
             // running out of file descriptors.
             await openFileAndThrowIfContentsMeetCondition(filenames[i]);


### PR DESCRIPTION
## Summary
- fix typo in docs/src/rules/no-await-in-loop.md
- change "desireable" to "desirable" in explanatory comment

## Why
- improves readability and professionalism of rule documentation