### PR TITLE
docs: Clarify parserOptions precedence

### DIFF
--- a/docs/src/use/configure/language-options.md
+++ b/docs/src/use/configure/language-options.md
@@ -69,6 +69,10 @@ export default defineConfig([
 ```
 
 ::: important
+For the default parser, avoid setting `ecmaVersion` or `sourceType` inside `languageOptions.parserOptions`. Those parser-specific values can still take precedence over `languageOptions.ecmaVersion` and `languageOptions.sourceType`, which is usually unnecessary and can be confusing. Set `ecmaVersion` and `sourceType` directly in `languageOptions` instead.
+:::
+
+::: important
 Please note that supporting JSX syntax is not the same as supporting React. React applies specific semantics to JSX syntax that ESLint doesn't recognize. We recommend using [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) if you are using React.
 :::
 

--- a/docs/src/use/configure/parser.md
+++ b/docs/src/use/configure/parser.md
@@ -71,5 +71,5 @@ export default defineConfig([
 ```
 
 ::: tip
-In addition to the options specified in `languageOptions.parserOptions`, ESLint also passes `ecmaVersion` and `sourceType` to all parsers. This allows custom parsers to understand the context in which ESLint is evaluating JavaScript code.
+In addition to the options specified in `languageOptions.parserOptions`, ESLint also passes `ecmaVersion` and `sourceType` from `languageOptions` to all parsers. Some parsers also accept `ecmaVersion` and `sourceType` in `languageOptions.parserOptions`; when those parser-specific values are set, they override the values from `languageOptions`.
 :::


### PR DESCRIPTION
## Summary
- add guidance against setting \cmaVersion\ and \sourceType\ in \languageOptions.parserOptions\ for the default parser
- clarify that parser-specific values can override \languageOptions\ values for custom parsers

Closes #20522