### PR TITLE
feat: add errorClassNames option to preserve-caught-error rule

### DIFF
--- a/docs/src/rules/preserve-caught-error.md
+++ b/docs/src/rules/preserve-caught-error.md
@@ -166,7 +166,7 @@ try {
 
 ### errorClassNames
 
-By default, this rule checks only the built-in `Error` types (`Error`, `TypeError`, `RangeError`, `SyntaxError`, `URIError`, `EvalError`, `ReferenceError`, `AggregateError`). Use `errorClassNames` to also check custom error classes.
+By default, this rule checks only the built-in `Error` types (`Error`, `EvalError`, `RangeError`, `ReferenceError`, `SyntaxError`, `TypeError`, `URIError`, `AggregateError`). Use `errorClassNames` to also check custom error classes.
 
 Each entry can be either a string or an object:
 

--- a/docs/src/rules/preserve-caught-error.md
+++ b/docs/src/rules/preserve-caught-error.md
@@ -117,9 +117,10 @@ try {
 
 ## Options
 
-This rule takes a single option — an object with the following optional property:
+This rule takes a single option — an object with the following optional properties:
 
 - `requireCatchParameter`: Requires the catch blocks to always have the caught error parameter when set to `true`. By default, this is `false`.
+- `errorClassNames`: Additional error class names to check for cause preservation. By default, this is `[]`.
 
 ### requireCatchParameter
 
@@ -158,6 +159,110 @@ try {
 	doSomething();
 } catch(error) { // Error is being referenced ✅
 	// Handling and re-throw logic
+}
+```
+
+:::
+
+### errorClassNames
+
+By default, this rule checks only the built-in `Error` types (`Error`, `TypeError`, `RangeError`, `SyntaxError`, `URIError`, `EvalError`, `ReferenceError`, `AggregateError`). Use `errorClassNames` to also check custom error classes.
+
+Each entry can be either a string or an object:
+
+- A **string** specifies the class name. The constructor is assumed to accept the options object as the second argument, matching the built-in `Error` signature.
+- An **object** with `name` and `argumentPosition` is used when the constructor accepts the options object at a different position. `argumentPosition` is 1-indexed.
+
+```json
+{
+    "rules": {
+        "preserve-caught-error": ["error", {
+            "errorClassNames": [
+                "AppError",
+                { "name": "APIError", "argumentPosition": 3 }
+            ]
+        }]
+    }
+}
+```
+
+Example of **incorrect** code for the `{ "errorClassNames": ["AppError"] }` option:
+
+::: incorrect
+
+```js
+/* eslint preserve-caught-error: ["error", { "errorClassNames": ["AppError"] }] */
+
+class AppError extends Error {}
+
+try {
+	doSomething();
+} catch (err) {
+	throw new AppError("Something failed");
+}
+```
+
+:::
+
+Example of **correct** code for the `{ "errorClassNames": ["AppError"] }` option:
+
+::: correct
+
+```js
+/* eslint preserve-caught-error: ["error", { "errorClassNames": ["AppError"] }] */
+
+class AppError extends Error {}
+
+try {
+	doSomething();
+} catch (err) {
+	throw new AppError("Something failed", { cause: err });
+}
+```
+
+:::
+
+Example of **incorrect** code for the `{ "errorClassNames": [{ "name": "APIError", "argumentPosition": 3 }] }` option:
+
+::: incorrect
+
+```js
+/* eslint preserve-caught-error: ["error", { "errorClassNames": [{ "name": "APIError", "argumentPosition": 3 }] }] */
+
+class APIError extends Error {
+	constructor(message, statusCode, options) {
+		super(message, options);
+		this.statusCode = statusCode;
+	}
+}
+
+try {
+	doSomething();
+} catch (err) {
+	throw new APIError("Request failed", 500);
+}
+```
+
+:::
+
+Example of **correct** code for the `{ "errorClassNames": [{ "name": "APIError", "argumentPosition": 3 }] }` option:
+
+::: correct
+
+```js
+/* eslint preserve-caught-error: ["error", { "errorClassNames": [{ "name": "APIError", "argumentPosition": 3 }] }] */
+
+class APIError extends Error {
+	constructor(message, statusCode, options) {
+		super(message, options);
+		this.statusCode = statusCode;
+	}
+}
+
+try {
+	doSomething();
+} catch (err) {
+	throw new APIError("Request failed", 500, { cause: err });
 }
 ```
 

--- a/lib/rules/preserve-caught-error.js
+++ b/lib/rules/preserve-caught-error.js
@@ -161,14 +161,6 @@ module.exports = {
 			recommended: true,
 			url: "https://eslint.org/docs/latest/rules/preserve-caught-error", // URL to the documentation page for this rule
 		},
-		/*
-		 * TODO: We should allow passing `customErrorTypes` option once something like `typescript-eslint`'s
-		 * 		`TypeOrValueSpecifier` is implemented in core Eslint.
-		 *      See:
-		 * 		1. https://typescript-eslint.io/packages/type-utils/type-or-value-specifier/
-		 *      2. https://github.com/eslint/eslint/pull/19913#discussion_r2192608593
-		 *      3. https://github.com/eslint/eslint/discussions/16540
-		 */
 		schema: [
 			{
 				type: "object",
@@ -177,6 +169,15 @@ module.exports = {
 						type: "boolean",
 						description:
 							"Requires the catch blocks to always have the caught error parameter so it is not discarded.",
+					},
+					errorClassNames: {
+						type: "array",
+						description:
+							"Additional error class names to check for cause preservation.",
+						items: {
+							type: "string",
+						},
+						uniqueItems: true,
 					},
 				},
 				additionalProperties: false,
@@ -201,7 +202,8 @@ module.exports = {
 
 	create(context) {
 		const sourceCode = context.sourceCode;
-		const [{ requireCatchParameter }] = context.options;
+		const [{ requireCatchParameter, errorClassNames = [] }] =
+			context.options;
 
 		//----------------------------------------------------------------------
 		// Helpers
@@ -216,19 +218,31 @@ module.exports = {
 		 * @returns {boolean} `true` if a new "Error" is being thrown, else `false`.
 		 */
 		function isThrowingNewError(throwStatement) {
-			return (
-				(throwStatement.argument.type === "NewExpression" ||
-					throwStatement.argument.type === "CallExpression") &&
-				throwStatement.argument.callee.type === "Identifier" &&
-				BUILT_IN_ERROR_TYPES.has(throwStatement.argument.callee.name) &&
-				/*
-				 * Make sure the thrown Error is instance is one of the built-in global error types.
-				 * Custom imports could shadow this, which would lead to false positives.
-				 * e.g. import { Error } from "./my-custom-error.js";
-				 *      throw Error("Failed to perform error prone operations");
-				 */
-				sourceCode.isGlobalReference(throwStatement.argument.callee)
-			);
+			if (
+				!(
+					throwStatement.argument.type === "NewExpression" ||
+					throwStatement.argument.type === "CallExpression"
+				) ||
+				throwStatement.argument.callee.type !== "Identifier"
+			) {
+				return false;
+			}
+
+			const errorClassName = throwStatement.argument.callee.name;
+
+			// Check if it's a built-in error type (must be global reference)
+			if (BUILT_IN_ERROR_TYPES.has(errorClassName)) {
+				return sourceCode.isGlobalReference(
+					throwStatement.argument.callee,
+				);
+			}
+
+			// Check if it's a custom error class name from options
+			if (errorClassNames.includes(errorClassName)) {
+				return true;
+			}
+
+			return false;
 		}
 
 		/**

--- a/lib/rules/preserve-caught-error.js
+++ b/lib/rules/preserve-caught-error.js
@@ -458,25 +458,88 @@ module.exports = {
 											return null;
 										}
 
-										// Non-AggregateError types (built-in and custom)
-										const optionsArg = args[optionsIndex];
-										const lastProvidedArg = args.at(-1);
-
-										/*
-										 * Custom error with fewer args than the options position: signature is
-										 * unknown, so skip rather than synthesize values for the missing slots.
-										 */
+										// Normal Error types
 										if (
-											args.length < optionsIndex &&
-											!BUILT_IN_ERROR_TYPES.has(
+											BUILT_IN_ERROR_TYPES.has(
 												errorClassName,
 											)
 										) {
+											const messageArg = args[0];
+											const optionsArg = args[1];
+
+											if (!messageArg) {
+												// Case: `throw new Error()` → insert both message and options
+												const lastToken =
+													sourceCode.getLastToken(
+														throwExpression,
+													);
+												const lastCalleeToken =
+													sourceCode.getLastToken(
+														throwExpression.callee,
+													);
+												const parenToken =
+													sourceCode.getFirstTokenBetween(
+														lastCalleeToken,
+														lastToken,
+														astUtils.isOpeningParenToken,
+													);
+
+												if (parenToken) {
+													return fixer.insertTextAfter(
+														parenToken,
+														`"", { cause: ${caughtError.name} }`,
+													);
+												}
+												return fixer.insertTextAfter(
+													throwExpression.callee,
+													`("", { cause: ${caughtError.name} })`,
+												);
+											}
+											if (!optionsArg) {
+												// Case: `throw new Error("Some message")` → insert only options
+												return fixer.insertTextAfter(
+													messageArg,
+													`, { cause: ${caughtError.name} }`,
+												);
+											}
+
+											if (
+												optionsArg.type ===
+												"ObjectExpression"
+											) {
+												return insertCauseIntoOptions(
+													fixer,
+													optionsArg,
+													caughtError.name,
+												);
+											}
+
+											return null; // Identifier or spread — do not fix
+										}
+
+										// Custom error types
+										const optionsArg = args[optionsIndex];
+
+										/*
+										 * Custom error signature is unknown, so skip the suggestion rather
+										 * than synthesize placeholder values for missing positional args.
+										 */
+										if (args.length < optionsIndex) {
 											return null;
 										}
 
-										if (!lastProvidedArg) {
-											// Case: no arguments at all
+										if (!optionsArg) {
+											const lastProvidedArg = args.at(-1);
+
+											if (lastProvidedArg) {
+												// Options slot missing, all prior args provided → append options
+												return fixer.insertTextAfter(
+													lastProvidedArg,
+													`, { cause: ${caughtError.name} }`,
+												);
+											}
+
+											// argumentPosition: 1 and no args → insert `{ cause: err }` inside parens
 											const lastToken =
 												sourceCode.getLastToken(
 													throwExpression,
@@ -492,33 +555,15 @@ module.exports = {
 													astUtils.isOpeningParenToken,
 												);
 
-											// Build placeholder args for positions before optionsIndex
-											const placeholders = Array(
-												optionsIndex,
-											)
-												.fill(`""`)
-												.join(", ");
-											const insertText = placeholders
-												? `${placeholders}, { cause: ${caughtError.name} }`
-												: `{ cause: ${caughtError.name} }`;
-
 											if (parenToken) {
 												return fixer.insertTextAfter(
 													parenToken,
-													insertText,
+													`{ cause: ${caughtError.name} }`,
 												);
 											}
 											return fixer.insertTextAfter(
 												throwExpression.callee,
-												`(${insertText})`,
-											);
-										}
-
-										if (!optionsArg) {
-											// Options argument not provided yet — insert after last existing argument
-											return fixer.insertTextAfter(
-												lastProvidedArg,
-												`, { cause: ${caughtError.name} }`,
+												`({ cause: ${caughtError.name} })`,
 											);
 										}
 

--- a/lib/rules/preserve-caught-error.js
+++ b/lib/rules/preserve-caught-error.js
@@ -40,18 +40,13 @@ const BUILT_IN_ERROR_TYPES = new Set([
 /**
  * Finds and returns information about the `cause` property of an error being thrown.
  * @param {ASTNode} throwStatement `ThrowStatement` to be checked.
+ * @param {number} optionsIndex The index of the options argument in the error constructor.
  * @returns {{ value: ASTNode; multipleDefinitions: boolean; } | UNKNOWN_CAUSE | null}
  * Information about the `cause` of the error being thrown, such as the value node and
  * whether there are multiple definitions of `cause`. `null` if there is no `cause`.
  */
-function getErrorCause(throwStatement) {
+function getErrorCause(throwStatement, optionsIndex) {
 	const throwExpression = throwStatement.argument;
-	/*
-	 * Determine which argument index holds the options object
-	 * `AggregateError` is a special case as it accepts the `options` object as third argument.
-	 */
-	const optionsIndex =
-		throwExpression.callee.name === "AggregateError" ? 2 : 1;
 
 	/*
 	 * Make sure there is no `SpreadElement` at or before the `optionsIndex`
@@ -152,6 +147,7 @@ module.exports = {
 		defaultOptions: [
 			{
 				requireCatchParameter: false,
+				errorClassNames: [],
 			},
 		],
 
@@ -175,7 +171,21 @@ module.exports = {
 						description:
 							"Additional error class names to check for cause preservation.",
 						items: {
-							type: "string",
+							oneOf: [
+								{ type: "string" },
+								{
+									type: "object",
+									required: ["name", "argumentPosition"],
+									properties: {
+										name: { type: "string" },
+										argumentPosition: {
+											type: "integer",
+											minimum: 1,
+										},
+									},
+									additionalProperties: false,
+								},
+							],
 						},
 						uniqueItems: true,
 					},
@@ -202,8 +212,15 @@ module.exports = {
 
 	create(context) {
 		const sourceCode = context.sourceCode;
-		const [{ requireCatchParameter, errorClassNames = [] }] =
+		const [{ requireCatchParameter, errorClassNames: rawErrorClassNames }] =
 			context.options;
+
+		// Normalize: "AppError" → { name: "AppError", argumentPosition: 2 }
+		const errorClassNames = rawErrorClassNames.map(item =>
+			typeof item === "string"
+				? { name: item, argumentPosition: 2 }
+				: item,
+		);
 
 		//----------------------------------------------------------------------
 		// Helpers
@@ -222,23 +239,41 @@ module.exports = {
 				!(
 					throwStatement.argument.type === "NewExpression" ||
 					throwStatement.argument.type === "CallExpression"
-				) ||
-				throwStatement.argument.callee.type !== "Identifier"
+				)
 			) {
 				return false;
 			}
 
-			const errorClassName = throwStatement.argument.callee.name;
+			const callee = throwStatement.argument.callee;
 
-			// Check if it's a built-in error type (must be global reference)
-			if (BUILT_IN_ERROR_TYPES.has(errorClassName)) {
-				return sourceCode.isGlobalReference(
-					throwStatement.argument.callee,
-				);
+			/*
+			 * Make sure the thrown Error instance is one of the built-in global error types.
+			 * Custom imports could shadow this, which would lead to false positives.
+			 * e.g. import { Error } from "./my-custom-error.js";
+			 *      throw Error("Failed to perform error prone operations");
+			 */
+			if (
+				callee.type === "Identifier" &&
+				BUILT_IN_ERROR_TYPES.has(callee.name)
+			) {
+				return sourceCode.isGlobalReference(callee);
 			}
 
-			// Check if it's a custom error class name from options
-			if (errorClassNames.includes(errorClassName)) {
+			// Custom error class names: Identifier (e.g., `throw new AppError(...)`)
+			if (
+				callee.type === "Identifier" &&
+				errorClassNames.some(e => e.name === callee.name)
+			) {
+				return true;
+			}
+
+			// Custom error class names via MemberExpression (e.g., `throw new errors.AppError(...)`)
+			if (
+				callee.type === "MemberExpression" &&
+				!callee.computed &&
+				callee.property.type === "Identifier" &&
+				errorClassNames.some(e => e.name === callee.property.name)
+			) {
 				return true;
 			}
 
@@ -313,8 +348,29 @@ module.exports = {
 						return;
 					}
 
+					// Determine the options argument index
+					const callee = throwStatement.argument.callee;
+					const errorClassName =
+						callee.type === "Identifier"
+							? callee.name
+							: callee.property.name;
+
+					let optionsIndex;
+					if (BUILT_IN_ERROR_TYPES.has(errorClassName)) {
+						optionsIndex =
+							errorClassName === "AggregateError" ? 2 : 1;
+					} else {
+						const config = errorClassNames.find(
+							e => e.name === errorClassName,
+						);
+						optionsIndex = config.argumentPosition - 1;
+					}
+
 					// Check if there is a cause attached to the new error
-					const errorCauseInfo = getErrorCause(throwStatement);
+					const errorCauseInfo = getErrorCause(
+						throwStatement,
+						optionsIndex,
+					);
 
 					if (errorCauseInfo === UNKNOWN_CAUSE) {
 						// Error options exist, but too complicated to be analyzed/fixed
@@ -333,11 +389,11 @@ module.exports = {
 										const throwExpression =
 											throwStatement.argument;
 										const args = throwExpression.arguments;
-										const errorType =
-											throwExpression.callee.name;
 
 										// AggregateError: errors, message, options
-										if (errorType === "AggregateError") {
+										if (
+											errorClassName === "AggregateError"
+										) {
 											const errorsArg = args[0];
 											const messageArg = args[1];
 											const optionsArg = args[2];
@@ -402,12 +458,12 @@ module.exports = {
 											return null;
 										}
 
-										// Normal Error types
-										const messageArg = args[0];
-										const optionsArg = args[1];
+										// Non-AggregateError types (built-in and custom)
+										const optionsArg = args[optionsIndex];
+										const lastProvidedArg = args.at(-1);
 
-										if (!messageArg) {
-											// Case: `throw new Error()` → insert both message and options
+										if (!lastProvidedArg) {
+											// Case: no arguments at all
 											const lastToken =
 												sourceCode.getLastToken(
 													throwExpression,
@@ -423,21 +479,32 @@ module.exports = {
 													astUtils.isOpeningParenToken,
 												);
 
+											// Build placeholder args for positions before optionsIndex
+											const placeholders = Array(
+												optionsIndex,
+											)
+												.fill(`""`)
+												.join(", ");
+											const insertText = placeholders
+												? `${placeholders}, { cause: ${caughtError.name} }`
+												: `{ cause: ${caughtError.name} }`;
+
 											if (parenToken) {
 												return fixer.insertTextAfter(
 													parenToken,
-													`"", { cause: ${caughtError.name} }`,
+													insertText,
 												);
 											}
 											return fixer.insertTextAfter(
 												throwExpression.callee,
-												`("", { cause: ${caughtError.name} })`,
+												`(${insertText})`,
 											);
 										}
+
 										if (!optionsArg) {
-											// Case: `throw new Error("Some message")` → insert only options
+											// Options argument not provided yet — insert after last existing argument
 											return fixer.insertTextAfter(
-												messageArg,
+												lastProvidedArg,
 												`, { cause: ${caughtError.name} }`,
 											);
 										}

--- a/lib/rules/preserve-caught-error.js
+++ b/lib/rules/preserve-caught-error.js
@@ -462,6 +462,19 @@ module.exports = {
 										const optionsArg = args[optionsIndex];
 										const lastProvidedArg = args.at(-1);
 
+										/*
+										 * Custom error with fewer args than the options position: signature is
+										 * unknown, so skip rather than synthesize values for the missing slots.
+										 */
+										if (
+											args.length < optionsIndex &&
+											!BUILT_IN_ERROR_TYPES.has(
+												errorClassName,
+											)
+										) {
+											return null;
+										}
+
 										if (!lastProvidedArg) {
 											// Case: no arguments at all
 											const lastToken =

--- a/lib/rules/preserve-caught-error.js
+++ b/lib/rules/preserve-caught-error.js
@@ -390,6 +390,27 @@ module.exports = {
 											throwStatement.argument;
 										const args = throwExpression.arguments;
 
+										/**
+										 * Inserts `cause` into the options argument if it is an `ObjectExpression`.
+										 * @param {ASTNode} optionsArg The options argument node.
+										 * @returns {Fix | null} The fix, or `null` if the argument is not an object.
+										 */
+										function fixExistingOptions(
+											optionsArg,
+										) {
+											if (
+												optionsArg.type ===
+												"ObjectExpression"
+											) {
+												return insertCauseIntoOptions(
+													fixer,
+													optionsArg,
+													caughtError.name,
+												);
+											}
+											return null;
+										}
+
 										// AggregateError: errors, message, options
 										if (
 											errorClassName === "AggregateError"
@@ -443,19 +464,9 @@ module.exports = {
 												);
 											}
 
-											if (
-												optionsArg.type ===
-												"ObjectExpression"
-											) {
-												return insertCauseIntoOptions(
-													fixer,
-													optionsArg,
-													caughtError.name,
-												);
-											}
-
-											// Complex dynamic options — skip
-											return null;
+											return fixExistingOptions(
+												optionsArg,
+											);
 										}
 
 										// Normal Error types
@@ -503,18 +514,9 @@ module.exports = {
 												);
 											}
 
-											if (
-												optionsArg.type ===
-												"ObjectExpression"
-											) {
-												return insertCauseIntoOptions(
-													fixer,
-													optionsArg,
-													caughtError.name,
-												);
-											}
-
-											return null; // Identifier or spread — do not fix
+											return fixExistingOptions(
+												optionsArg,
+											);
 										}
 
 										// Custom error types
@@ -567,18 +569,7 @@ module.exports = {
 											);
 										}
 
-										if (
-											optionsArg.type ===
-											"ObjectExpression"
-										) {
-											return insertCauseIntoOptions(
-												fixer,
-												optionsArg,
-												caughtError.name,
-											);
-										}
-
-										return null; // Identifier or spread — do not fix
+										return fixExistingOptions(optionsArg);
 									},
 								},
 							],

--- a/lib/types/rules.d.ts
+++ b/lib/types/rules.d.ts
@@ -4968,6 +4968,16 @@ export interface ESLintRules extends Linter.RulesRecord {
 				 * @default false
 				 */
 				requireCatchParameter: boolean;
+				/**
+				 * @default []
+				 */
+				errorClassNames: Array<
+					| string
+					| {
+							name: string;
+							argumentPosition: number;
+					  }
+				>;
 			}>,
 		]
 	>;

--- a/tests/lib/rules/preserve-caught-error.js
+++ b/tests/lib/rules/preserve-caught-error.js
@@ -848,3 +848,97 @@ ruleTester.run("preserve-caught-error", rule, {
 		},
 	],
 });
+
+// Custom error class names - additional valid cases
+ruleTester.run("preserve-caught-error", rule, {
+	valid: [
+		{
+			code: `
+			class CustomApplicationError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomApplicationError("Cause not provided", { cause: err });
+			}`,
+			options: [{ errorClassNames: ["CustomApplicationError"] }],
+		},
+		{
+			code: `
+			class APIError extends Error {}
+			class ValidationError extends Error {}
+			try {
+				doSomething();
+			} catch (error) {
+				throw new APIError("API failed", { cause: error });
+				throw new ValidationError("Validation failed", { cause: error });
+			}`,
+			options: [{ errorClassNames: ["APIError", "ValidationError"] }],
+		},
+		{
+			code: `
+			class CustomError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomError("No cause");
+			}`,
+			options: [{ errorClassNames: [] }],
+		},
+	],
+	invalid: [
+		{
+			code: `
+			class CustomApplicationError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomApplicationError("Cause not provided");
+			}`,
+			options: [{ errorClassNames: ["CustomApplicationError"] }],
+			errors: [
+				{
+					messageId: "missingCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `
+			class CustomApplicationError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomApplicationError("Cause not provided", { cause: err });
+			}`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `
+			class APIError extends Error {}
+			try {
+				doSomething();
+			} catch (error) {
+				throw new APIError("API failed", { cause: wrong });
+			}`,
+			options: [{ errorClassNames: ["APIError"] }],
+			errors: [
+				{
+					messageId: "incorrectCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `
+			class APIError extends Error {}
+			try {
+				doSomething();
+			} catch (error) {
+				throw new APIError("API failed", { cause: error });
+			}`,
+						},
+					],
+				},
+			],
+		},
+	],
+});

--- a/tests/lib/rules/preserve-caught-error.js
+++ b/tests/lib/rules/preserve-caught-error.js
@@ -1136,5 +1136,22 @@ ruleTester.run("preserve-caught-error", rule, {
 				},
 			],
 		},
+
+		// Custom error with fewer args than the options position - no suggestion
+		{
+			code: `
+			try {
+				doSomething();
+			} catch (err) {
+				throw new MyError();
+			}`,
+			options: [{ errorClassNames: ["MyError"] }],
+			errors: [
+				{
+					messageId: "missingCause",
+					suggestions: [],
+				},
+			],
+		},
 	],
 });

--- a/tests/lib/rules/preserve-caught-error.js
+++ b/tests/lib/rules/preserve-caught-error.js
@@ -127,6 +127,91 @@ ruleTester.run("preserve-caught-error", rule, {
 		} catch (error) {
 			throw new Error("Something failed", { cause: anotherError, "cause": error });
 		}`,
+
+		// MemberExpression - Custom errors accessed via namespace
+		{
+			code: `
+			const errors = { AppError: class AppError extends Error {} };
+			try {
+				doSomething();
+			} catch (error) {
+				throw new errors.AppError("Something failed", { cause: error });
+			}`,
+			options: [{ errorClassNames: ["AppError"] }],
+		},
+		{
+			code: `
+			const lib = { APIError: class APIError extends Error {} };
+			try {
+				doSomething();
+			} catch (error) {
+				throw new lib.APIError("Something failed", { cause: error });
+			}`,
+			options: [{ errorClassNames: ["APIError"] }],
+		},
+
+		// Custom error class names - valid (Identifier with correct cause)
+		{
+			code: `
+			class CustomApplicationError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomApplicationError("Cause not provided", { cause: err });
+			}`,
+			options: [{ errorClassNames: ["CustomApplicationError"] }],
+		},
+		{
+			code: `
+			class APIError extends Error {}
+			try {
+				doSomething();
+			} catch (error) {
+				throw new APIError("API failed", { cause: error });
+			}`,
+			options: [{ errorClassNames: ["APIError"] }],
+		},
+		/* Custom error not in errorClassNames list — rule should not report */
+		{
+			code: `
+			class CustomError extends Error {}
+			try {
+				doSomething();
+			} catch (err) {
+				throw new CustomError("No cause");
+			}`,
+			options: [{ errorClassNames: [] }],
+		},
+
+		// argumentPosition - custom error with options at position 3
+		{
+			code: `
+			try {
+				doSomething();
+			} catch (err) {
+				throw new MyError("failed", someData, { cause: err });
+			}`,
+			options: [
+				{ errorClassNames: [{ name: "MyError", argumentPosition: 3 }] },
+			],
+		},
+
+		// argumentPosition - custom error with options at position 1
+		{
+			code: `
+			try {
+				doSomething();
+			} catch (err) {
+				throw new SimpleError({ cause: err });
+			}`,
+			options: [
+				{
+					errorClassNames: [
+						{ name: "SimpleError", argumentPosition: 1 },
+					],
+				},
+			],
+		},
 	],
 	invalid: [
 		/* 1. Throws a new Error without cause, even though an error was caught */
@@ -846,46 +931,8 @@ ruleTester.run("preserve-caught-error", rule, {
 			}`,
 			errors: [{ messageId: "incorrectCause" }],
 		},
-	],
-});
 
-// Custom error class names - additional valid cases
-ruleTester.run("preserve-caught-error", rule, {
-	valid: [
-		{
-			code: `
-			class CustomApplicationError extends Error {}
-			try {
-				doSomething();
-			} catch (err) {
-				throw new CustomApplicationError("Cause not provided", { cause: err });
-			}`,
-			options: [{ errorClassNames: ["CustomApplicationError"] }],
-		},
-		{
-			code: `
-			class APIError extends Error {}
-			class ValidationError extends Error {}
-			try {
-				doSomething();
-			} catch (error) {
-				throw new APIError("API failed", { cause: error });
-				throw new ValidationError("Validation failed", { cause: error });
-			}`,
-			options: [{ errorClassNames: ["APIError", "ValidationError"] }],
-		},
-		{
-			code: `
-			class CustomError extends Error {}
-			try {
-				doSomething();
-			} catch (err) {
-				throw new CustomError("No cause");
-			}`,
-			options: [{ errorClassNames: [] }],
-		},
-	],
-	invalid: [
+		// Custom error class names - missing cause (Identifier)
 		{
 			code: `
 			class CustomApplicationError extends Error {}
@@ -934,6 +981,155 @@ ruleTester.run("preserve-caught-error", rule, {
 				doSomething();
 			} catch (error) {
 				throw new APIError("API failed", { cause: error });
+			}`,
+						},
+					],
+				},
+			],
+		},
+
+		// MemberExpression - Custom errors missing cause
+		{
+			code: `
+			const errors = { AppError: class AppError extends Error {} };
+			try {
+				doSomething();
+			} catch (error) {
+				throw new errors.AppError("Something failed");
+			}`,
+			options: [{ errorClassNames: ["AppError"] }],
+			errors: [
+				{
+					messageId: "missingCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `
+			const errors = { AppError: class AppError extends Error {} };
+			try {
+				doSomething();
+			} catch (error) {
+				throw new errors.AppError("Something failed", { cause: error });
+			}`,
+						},
+					],
+				},
+			],
+		},
+
+		// MemberExpression - Custom errors with incorrect cause
+		{
+			code: `
+			const lib = { APIError: class APIError extends Error {} };
+			try {
+				doSomething();
+			} catch (error) {
+				throw new lib.APIError("Something failed", { cause: wrong });
+			}`,
+			options: [{ errorClassNames: ["APIError"] }],
+			errors: [
+				{
+					messageId: "incorrectCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `
+			const lib = { APIError: class APIError extends Error {} };
+			try {
+				doSomething();
+			} catch (error) {
+				throw new lib.APIError("Something failed", { cause: error });
+			}`,
+						},
+					],
+				},
+			],
+		},
+
+		// argumentPosition - missing cause at position 3
+		{
+			code: `
+			try {
+				doSomething();
+			} catch (err) {
+				throw new MyError("failed", someData);
+			}`,
+			options: [
+				{ errorClassNames: [{ name: "MyError", argumentPosition: 3 }] },
+			],
+			errors: [
+				{
+					messageId: "missingCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `
+			try {
+				doSomething();
+			} catch (err) {
+				throw new MyError("failed", someData, { cause: err });
+			}`,
+						},
+					],
+				},
+			],
+		},
+
+		// argumentPosition - incorrect cause at position 3
+		{
+			code: `
+			try {
+				doSomething();
+			} catch (err) {
+				throw new MyError("failed", someData, { cause: wrong });
+			}`,
+			options: [
+				{ errorClassNames: [{ name: "MyError", argumentPosition: 3 }] },
+			],
+			errors: [
+				{
+					messageId: "incorrectCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `
+			try {
+				doSomething();
+			} catch (err) {
+				throw new MyError("failed", someData, { cause: err });
+			}`,
+						},
+					],
+				},
+			],
+		},
+
+		// argumentPosition - missing cause at position 1
+		{
+			code: `
+			try {
+				doSomething();
+			} catch (err) {
+				throw new SimpleError();
+			}`,
+			options: [
+				{
+					errorClassNames: [
+						{ name: "SimpleError", argumentPosition: 1 },
+					],
+				},
+			],
+			errors: [
+				{
+					messageId: "missingCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `
+			try {
+				doSomething();
+			} catch (err) {
+				throw new SimpleError({ cause: err });
 			}`,
 						},
 					],


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
- [x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
- [ ] Add autofix to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

Fixes #20428

#### What changes did you make? (Give an overview)

Added a new `errorClassNames` option to the `preserve-caught-error` rule that allows users to specify custom error class names to check for cause preservation. 

Changes include:
- Updated rule schema to accept `errorClassNames` array option
- Modified `isThrowingNewError()` to handle both built-in and custom error classes
- Added 6 test cases covering valid and invalid scenarios with custom error classes



<!-- markdownlint-disable-file MD004 -->