### PR TITLE
fix: add es2015 lib reference to published types

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -2,6 +2,7 @@
  * @fileoverview This file contains the core types for ESLint. It was initially extracted
  * from the `@types/eslint` package.
  */
+/// <reference lib="es2015" />
 
 /*
  * MIT License

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "test:fuzz": "node Makefile.js fuzz",
     "test:performance": "node Makefile.js perf",
     "test:pnpm": "cd tests/pnpm && node check.js && pnpm install && pnpm exec tsc",
-    "test:types": "tsc -p tests/lib/types/tsconfig.json"
+    "test:types": "tsc -p tests/lib/types/tsconfig.json && tsc -p tests/lib/types/tsconfig.es5.json"
   },
   "gitHooks": {
     "pre-commit": "lint-staged"

--- a/tests/lib/types/es5-lib.test.ts
+++ b/tests/lib/types/es5-lib.test.ts
@@ -1,0 +1,9 @@
+import { builtinRules } from "eslint/use-at-your-own-risk";
+import type { ESLint, SourceCode } from "eslint";
+
+declare const eslintCtor: typeof ESLint;
+declare const sourceCode: SourceCode;
+
+void eslintCtor;
+void sourceCode;
+void builtinRules;

--- a/tests/lib/types/tsconfig.es5.json
+++ b/tests/lib/types/tsconfig.es5.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "node16",
+    "lib": ["dom", "es5"],
+    "strict": true,
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "exactOptionalPropertyTypes": true
+  },
+  "files": ["es5-lib.test.ts"]
+}


### PR DESCRIPTION
## Summary
- add an `es2015` lib reference to ESLint's published root type entrypoint so `Map`, `Iterable`, and `Promise` are available without forcing consumers to opt into ES2015 libs
- extend `npm run test:types` with a consumer-style `dom + es5` compile that imports `eslint` and `eslint/use-at-your-own-risk`
- keep the regression minimal so the existing type suite still runs unchanged alongside the new smoke test

## Testing
- npm run test:types

Fixes #20685.