### PR TITLE
feat: add errorClassNames option to preserve-caught-error rule (#20428)

### DIFF
--- a/lib/rules/preserve-caught-error.js
+++ b/lib/rules/preserve-caught-error.js
@@ -40,65 +40,110 @@ const BUILT_IN_ERROR_TYPES = new Set([
 /**
  * Finds and returns information about the `cause` property of an error being thrown.
  * @param {ASTNode} throwStatement `ThrowStatement` to be checked.
+ * @param {string} errorClassName The name of the error class being thrown.
  * @returns {{ value: ASTNode; multipleDefinitions: boolean; } | UNKNOWN_CAUSE | null}
  * Information about the `cause` of the error being thrown, such as the value node and
  * whether there are multiple definitions of `cause`. `null` if there is no `cause`.
  */
-function getErrorCause(throwStatement) {
+function getErrorCause(throwStatement, errorClassName) {
 	const throwExpression = throwStatement.argument;
-	/*
-	 * Determine which argument index holds the options object
-	 * `AggregateError` is a special case as it accepts the `options` object as third argument.
-	 */
-	const optionsIndex =
-		throwExpression.callee.name === "AggregateError" ? 2 : 1;
+	const isBuiltIn = BUILT_IN_ERROR_TYPES.has(errorClassName);
 
-	/*
-	 * Make sure there is no `SpreadElement` at or before the `optionsIndex`
-	 * as this messes up the effective order of arguments and makes it complicated
-	 * to track where the actual error options need to be at
-	 */
-	const spreadExpressionIndex = throwExpression.arguments.findIndex(
-		arg => arg.type === "SpreadElement",
-	);
-	if (spreadExpressionIndex >= 0 && spreadExpressionIndex <= optionsIndex) {
-		return UNKNOWN_CAUSE;
-	}
+	// For built-in errors, use positional logic (we know their constructor signature)
+	if (isBuiltIn) {
+		/*
+		 * Determine which argument index holds the options object
+		 * `AggregateError` is a special case as it accepts the `options` object as third argument.
+		 */
+		const optionsIndex =
+			throwExpression.callee.name === "AggregateError" ? 2 : 1;
 
-	const errorOptions = throwExpression.arguments[optionsIndex];
+		/*
+		 * Make sure there is no `SpreadElement` at or before the `optionsIndex`
+		 * as this messes up the effective order of arguments and makes it complicated
+		 * to track where the actual error options need to be at
+		 */
+		const spreadExpressionIndex = throwExpression.arguments.findIndex(
+			arg => arg.type === "SpreadElement",
+		);
+		if (
+			spreadExpressionIndex >= 0 &&
+			spreadExpressionIndex <= optionsIndex
+		) {
+			return UNKNOWN_CAUSE;
+		}
 
-	if (errorOptions) {
-		if (errorOptions.type === "ObjectExpression") {
-			if (
-				errorOptions.properties.some(
-					prop => prop.type === "SpreadElement",
-				)
-			) {
-				/*
-				 * If there is a spread element as part of error options, it is too complicated
-				 * to verify if the cause is used properly and auto-fix.
-				 */
-				return UNKNOWN_CAUSE;
+		const errorOptions = throwExpression.arguments[optionsIndex];
+
+		if (errorOptions) {
+			if (errorOptions.type === "ObjectExpression") {
+				if (
+					errorOptions.properties.some(
+						prop => prop.type === "SpreadElement",
+					)
+				) {
+					/*
+					 * If there is a spread element as part of error options, it is too complicated
+					 * to verify if the cause is used properly and auto-fix.
+					 */
+					return UNKNOWN_CAUSE;
+				}
+
+				const causeProperties = errorOptions.properties.filter(
+					prop => astUtils.getStaticPropertyName(prop) === "cause",
+				);
+
+				const causeProperty = causeProperties.at(-1);
+				return causeProperty
+					? {
+							value: causeProperty.value,
+							multipleDefinitions: causeProperties.length > 1,
+						}
+					: null;
 			}
 
-			const causeProperties = errorOptions.properties.filter(
+			// Error options exist, but too complicated to be analyzed/fixed
+			return UNKNOWN_CAUSE;
+		}
+
+		return null;
+	}
+
+	/*
+	 * For custom error classes, use search logic (we don't know their constructor signature).
+	 * Search all arguments for an ObjectExpression with a `cause` property.
+	 */
+	let lastCauseInfo = null;
+
+	for (const arg of throwExpression.arguments) {
+		if (arg.type === "ObjectExpression") {
+			const causeProperties = arg.properties.filter(
 				prop => astUtils.getStaticPropertyName(prop) === "cause",
 			);
 
-			const causeProperty = causeProperties.at(-1);
-			return causeProperty
-				? {
-						value: causeProperty.value,
-						multipleDefinitions: causeProperties.length > 1,
-					}
-				: null;
-		}
+			if (causeProperties.length > 0) {
+				/*
+				 * Found an object with cause(s).
+				 * Check if this specific object has spread elements.
+				 */
+				if (
+					arg.properties.some(prop => prop.type === "SpreadElement")
+				) {
+					// Too complex to analyze this specific object
+					return UNKNOWN_CAUSE;
+				}
 
-		// Error options exist, but too complicated to be analyzed/fixed
-		return UNKNOWN_CAUSE;
+				// Found a valid cause, update to this one (last-one-wins)
+				const causeProperty = causeProperties.at(-1);
+				lastCauseInfo = {
+					value: causeProperty.value,
+					multipleDefinitions: causeProperties.length > 1,
+				};
+			}
+		}
 	}
 
-	return null;
+	return lastCauseInfo;
 }
 
 /**
@@ -202,8 +247,18 @@ module.exports = {
 
 	create(context) {
 		const sourceCode = context.sourceCode;
-		const [{ requireCatchParameter, errorClassNames = [] }] =
-			context.options;
+		const [
+			{
+				requireCatchParameter,
+				errorClassNames: configuredErrorClassNames = [],
+			},
+		] = context.options;
+
+		// Track error class names: built-in + configured + auto-detected (same file only)
+		const errorClassNames = new Set([
+			...BUILT_IN_ERROR_TYPES,
+			...configuredErrorClassNames,
+		]);
 
 		//----------------------------------------------------------------------
 		// Helpers
@@ -215,9 +270,9 @@ module.exports = {
 		 * Covers all the error types on `globalThis` that support `cause` property:
 		 * https://github.com/microsoft/TypeScript/blob/main/src/lib/es2022.error.d.ts
 		 * @param {ASTNode} throwStatement The `ThrowStatement` that needs to be checked.
-		 * @returns {boolean} `true` if a new "Error" is being thrown, else `false`.
+		 * @returns {{ isError: boolean; className: string | null }} Information about the error.
 		 */
-		function isThrowingNewError(throwStatement) {
+		function getErrorInfo(throwStatement) {
 			if (
 				!(
 					throwStatement.argument.type === "NewExpression" ||
@@ -225,24 +280,27 @@ module.exports = {
 				) ||
 				throwStatement.argument.callee.type !== "Identifier"
 			) {
-				return false;
+				return { isError: false, className: null };
 			}
 
 			const errorClassName = throwStatement.argument.callee.name;
 
 			// Check if it's a built-in error type (must be global reference)
 			if (BUILT_IN_ERROR_TYPES.has(errorClassName)) {
-				return sourceCode.isGlobalReference(
-					throwStatement.argument.callee,
-				);
+				return {
+					isError: sourceCode.isGlobalReference(
+						throwStatement.argument.callee,
+					),
+					className: errorClassName,
+				};
 			}
 
-			// Check if it's a custom error class name from options
-			if (errorClassNames.includes(errorClassName)) {
-				return true;
+			// Check if it's a custom error class name (configured or auto-detected)
+			if (errorClassNames.has(errorClassName)) {
+				return { isError: true, className: errorClassName };
 			}
 
-			return false;
+			return { isError: false, className: null };
 		}
 
 		/**
@@ -264,6 +322,22 @@ module.exports = {
 			}
 
 			const lastProp = properties.at(-1);
+			const lastToken = sourceCode.getLastToken(lastProp);
+
+			// Check if there's a trailing comma after the last property
+			const nextToken = sourceCode.getTokenAfter(lastToken);
+			const hasTrailingComma =
+				nextToken && astUtils.isCommaToken(nextToken);
+
+			if (hasTrailingComma) {
+				// Insert before the trailing comma: `{ a: 1, }` → `{ a: 1, cause: err, }`
+				return fixer.insertTextBefore(
+					nextToken,
+					`, cause: ${caughtErrorName}`,
+				);
+			}
+
+			// No trailing comma, insert after last property: `{ a: 1 }` → `{ a: 1, cause: err }`
 			return fixer.insertTextAfter(
 				lastProp,
 				`, cause: ${caughtErrorName}`,
@@ -274,13 +348,34 @@ module.exports = {
 		// Public
 		//----------------------------------------------------------------------
 		return {
+			/*
+			 * Auto-detect classes that extend Error (same file only).
+			 * For cross-file imports, use errorClassNames config option.
+			 */
+			ClassDeclaration(node) {
+				if (node.superClass?.name === "Error") {
+					errorClassNames.add(node.id.name);
+				}
+			},
+
+			ClassExpression(node) {
+				if (node.superClass?.name === "Error" && node.id?.name) {
+					errorClassNames.add(node.id.name);
+				}
+			},
+
 			ThrowStatement(node) {
 				// Check if the throw is inside a catch block
 				const parentCatch = findParentCatch(node);
 				const throwStatement = node;
 
 				// Check if a new error is being thrown in a catch block
-				if (parentCatch && isThrowingNewError(throwStatement)) {
+				if (parentCatch) {
+					const errorInfo = getErrorInfo(throwStatement);
+
+					if (!errorInfo.isError) {
+						return;
+					}
 					if (
 						parentCatch.param &&
 						parentCatch.param.type !== "Identifier"
@@ -314,7 +409,10 @@ module.exports = {
 					}
 
 					// Check if there is a cause attached to the new error
-					const errorCauseInfo = getErrorCause(throwStatement);
+					const errorCauseInfo = getErrorCause(
+						throwStatement,
+						errorInfo.className,
+					);
 
 					if (errorCauseInfo === UNKNOWN_CAUSE) {
 						// Error options exist, but too complicated to be analyzed/fixed
@@ -335,8 +433,10 @@ module.exports = {
 										const args = throwExpression.arguments;
 										const errorType =
 											throwExpression.callee.name;
+										const isBuiltIn =
+											BUILT_IN_ERROR_TYPES.has(errorType);
 
-										// AggregateError: errors, message, options
+										// AggregateError: errors, message, options (built-in only)
 										if (errorType === "AggregateError") {
 											const errorsArg = args[0];
 											const messageArg = args[1];
@@ -402,12 +502,69 @@ module.exports = {
 											return null;
 										}
 
-										// Normal Error types
-										const messageArg = args[0];
-										const optionsArg = args[1];
+										// For built-in Error types (not AggregateError)
+										if (isBuiltIn) {
+											const messageArg = args[0];
+											const optionsArg = args[1];
 
-										if (!messageArg) {
-											// Case: `throw new Error()` → insert both message and options
+											if (!messageArg) {
+												// Case: `throw new Error()` → insert both message and options
+												const lastToken =
+													sourceCode.getLastToken(
+														throwExpression,
+													);
+												const lastCalleeToken =
+													sourceCode.getLastToken(
+														throwExpression.callee,
+													);
+												const parenToken =
+													sourceCode.getFirstTokenBetween(
+														lastCalleeToken,
+														lastToken,
+														astUtils.isOpeningParenToken,
+													);
+
+												if (parenToken) {
+													return fixer.insertTextAfter(
+														parenToken,
+														`"", { cause: ${caughtError.name} }`,
+													);
+												}
+												return fixer.insertTextAfter(
+													throwExpression.callee,
+													`("", { cause: ${caughtError.name} })`,
+												);
+											}
+											if (!optionsArg) {
+												// Case: `throw new Error("Some message")` → insert only options
+												return fixer.insertTextAfter(
+													messageArg,
+													`, { cause: ${caughtError.name} }`,
+												);
+											}
+
+											if (
+												optionsArg.type ===
+												"ObjectExpression"
+											) {
+												return insertCauseIntoOptions(
+													fixer,
+													optionsArg,
+													caughtError.name,
+												);
+											}
+
+											return null; // Identifier or spread — do not fix
+										}
+
+										/*
+										 * For custom error classes - use search logic.
+										 * Find the last ObjectExpression argument or add after last argument.
+										 */
+										const lastArg = args.at(-1);
+
+										if (!lastArg) {
+											// No arguments at all: `throw new CustomError()`
 											const lastToken =
 												sourceCode.getLastToken(
 													throwExpression,
@@ -426,34 +583,50 @@ module.exports = {
 											if (parenToken) {
 												return fixer.insertTextAfter(
 													parenToken,
-													`"", { cause: ${caughtError.name} }`,
+													`{ cause: ${caughtError.name} }`,
 												);
 											}
 											return fixer.insertTextAfter(
 												throwExpression.callee,
-												`("", { cause: ${caughtError.name} })`,
-											);
-										}
-										if (!optionsArg) {
-											// Case: `throw new Error("Some message")` → insert only options
-											return fixer.insertTextAfter(
-												messageArg,
-												`, { cause: ${caughtError.name} }`,
+												`({ cause: ${caughtError.name} })`,
 											);
 										}
 
-										if (
-											optionsArg.type ===
-											"ObjectExpression"
+										// Find the last ObjectExpression in arguments (without spread elements)
+										let lastObjectArgIndex = -1;
+										for (
+											let i = args.length - 1;
+											i >= 0;
+											i--
 										) {
+											if (
+												args[i].type ===
+													"ObjectExpression" &&
+												!args[i].properties.some(
+													prop =>
+														prop.type ===
+														"SpreadElement",
+												)
+											) {
+												lastObjectArgIndex = i;
+												break;
+											}
+										}
+
+										if (lastObjectArgIndex >= 0) {
+											// Add cause to the last ObjectExpression (without spread)
 											return insertCauseIntoOptions(
 												fixer,
-												optionsArg,
+												args[lastObjectArgIndex],
 												caughtError.name,
 											);
 										}
 
-										return null; // Identifier or spread — do not fix
+										// No suitable ObjectExpression found, add as last argument
+										return fixer.insertTextAfter(
+											lastArg,
+											`, { cause: ${caughtError.name} }`,
+										);
 									},
 								},
 							],

--- a/tests/lib/rules/preserve-caught-error.js
+++ b/tests/lib/rules/preserve-caught-error.js
@@ -874,6 +874,45 @@ ruleTester.run("preserve-caught-error", rule, {
 			}`,
 			options: [{ errorClassNames: ["APIError", "ValidationError"] }],
 		},
+
+		// Auto-detected custom errors (no config needed) - valid cases
+		`
+			class CustomError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomError("With cause", { cause: err });
+			}`,
+		`
+			class APIError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new APIError("msg", { cause: err });
+			}`,
+		`
+			class CustomError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomError({ cause: err }, "msg");
+			}`,
+		`
+			class CustomError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomError("type", "msg", { cause: err });
+			}`,
+		`
+			class CustomError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomError({ meta: "data" }, "msg", { cause: err });
+			}`,
+	],
+	invalid: [
 		{
 			code: `
 			class CustomError extends Error {}
@@ -882,10 +921,182 @@ ruleTester.run("preserve-caught-error", rule, {
 			} catch (err) {
 				throw new CustomError("No cause");
 			}`,
-			options: [{ errorClassNames: [] }],
+			errors: [
+				{
+					messageId: "missingCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `
+			class CustomError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomError("No cause", { cause: err });
+			}`,
+						},
+					],
+				},
+			],
 		},
-	],
-	invalid: [
+
+		// Auto-detected custom errors without cause - should be flagged
+		{
+			code: `
+			class APIError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new APIError("msg");
+			}`,
+			errors: [
+				{
+					messageId: "missingCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `
+			class APIError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new APIError("msg", { cause: err });
+			}`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+			class CustomError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomError("msg", { other: "value" });
+			}`,
+			errors: [
+				{
+					messageId: "missingCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `
+			class CustomError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomError("msg", { other: "value", cause: err });
+			}`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+			class CustomError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomError({ cause: wrong }, "msg");
+			}`,
+			errors: [
+				{
+					messageId: "incorrectCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `
+			class CustomError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomError({ cause: err }, "msg");
+			}`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+			class CustomError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomError("type", "msg");
+			}`,
+			errors: [
+				{
+					messageId: "missingCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `
+			class CustomError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomError("type", "msg", { cause: err });
+			}`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+			class CustomError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomError({ meta: "data" }, "msg");
+			}`,
+			errors: [
+				{
+					messageId: "missingCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `
+			class CustomError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomError({ meta: "data", cause: err }, "msg");
+			}`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+			class CustomError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomError({ a: 1, });
+			}`,
+			errors: [
+				{
+					messageId: "missingCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `
+			class CustomError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomError({ a: 1, cause: err, });
+			}`,
+						},
+					],
+				},
+			],
+		},
 		{
 			code: `
 			class CustomApplicationError extends Error {}
@@ -934,6 +1145,60 @@ ruleTester.run("preserve-caught-error", rule, {
 				doSomething();
 			} catch (error) {
 				throw new APIError("API failed", { cause: error });
+			}`,
+						},
+					],
+				},
+			],
+		},
+
+		// Spread in non-cause object should not block detection
+		{
+			code: `
+			class CustomError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomError({ ...meta }, "message");
+			}`,
+			errors: [
+				{
+					messageId: "missingCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `
+			class CustomError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomError({ ...meta }, "message", { cause: err });
+			}`,
+						},
+					],
+				},
+			],
+		},
+
+		// Trailing comma with built-in Error
+		{
+			code: `
+			try {
+				doSomething();
+			} catch (err) {
+				throw new Error("msg", { a: 1, });
+			}`,
+			errors: [
+				{
+					messageId: "missingCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `
+			try {
+				doSomething();
+			} catch (err) {
+				throw new Error("msg", { a: 1, cause: err, });
 			}`,
 						},
 					],


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
### 1. Search Logic for Custom Errors
- Custom errors can now have `cause` at ANY argument position (not just index 1)

### 2. Auto-Detection of Custom Error Classes
- Automatically detects `class X extends Error {}` in the same file
- No configuration needed for most use cases
- Falls back to `errorClassNames` config for cross-file imports

### 3. Robust Auto-Fixer
- Handles trailing commas without creating syntax errors
- Safely skips objects with spread elements
- Creates new options object when none exists



<!-- markdownlint-disable-file MD004 -->
