### PR TITLE
fix: catch errors thrown by rule fix functions in normalizeFixes

### DIFF
--- a/lib/linter/file-report.js
+++ b/lib/linter/file-report.js
@@ -293,7 +293,13 @@ function normalizeFixes(descriptor, sourceCode) {
 	const ruleFixer = new RuleFixer({ sourceCode });
 
 	// @type {null | Fix | Fix[] | IterableIterator<Fix>}
-	const fix = descriptor.fix(ruleFixer);
+	let fix;
+
+	try {
+		fix = descriptor.fix(ruleFixer);
+	} catch {
+		return null;
+	}
 
 	// Merge to one.
 	if (fix && Symbol.iterator in fix) {

--- a/tests/lib/linter/file-report.js
+++ b/tests/lib/linter/file-report.js
@@ -286,6 +286,22 @@ describe("FileReport", () => {
 
 			assert.strictEqual(fileReport.messages.length, 0);
 		});
+
+		it("should still add a message when the fix function throws", () => {
+			fileReport.addRuleMessage("foo-rule", 2, {
+				node,
+				loc: location,
+				message: "foo",
+				fix() {
+					throw new Error("ENOENT: no such file or directory");
+				},
+			});
+
+			assert.strictEqual(fileReport.messages.length, 1);
+			assert.strictEqual(fileReport.messages[0].ruleId, "foo-rule");
+			assert.strictEqual(fileReport.messages[0].message, "foo");
+			assert.strictEqual(fileReport.messages[0].fix, void 0);
+		});
 	});
 
 	describe("addError", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [X] (If the above is not checked) I have reviewed the AI-generated content before submitting.



#### What is the purpose of this pull request? (put an "X" next to an item)
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:** v24.3.0
- **npm version:** v11.4.2
- **Local ESLint version:** v10.1.0
- **Global ESLint version:** Not found
- **Operating System:** darwin 24.6.0

**What parser are you using?**

[x] `@typescript-eslint/parser`

(The bug is parser-independent — it affects any rule with a fixer that throws.)

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

Not configuration-specific. Any ESLint config that uses a rule whose `fix()` function throws an error will trigger this bug.

</details>

**What did you do?**

I saw a bug on a bad import line, but when I fixed it, more lint errors/warnings popped up in the same file. But fixing that file wasn't enough, because I kept finding even more lint problems in files without that import error. Ran the lint command and saw an ENOENT crash. After a small fix, _many_ lint issues emerged. Looks like ESLint doesn't catch errors that any fixer throws at it, so all the other fixers broke too. (I wrote this paragraph, but worked with _Claude Opus 4.6 Thinking_ for fixing and detailing the rest of this PR. I also made a PR on nx: [fix(linter): prevent ENOENT crash in getRelativeImportPath for unresolvable paths#35007](https://github.com/nrwl/nx/pull/35007)

Used `@nx/enforce-module-boundaries` (which provides an auto-fixer) in a project with wildcard tsconfig path aliases. The fixer calls `getRelativeImportPath` which crashes with `ENOENT` when it can't resolve the path. Reproduction repo: https://github.com/SharonLougheed/module-boundaries-bug

**What did you expect to happen?**

The lint error should still be reported, with the auto-fix suggestion dropped for that specific error.

**What actually happened?**

```
Oops! Something went wrong! :(
ENOENT: no such file or directory, open '.../libs/libB/src/lib/*'
Occurred while linting /path/to/libs/libA/src/lib/componentA/LibA.ts:3
Rule: "@nx/enforce-module-boundaries"
```

The crash propagates through `normalizeFixes` → `addRuleMessage` → `ruleErrorHandler` → the linter's outer catch, which re-throws. In the CLI, this reaches `eslint-helpers.js` where `controller.abort()` kills the **entire** `lintFiles` batch, suppressing every diagnostic across all files. The user sees an error about one file and reasonably assumes everything else was checked — there is no indication that all other diagnostics were lost.

In the IDE extension, the language server lints open files individually with no shared `AbortController`, so only the crashing file's diagnostics are lost. The crash is effectively invisible — no squiggles, no Problems panel entry, no notification. Every other open file still shows its lint errors normally, so the linter appears to be working fine.

Critically, a typical project uses many ESLint plugins simultaneously (`@typescript-eslint`, `eslint-plugin-import`, `eslint-plugin-react`, `@nx/eslint-plugin`, etc.), each with their own fixers. If one fixer in one plugin crashes on one file, every other perfectly-working fixer and rule from every other plugin across every file is suppressed — and the user has no way to tell. The rule author has no way to prevent this — the `AbortController` propagation is ESLint's own mechanism, and only ESLint can add the safety net. A single plugin bug shouldn't be able to silently disable linting for an entire workspace.

#### What changes did you make?

This PR wraps `descriptor.fix(ruleFixer)` in `normalizeFixes()` (`lib/linter/file-report.js`) with a try-catch that returns `null` on error. The lint error is still reported — only the auto-fix suggestion is dropped for that specific error.

**Before (one crash → zero diagnostics):**

```
Oops! Something went wrong! :(
ENOENT: no such file or directory
Occurred while linting /path/to/file.ts:3
Rule: "@nx/enforce-module-boundaries"
```

**After (crash caught → all diagnostics reported, fix dropped):**

```
file.ts:3:1  error  Projects cannot be imported by a relative path  @nx/enforce-module-boundaries
utils.ts:5   warn   Unexpected any  @typescript-eslint/no-explicit-any
...
✖ 7 problems (4 errors, 3 warnings)
```

#### Archived Issue

This was originally reported as [#13872](https://github.com/eslint/eslint/issues/13872) ("Improve error handling of crashing rules") in Nov 2020 by @AriPerkkio . That issue was auto-closed and archived without resolution. The problem described there — "every other valid linting error is lost" when a rule crashes — is exactly what we experienced and what this fix addresses for the `fix()` code path.

#### Is there anything you'd like reviewers to focus on?

- The fix is intentionally minimal: a 5-line try-catch in `normalizeFixes()`. Since `mapSuggestions()` also calls `normalizeFixes` for suggestion fixes, both the main fix and suggestion fix code paths are covered.
- The `ruleErrorHandler` in `linter.js` already catches and re-throws errors from rule _listeners_. This fix extends similar resilience to rule _fixers_.
