### PR TITLE
fix: validate that max and maximum options are not both specified in max-params rule

### DIFF
--- a/lib/rules/max-params.js
+++ b/lib/rules/max-params.js
@@ -61,6 +61,7 @@ module.exports = {
 						},
 						additionalProperties: false,
 						not: { required: ["countVoidThis", "countThis"] },
+						not: { required: ["max", "maximum"] },
 					},
 				],
 			},


### PR DESCRIPTION
Fixes eslint/eslint#20322.

Currently, when both `max` and `maximum` options are specified for the `max-params` rule, only `maximum` takes priority without any error being thrown. This change adds a JSON Schema validation constraint that prevents both options from being used together, providing clearer feedback to users about the configuration error.