### PR TITLE
fix: add es2015 lib reference for published types

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -1,3 +1,5 @@
+/// <reference lib="es2015" />
+
 /**
  * @fileoverview This file contains the core types for ESLint. It was initially extracted
  * from the `@types/eslint` package.

--- a/lib/types/use-at-your-own-risk.d.ts
+++ b/lib/types/use-at-your-own-risk.d.ts
@@ -1,3 +1,5 @@
+/// <reference lib="es2015" />
+
 /**
  * @fileoverview This file contains the types for the use-at-your-own-risk
  * entrypoint. It was initially extracted from the `@types/eslint` package.

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "test:fuzz": "node Makefile.js fuzz",
     "test:performance": "node Makefile.js perf",
     "test:pnpm": "cd tests/pnpm && node check.js && pnpm install && pnpm exec tsc",
-    "test:types": "tsc -p tests/lib/types/tsconfig.json"
+    "test:types": "tsc -p tests/lib/types/tsconfig.json && tsc -p tests/lib/types/tsconfig.es5.json"
   },
   "gitHooks": {
     "pre-commit": "lint-staged"

--- a/tests/lib/types/es5-lib-consumer.test.ts
+++ b/tests/lib/types/es5-lib-consumer.test.ts
@@ -1,0 +1,8 @@
+import { ESLint } from "eslint";
+import { builtinRules, shouldUseFlatConfig } from "eslint/use-at-your-own-risk";
+
+const eslint = new ESLint();
+
+eslint;
+builtinRules;
+shouldUseFlatConfig();

--- a/tests/lib/types/tsconfig.es5.json
+++ b/tests/lib/types/tsconfig.es5.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "node16",
+    "lib": ["dom", "es5"],
+    "strict": true,
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "exactOptionalPropertyTypes": true
+  },
+  "files": ["es5-lib-consumer.test.ts"]
+}


### PR DESCRIPTION
Fixes #20685.

## Summary
- add an `es2015` lib reference to the published `eslint` declaration entrypoints that rely on `Map`, `Iterable`, and `Promise` 
- add a dedicated ES5-era consumer type check that imports `eslint` and `eslint/use-at-your-own-risk` 
- run both the existing type suite and the new low-lib declaration regression in `npm run test:types` 

## Testing
- npm run test:types
- npm run lint:types
- node .\\node_modules\\typescript\\bin\\tsc --noEmit --module node16 --lib es5,dom --types estree --pretty false lib/types/index.d.ts
