### PR TITLE
fix: add es2015 lib reference to published types

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -25,6 +25,8 @@
  * SOFTWARE
  */
 
+/// <reference lib="es2015" />
+
 import * as ESTree from "estree";
 import type {
 	DeprecatedInfo,

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "test:fuzz": "node Makefile.js fuzz",
     "test:performance": "node Makefile.js perf",
     "test:pnpm": "cd tests/pnpm && node check.js && pnpm install && pnpm exec tsc",
-    "test:types": "tsc -p tests/lib/types/tsconfig.json"
+    "test:types": "tsc -p tests/lib/types/tsconfig.json && tsc -p tests/lib/types/tsconfig.es5-package.json"
   },
   "gitHooks": {
     "pre-commit": "lint-staged"

--- a/tests/lib/types/tsconfig.es5-package.json
+++ b/tests/lib/types/tsconfig.es5-package.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "module": "node16",
+    "lib": ["dom", "es5"],
+    "strict": true,
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "exactOptionalPropertyTypes": true
+  },
+  "files": [
+    "../../../lib/types/config-api.d.ts",
+    "../../../lib/types/index.d.ts",
+    "../../../lib/types/rules.d.ts",
+    "../../../lib/types/universal.d.ts",
+    "../../../lib/types/use-at-your-own-risk.d.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- add an `es2015` lib reference to ESLint's published root declaration file so its `Promise`, `Map`, and `Iterable` types compile under `es5` consumers
- extend `npm run test:types` with a dedicated package-surface declaration compile that exercises the published `.d.ts` entrypoints with `lib: ["dom", "es5"]`

## Testing
- npm run test:types