### PR TITLE
fix: ignore unavailable globals via global object in no-obj-calls

### DIFF
--- a/lib/rules/no-obj-calls.js
+++ b/lib/rules/no-obj-calls.js
@@ -79,6 +79,10 @@ module.exports = {
 				const traceMap = {};
 
 				for (const g of nonCallableGlobals) {
+					if (!scope.set.has(g)) {
+						continue;
+					}
+
 					traceMap[g] = {
 						[CALL]: true,
 						[CONSTRUCT]: true,

--- a/tests/lib/rules/no-obj-calls.js
+++ b/tests/lib/rules/no-obj-calls.js
@@ -122,6 +122,20 @@ ruleTester.run("no-obj-calls", rule, {
 				globals: { Temporal: false },
 			},
 		},
+		{
+			code: "window.Atomics();",
+			languageOptions: {
+				ecmaVersion: 6,
+				globals: { window: false },
+			},
+		},
+		{
+			code: "const atomics = window.Atomics; atomics();",
+			languageOptions: {
+				ecmaVersion: 6,
+				globals: { window: false },
+			},
+		},
 
 		// non-existing variables
 		"/*globals Math: off*/ Math();",


### PR DESCRIPTION
## Summary
- only trace `no-obj-calls` globals that actually exist in the current scope
- stop treating `window.Atomics()` as a call to the built-in `Atomics` global when `Atomics` is unavailable for the configured `ecmaVersion`
- add direct-call and alias regressions for the reported `window.Atomics` case

Closes #20674.

## Testing
- `node node_modules/mocha/bin/mocha.js tests/lib/rules/no-obj-calls.js`
- `node node_modules/prettier/bin/prettier.cjs --check lib/rules/no-obj-calls.js tests/lib/rules/no-obj-calls.js`
- `git diff --check`