### PR TITLE
docs: clarify forking wording in development guide

### DIFF
--- a/docs/src/contribute/development-environment.md
+++ b/docs/src/contribute/development-environment.md
@@ -19,7 +19,7 @@ Most of the installers already come with [npm](https://www.npmjs.com/) but if fo
 
 ## Step 2: Fork and Checkout Your Own ESLint Repository
 
-Go to <https://github.com/eslint/eslint> and click the "Fork" button. Follow the [GitHub documentation](https://help.github.com/articles/fork-a-repo) for forking and cloning.
+Go to <https://github.com/eslint/eslint> and click the "Fork" button. Follow the [GitHub documentation](https://help.github.com/articles/fork-a-repo) on forking and cloning.
 
 Clone your fork:
 


### PR DESCRIPTION
## Summary
- clarify one sentence in `docs/src/contribute/development-environment.md`
- change wording from "for forking and cloning" to "on forking and cloning"

## Notes
This is a small documentation-only improvement; no code or behavior changes.
