### PR TITLE
feat: support comparison operators in no-constant-binary-expression

### DIFF
--- a/docs/src/rules/no-constant-binary-expression.md
+++ b/docs/src/rules/no-constant-binary-expression.md
@@ -31,7 +31,7 @@ const isEmpty = x === [];
 
 ## Rule Details
 
-This rule identifies `==` and `===` comparisons which, based on the semantics of the JavaScript language, will always evaluate to `true` or `false`.
+This rule identifies `==`, `===`, `>`, `<`, `>=`, and `<=` comparisons which, based on the semantics of the JavaScript language, will always evaluate to `true` or `false`.
 
 It also identifies `||`, `&&` and `??` logical expressions which will either always or never short-circuit.
 
@@ -59,6 +59,10 @@ const shortCircuit1 = condition1 && false && condition2;
 const shortCircuit2 = condition1 || true || condition2;
 
 const shortCircuit3 = condition1 ?? "non-nullish" ?? condition2;
+
+const alwaysFalse = 0 > 1;
+
+const shouldShowStreak = profile.streak ?? 0 > 1;
 ```
 
 :::

--- a/lib/rules/no-constant-binary-expression.js
+++ b/lib/rules/no-constant-binary-expression.js
@@ -481,6 +481,15 @@ function findBinaryExpressionConstantOperand(scope, a, b, operator) {
 		) {
 			return b;
 		}
+	} else if (
+		operator === ">" ||
+		operator === "<" ||
+		operator === ">=" ||
+		operator === "<="
+	) {
+		if (isConstant(scope, a, false) && isConstant(scope, b, false)) {
+			return b;
+		}
 	}
 	return null;
 }

--- a/tests/lib/rules/no-constant-binary-expression.js
+++ b/tests/lib/rules/no-constant-binary-expression.js
@@ -74,6 +74,21 @@ ruleTester.run("no-constant-binary-expression", rule, {
 		"foo ?? null ?? bar",
 		"a ?? (doSomething(), undefined) ?? b",
 		"a ?? (something = null) ?? b",
+
+		// Comparison operators with non-constant operands
+		"x > 0",
+		"x < 0",
+		"x >= 0",
+		"x <= 0",
+		"0 > x",
+		"0 < x",
+		"0 >= x",
+		"0 <= x",
+		"foo() > 0",
+		"foo() < 0",
+		"x > y",
+		"foo.bar > 0",
+		"foo.bar > baz.qux",
 	],
 	invalid: [
 		// Error messages
@@ -970,6 +985,72 @@ ruleTester.run("no-constant-binary-expression", rule, {
 		{
 			code: "window.abc ?? 'non-nullish' ?? anything",
 			errors: [{ messageId: "constantShortCircuit" }],
+		},
+
+		// Comparison operators with both sides constant
+		{
+			code: "1 > 0",
+			errors: [{ messageId: "constantBinaryOperand" }],
+		},
+		{
+			code: "0 > 1",
+			errors: [{ messageId: "constantBinaryOperand" }],
+		},
+		{
+			code: "1 < 0",
+			errors: [{ messageId: "constantBinaryOperand" }],
+		},
+		{
+			code: "0 < 1",
+			errors: [{ messageId: "constantBinaryOperand" }],
+		},
+		{
+			code: "1 >= 0",
+			errors: [{ messageId: "constantBinaryOperand" }],
+		},
+		{
+			code: "0 >= 1",
+			errors: [{ messageId: "constantBinaryOperand" }],
+		},
+		{
+			code: "1 <= 0",
+			errors: [{ messageId: "constantBinaryOperand" }],
+		},
+		{
+			code: "0 <= 1",
+			errors: [{ messageId: "constantBinaryOperand" }],
+		},
+		{
+			code: "0 > 0",
+			errors: [{ messageId: "constantBinaryOperand" }],
+		},
+		{
+			code: "0 >= 0",
+			errors: [{ messageId: "constantBinaryOperand" }],
+		},
+		{
+			code: "'a' > 'b'",
+			errors: [{ messageId: "constantBinaryOperand" }],
+		},
+		{
+			code: "'a' < 'b'",
+			errors: [{ messageId: "constantBinaryOperand" }],
+		},
+		{
+			code: "-1 > -2",
+			errors: [{ messageId: "constantBinaryOperand" }],
+		},
+		{
+			code: "true > false",
+			errors: [{ messageId: "constantBinaryOperand" }],
+		},
+		{
+			code: "1 + 2 > 3",
+			errors: [{ messageId: "constantBinaryOperand" }],
+		},
+		{
+			code: "null > 0",
+			errors: [{ messageId: "constantBinaryOperand" }],
 		},
 	],
 });


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #20573

#### What changes did you make? (Give an overview)

Extended the `no-constant-binary-expression` rule to detect constant comparison expressions using `>`, `<`, `>=`, and `<=` operators where both operands are constant.

Previously, the rule only checked `==`, `!=`, `===`, `!==` for constant operands. This missed cases like:

- `1 > 0` (always `true`)
- `0 > 1` (always `false`)
- `profile.streak ?? 0 > 1` (where `0 > 1` is always `false` due to operator precedence)

**Changes:**

1. **`lib/rules/no-constant-binary-expression.js`** — Added a new branch in `findBinaryExpressionConstantOperand()` for `>`, `<`, `>=`, `<=` operators. When both operands are constant (determined via the existing `isConstant()` utility), the expression is flagged.

2. **`tests/lib/rules/no-constant-binary-expression.js`** — Added 13 valid test cases (non-constant operands like `x > 0`, `foo() < 0`) and 16 invalid test cases (constant operands like `1 > 0`, `0 > 1`, `'a' > 'b'`, `-1 > -2`, `true > false`, `1 + 2 > 3`, `null > 0`).

3. **`docs/src/rules/no-constant-binary-expression.md`** — Updated the rule description to mention comparison operators and added `0 > 1` and `profile.streak ?? 0 > 1` as examples of incorrect code.

#### Is there anything you'd like reviewers to focus on?

The implementation reuses the existing `isConstant()` function from `ast-utils.js` to determine if both operands of a comparison are constant. This is the same function used by `no-constant-condition` and handles literals, unary expressions, binary expressions, template literals, etc. This approach ensures consistency with the rest of the codebase.