### PR TITLE
fix: handle generator yield paths in code analysis (#20583)

### DIFF
--- a/lib/linter/code-path-analysis/code-path-analyzer.js
+++ b/lib/linter/code-path-analysis/code-path-analyzer.js
@@ -626,8 +626,11 @@ function processCodePathToExit(analyzer, node) {
 		case "ImportExpression":
 		case "MemberExpression":
 		case "NewExpression":
-		case "YieldExpression":
 			state.makeFirstThrowablePathInTryBlock();
+			break;
+
+		case "YieldExpression":
+			state.makeYield();
 			break;
 
 		case "WhileStatement":

--- a/lib/linter/code-path-analysis/code-path-state.js
+++ b/lib/linter/code-path-analysis/code-path-state.js
@@ -569,11 +569,10 @@ class TryContext {
 		this.position = "try";
 
 		/**
-		 * If the `try` statement has a `finally` block, this affects how a
-		 * `return` statement behaves in the `try` block. Without `finally`,
-		 * `return` behaves as usual and doesn't require a fork; with `finally`,
-		 * `return` forks into the `finally` block, so we need a fork context
-		 * to track it.
+		 * If the `try` statement has a `finally` block, this affects how return-like
+		 * leaving paths behave in the `try` block. Without `finally`, they behave as
+		 * usual and don't require a fork; with `finally`, they fork into the
+		 * `finally` block, so we need a fork context to track them.
 		 * @type {ForkContext|null}
 		 */
 		this.returnedForkContext = hasFinalizer
@@ -1753,6 +1752,23 @@ class CodePathState {
 
 		this.pushForkContext(true);
 		this.forkContext.add(segments);
+	}
+
+	/**
+	 * Records abrupt resumption paths from a suspended `yield` expression,
+	 * then splits normal post-`yield` continuation into a fresh segment.
+	 * @returns {void}
+	 */
+	makeYield() {
+		const forkContext = this.forkContext;
+		const leavingSegments = forkContext.head;
+
+		if (forkContext.reachable) {
+			getReturnContext(this).returnedForkContext.add(leavingSegments);
+			getThrowContext(this).thrownForkContext.add(leavingSegments);
+
+			forkContext.replaceHead(forkContext.makeNext(-1, -1));
+		}
 	}
 
 	/**

--- a/tests/fixtures/code-path-analysis/generator-yield-return-1.js
+++ b/tests/fixtures/code-path-analysis/generator-yield-return-1.js
@@ -1,0 +1,42 @@
+/*expected
+initial->s2_1->s2_2->s2_3->s2_4;
+s2_2->s2_4;
+s2_1->final;
+s2_4->final;
+s2_1->thrown;
+*/
+/*expected
+initial->s1_1->final;
+*/
+
+function* generator(flag) {
+    yield 1;
+    if (flag) {
+        foo();
+    }
+    bar();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    thrown[label="✘",shape=circle,width=0.3,height=0.3,fixedsize=true];
+    s2_1[label="FunctionDeclaration:enter\nIdentifier (generator)\nIdentifier (flag)\nBlockStatement:enter\nExpressionStatement:enter\nYieldExpression:enter\nLiteral (1)"];
+    s2_2[label="YieldExpression:exit\nExpressionStatement:exit\nIfStatement:enter\nIdentifier (flag)"];
+    s2_3[label="BlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (foo)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s2_4[label="IfStatement:exit\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (bar)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit\nFunctionDeclaration:exit"];
+    initial->s2_1->s2_2->s2_3->s2_4;
+    s2_2->s2_4;
+    s2_1->final;
+    s2_4->final;
+    s2_1->thrown;
+}
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nFunctionDeclaration\nProgram:exit"];
+    initial->s1_1->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/try--generator-yield-finally-1.js
+++ b/tests/fixtures/code-path-analysis/try--generator-yield-finally-1.js
@@ -1,0 +1,48 @@
+/*expected
+initial->s2_1->s2_2->s2_3->s2_5;
+s2_1->s2_3;
+s2_2->s2_5;
+s2_3->s2_6;
+s2_1->s2_6->final;
+s2_5->final;
+*/
+/*expected
+initial->s1_1->final;
+*/
+
+function* generator() {
+    try {
+        yield 1;
+        foo();
+    } catch (err) {
+        bar(err);
+    } finally {
+        baz();
+    }
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s2_1[label="FunctionDeclaration:enter\nIdentifier (generator)\nBlockStatement:enter\nTryStatement:enter\nBlockStatement:enter\nExpressionStatement:enter\nYieldExpression:enter\nLiteral (1)"];
+    s2_2[label="YieldExpression:exit\nExpressionStatement:exit\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (foo)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s2_3[label="CatchClause:enter\nIdentifier (err)\nBlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (bar)\nIdentifier (err)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit\nCatchClause:exit"];
+    s2_5[label="BlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (baz)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit\nTryStatement:exit\nBlockStatement:exit\nFunctionDeclaration:exit"];
+    s2_6[label="BlockStatement:enter\nExpressionStatement:enter\nCallExpression:enter\nIdentifier (baz)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    initial->s2_1->s2_2->s2_3->s2_5;
+    s2_1->s2_3;
+    s2_2->s2_5;
+    s2_3->s2_6;
+    s2_1->s2_6->final;
+    s2_5->final;
+}
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program:enter\nFunctionDeclaration\nProgram:exit"];
+    initial->s1_1->final;
+}
+*/

--- a/tests/lib/rules/no-useless-assignment.js
+++ b/tests/lib/rules/no-useless-assignment.js
@@ -359,6 +359,31 @@ ruleTester.run("no-useless-assignment", rule, {
             a = 5;
         }
         console.log(a);`,
+		`function* generator() {
+            let done = false;
+            try {
+                yield 1;
+                done = true;
+            } catch {
+                done = true;
+            } finally {
+                if (!done) {
+                    console.log("done is false");
+                }
+            }
+        }`,
+		`function* generator() {
+            let done = false;
+            try {
+                yield 1;
+                done = true;
+                yield 2;
+            } finally {
+                if (done) {
+                    console.log("done is true");
+                }
+            }
+        }`,
 
 		// An expression within an assignment.
 		`const obj = { a: 5 };
@@ -1254,6 +1279,27 @@ ruleTester.run("no-useless-assignment", rule, {
 					data: { name: "v" },
 					line: 1,
 					column: 5,
+				},
+			],
+		},
+		{
+			code: `function* generator() {
+                let done = false;
+                try {
+                    yield 1;
+                } finally {
+                    done = true;
+                    console.log(done);
+                }
+            }`,
+			errors: [
+				{
+					messageId: "unnecessaryAssignment",
+					data: { name: "done" },
+					line: 2,
+					column: 21,
+					endLine: 2,
+					endColumn: 25,
 				},
 			],
 		},


### PR DESCRIPTION
This teaches code-path analysis to treat `yield` as a return-like leaving path in generators, which fixes the `no-useless-assignment` false positive and the related generator fixtures.

Validation:
- stdin repro via `node .\bin\eslint.js --stdin ... --rule ''{"no-useless-assignment":"error"}''` now exits 0 with no lint error
- `node .\node_modules\mocha\bin\mocha.js tests/lib/rules/no-useless-assignment.js`
- `node .\node_modules\mocha\bin\mocha.js tests/lib/linter/code-path-analysis/code-path-analyzer.js`
- `node .\bin\eslint.js lib/linter/code-path-analysis/code-path-analyzer.js lib/linter/code-path-analysis/code-path-state.js tests/lib/rules/no-useless-assignment.js`
- `node .\node_modules\prettier\bin\prettier.cjs --check ...`