### PR TITLE
feat: apply fix for  `no-var` in `TSModuleBlock`

### DIFF
--- a/lib/rules/no-var.js
+++ b/lib/rules/no-var.js
@@ -319,6 +319,10 @@ module.exports = {
 		function canFix(node) {
 			const variables = sourceCode.getDeclaredVariables(node);
 			const scopeNode = getScopeNode(node);
+			const parentStatementList = new Set([
+				...astUtils.STATEMENT_LIST_PARENTS,
+				"TSModuleBlock",
+			]);
 
 			if (
 				node.parent.type === "SwitchCase" ||
@@ -347,7 +351,7 @@ module.exports = {
 					node.parent.type === "ForStatement" &&
 					node.parent.init === node
 				) &&
-				!astUtils.STATEMENT_LIST_PARENTS.has(node.parent.type)
+				!parentStatementList.has(node.parent.type)
 			) {
 				// If the declaration is not in a block, e.g. `if (foo) var bar = 1;`, then it can't be fixed.
 				return false;

--- a/tests/lib/rules/no-var.js
+++ b/tests/lib/rules/no-var.js
@@ -518,11 +518,18 @@ ruleTesterTypeScript.run("no-var", rule, {
 	valid: ["declare global { var bar: 'car' }"],
 	invalid: [
 		{
+			code: "declare var x: number",
+			output: "declare let x: number",
+			errors: [{ messageId: "unexpectedVar" }],
+		},
+		{
 			code: "declare namespace ns { var bar: 'car' }",
+			output: "declare namespace ns { let bar: 'car' }",
 			errors: [{ messageId: "unexpectedVar" }],
 		},
 		{
 			code: "declare module 'module' { var bar: 'car' }",
+			output: "declare module 'module' { let bar: 'car' }",
 			errors: [{ messageId: "unexpectedVar" }],
 		},
 	],


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Enable the fix for `no-var` rule inside `TSModuleBlock` as well.
Right now it does give fix for `declare var x: number` but not for following code:

```ts
declare namespace ns {
	var x: number
}

declare module 'module' {
	var x: number
}
```

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
