### PR TITLE
fix: encode rule metadata in HTML formatter

### DIFF
--- a/lib/cli-engine/formatters/html.js
+++ b/lib/cli-engine/formatters/html.js
@@ -244,7 +244,7 @@ function messageTemplate(it) {
     <td class="clr-${severityNumber}">${severityName}</td>
     <td>${encodeHTML(message)}</td>
     <td>
-        <a href="${ruleUrl ? ruleUrl : ""}" target="_blank" rel="noopener noreferrer">${ruleId ? ruleId : ""}</a>
+        <a href="${ruleUrl && !/^\s*(?:javascript|data):/iu.test(ruleUrl) ? encodeHTML(ruleUrl) : ""}" target="_blank" rel="noopener noreferrer">${ruleId ? encodeHTML(ruleId) : ""}</a>
     </td>
 </tr>
 `.trimStart();

--- a/tests/lib/cli-engine/formatters/html.js
+++ b/tests/lib/cli-engine/formatters/html.js
@@ -3,6 +3,8 @@
  * @author Julian Laval
  */
 
+/* eslint-disable no-script-url -- Testing for disallowed protocols */
+
 "use strict";
 
 //------------------------------------------------------------------------------
@@ -870,6 +872,122 @@ describe("formatter:html", () => {
 				message: "Unexpected foo.",
 				ruleId: "foo",
 			});
+		});
+	});
+
+	describe("when passing a single message with illegal characters in ruleId and ruleUrl", () => {
+		const rulesMeta = {
+			"foo<": {
+				docs: {
+					url: "https://eslint.org/docs/rules/foo<",
+				},
+			},
+		};
+		const code = {
+			results: [
+				{
+					filePath: "foo.js",
+					errorCount: 1,
+					warningCount: 0,
+					messages: [
+						{
+							message: "Unexpected foo.",
+							severity: 2,
+							line: 5,
+							column: 10,
+							ruleId: "foo<",
+							source: "foo",
+						},
+					],
+				},
+			],
+			rulesMeta,
+		};
+
+		it("should return a string in HTML format with escaped ruleId and ruleUrl", () => {
+			const result = formatter(code.results, { rulesMeta });
+
+			assert(
+				result.includes("https://eslint.org/docs/rules/foo&#60;"),
+				"Check if ruleUrl is escaped in raw HTML",
+			);
+			assert(
+				result.includes("foo&#60;"),
+				"Check if ruleId is escaped in raw HTML",
+			);
+
+			const $ = cheerio.load(result);
+
+			assert.strictEqual(
+				$($("tr")[1]).find("td:nth-child(4) a").attr("href"),
+				"https://eslint.org/docs/rules/foo<",
+				"Check if ruleUrl is correctly parsed by cheerio",
+			);
+			assert.strictEqual(
+				$($("tr")[1]).find("td:nth-child(4) a").text(),
+				"foo<",
+				"Check if ruleId is correctly parsed by cheerio",
+			);
+		});
+	});
+
+	describe("when passing a single message with dangerous protocols in ruleUrl", () => {
+		const rulesMeta = {
+			"foo-js": {
+				docs: {
+					// eslint-disable-next-line eslint/no-script-url -- Testing for disallowed protocols
+					url: "javascript:alert('XSS')",
+				},
+			},
+			"foo-data": {
+				docs: {
+					url: "data:text/html,<script>alert('XSS')</script>",
+				},
+			},
+		};
+		const code = {
+			results: [
+				{
+					filePath: "foo.js",
+					errorCount: 2,
+					warningCount: 0,
+					messages: [
+						{
+							message: "Unexpected foo.",
+							severity: 2,
+							line: 5,
+							column: 10,
+							ruleId: "foo-js",
+							source: "foo",
+						},
+						{
+							message: "Unexpected bar.",
+							severity: 2,
+							line: 6,
+							column: 10,
+							ruleId: "foo-data",
+							source: "bar",
+						},
+					],
+				},
+			],
+			rulesMeta,
+		};
+
+		it("should return a string in HTML format with empty href for dangerous protocols", () => {
+			const result = formatter(code.results, { rulesMeta });
+			const $ = cheerio.load(result);
+
+			assert.strictEqual(
+				$($("tr")[1]).find("td:nth-child(4) a").attr("href"),
+				"",
+				"Check if javascript: URL is disallowed",
+			);
+			assert.strictEqual(
+				$($("tr")[2]).find("td:nth-child(4) a").attr("href"),
+				"",
+				"Check if data: URL is disallowed",
+			);
 		});
 	});
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

---

### Bug Report Template

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:** v24.14.0
- **npm version:** v11.9.0
- **Local ESLint version:** v10.0.3
- **Global ESLint version:** Not found
- **Operating System:** win32 10.0.26200

**What parser are you using (place an "X" next to just one item)?**

[X] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

```js
// Repro configuration using a custom rule with malicious metadata
{
    "root": true,
    "rules": {
        "malicious-rule": "error"
    }
}
```

</details>

**What did you do? Please include the actual source code causing the issue.**

I simulated a scenario where a rule's metadata (specifically `ruleId` or `ruleUrl`) contains HTML special characters designed for injection. 

**Reproduction Case:**
Passing a message object like this to the HTML formatter:
```js
{
    ruleId: '"><script>alert("XSS")</script>',
    message: 'Potential vulnerability',
    line: 1,
    column: 1
}
```

**What did you expect to happen?**

I expected the HTML formatter to encode these strings safely (e.g., converting `<` to `&#60;`) before embedding them in the report, rendering them as harmless text.

**What actually happened? Please include the actual, raw output from ESLint.**

The strings were injected directly into the HTML template without escaping. This resulted in the following raw HTML output, which triggers script execution when the report is opened in a browser:

```html
<a href="" target="_blank">"><script>alert("XSS")</script></a>
```

---
#### What changes did you make? (Give an overview)

I fixed potential XSS vulnerabilities in the HTML formatter (`lib/cli-engine/formatters/html.js`) involving both HTML injection and dangerous URI protocols.

**Overview of changes:**
- **HTML Entity Encoding:** Wrapped `ruleId` and `ruleUrl` interpolations in the `messageTemplate` function with the `encodeHTML` utility. This prevents injection of HTML tags (e.g., `<script>`) from malicious rule metadata.
- **Protocol Sanitization:** Added a protocol check to `ruleUrl` to disallow dangerous URI schemes such as `javascript:` and `data:`. This prevents XSS attacks that execute when a user clicks the rule link in the report.
- **Regression Tests:** Added comprehensive tests in `tests/lib/cli-engine/formatters/html.js` to verify:
    - HTML entities are correctly escaped in the raw output.
    - `javascript:` and `data:` protocols result in an empty `href` attribute.

#### Is there anything you'd like reviewers to focus on?

The protocol check uses a case-insensitive regex (`/^\s*(?:javascript|data):/iu`) to identify and block unsafe URLs. If a dangerous protocol is detected, the `href` attribute is rendered empty, effectively neutralizing the attack vector while maintaining a clean report for safe URLs.

---

**Reproduction Case (URI XSS):**
Passing a message object with a malicious URL:
```js
{
    ruleId: 'xss-rule',
    docs: { url: "javascript:alert('XSS')" },
    message: 'Vulnerability test',
    line: 1,
    column: 1
}
```

**Expected/Actual:** The resulting link should have an empty `href=""` instead of executing the script.

---
<!-- markdownlint-disable-file MD004 -->
