### PR TITLE
feat: update error location of `func-style`

### DIFF
--- a/lib/rules/func-style.js
+++ b/lib/rules/func-style.js
@@ -5,6 +5,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const astUtils = require("./utils/ast-utils");
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -71,6 +77,7 @@ module.exports = {
 		const enforceDeclarations = style === "declaration";
 		const { namedExports: exportFunctionStyle } = overrides;
 		const stack = [];
+		const sourceCode = context.sourceCode;
 
 		/**
 		 * Checks if a function declaration is part of an overloaded function
@@ -120,7 +127,10 @@ module.exports = {
 						node.parent.type !== "ExportNamedDeclaration") &&
 					!isOverloadedFunction(node)
 				) {
-					context.report({ node, messageId: "expression" });
+					context.report({
+						loc: astUtils.getFunctionHeadLoc(node, sourceCode),
+						messageId: "expression",
+					});
 				}
 
 				if (
@@ -128,7 +138,10 @@ module.exports = {
 					exportFunctionStyle === "expression" &&
 					!isOverloadedFunction(node)
 				) {
-					context.report({ node, messageId: "expression" });
+					context.report({
+						loc: astUtils.getFunctionHeadLoc(node, sourceCode),
+						messageId: "expression",
+					});
 				}
 			},
 			"FunctionDeclaration:exit"() {
@@ -147,7 +160,10 @@ module.exports = {
 					!(allowTypeAnnotation && node.parent.id.typeAnnotation)
 				) {
 					context.report({
-						node: node.parent,
+						loc: astUtils.getFunctionHeadLoc(
+							node.parent,
+							sourceCode,
+						),
 						messageId: "declaration",
 					});
 				}
@@ -160,7 +176,10 @@ module.exports = {
 					!(allowTypeAnnotation && node.parent.id.typeAnnotation)
 				) {
 					context.report({
-						node: node.parent,
+						loc: astUtils.getFunctionHeadLoc(
+							node.parent,
+							sourceCode,
+						),
 						messageId: "declaration",
 					});
 				}
@@ -196,7 +215,13 @@ module.exports = {
 						!(allowTypeAnnotation && node.parent.id.typeAnnotation)
 					) {
 						context.report({
-							node: node.parent,
+							loc: {
+								start: node.parent.loc.start,
+								end: astUtils.getFunctionHeadLoc(
+									node,
+									sourceCode,
+								).end,
+							},
 							messageId: "declaration",
 						});
 					}
@@ -208,7 +233,13 @@ module.exports = {
 						!(allowTypeAnnotation && node.parent.id.typeAnnotation)
 					) {
 						context.report({
-							node: node.parent,
+							loc: {
+								start: node.parent.loc.start,
+								end: astUtils.getFunctionHeadLoc(
+									node,
+									sourceCode,
+								).end,
+							},
 							messageId: "declaration",
 						});
 					}

--- a/tests/lib/rules/func-style.js
+++ b/tests/lib/rules/func-style.js
@@ -219,6 +219,10 @@ ruleTester.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 5,
+					endLine: 1,
+					endColumn: 19,
 				},
 			],
 		},
@@ -229,6 +233,10 @@ ruleTester.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 5,
+					endLine: 1,
+					endColumn: 16,
 				},
 			],
 		},
@@ -239,6 +247,10 @@ ruleTester.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 5,
+					endLine: 1,
+					endColumn: 16,
 				},
 			],
 		},
@@ -249,6 +261,10 @@ ruleTester.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 5,
+					endLine: 1,
+					endColumn: 16,
 				},
 			],
 		},
@@ -258,6 +274,10 @@ ruleTester.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "expression",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 13,
 				},
 			],
 		},
@@ -267,6 +287,10 @@ ruleTester.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "expression",
+					line: 1,
+					column: 8,
+					endLine: 1,
+					endColumn: 20,
 				},
 			],
 		},
@@ -279,6 +303,10 @@ ruleTester.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "expression",
+					line: 1,
+					column: 8,
+					endLine: 1,
+					endColumn: 20,
 				},
 			],
 		},
@@ -291,6 +319,10 @@ ruleTester.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "expression",
+					line: 1,
+					column: 8,
+					endLine: 1,
+					endColumn: 20,
 				},
 			],
 		},
@@ -301,6 +333,10 @@ ruleTester.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 12,
+					endLine: 1,
+					endColumn: 26,
 				},
 			],
 		},
@@ -314,6 +350,10 @@ ruleTester.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 12,
+					endLine: 1,
+					endColumn: 26,
 				},
 			],
 		},
@@ -327,6 +367,10 @@ ruleTester.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 12,
+					endLine: 1,
+					endColumn: 26,
 				},
 			],
 		},
@@ -337,6 +381,10 @@ ruleTester.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 12,
+					endLine: 1,
+					endColumn: 23,
 				},
 			],
 		},
@@ -350,6 +398,10 @@ ruleTester.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 12,
+					endLine: 1,
+					endColumn: 21,
 				},
 			],
 		},
@@ -363,6 +415,10 @@ ruleTester.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 12,
+					endLine: 1,
+					endColumn: 21,
 				},
 			],
 		},
@@ -376,6 +432,11 @@ ruleTester.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "expression",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 13,
+
 				},
 			],
 		},
@@ -389,6 +450,10 @@ ruleTester.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 5,
+					endLine: 1,
+					endColumn: 19,
 				},
 			],
 		},
@@ -402,6 +467,10 @@ ruleTester.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 5,
+					endLine: 1,
+					endColumn: 16,
 				},
 			],
 		},
@@ -411,6 +480,10 @@ ruleTester.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 7,
+					endLine: 1,
+					endColumn: 21,
 				},
 			],
 		},
@@ -420,6 +493,10 @@ ruleTester.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "expression",
+					line: 1,
+					column: 5,
+					endLine: 1,
+					endColumn: 16,
 				},
 			],
 		},
@@ -429,6 +506,10 @@ ruleTester.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 7,
+					endLine: 1,
+					endColumn: 18,
 				},
 			],
 		},
@@ -444,6 +525,10 @@ ruleTester.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 14,
+					endLine: 1,
+					endColumn: 28,
 				},
 			],
 		},
@@ -459,6 +544,10 @@ ruleTester.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 14,
+					endLine: 1,
+					endColumn: 25,
 				},
 			],
 		},
@@ -468,6 +557,10 @@ ruleTester.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "expression",
+					line: 1,
+					column: 10,
+					endLine: 1,
+					endColumn: 22,
 				},
 			],
 		},
@@ -690,6 +783,10 @@ ruleTesterTypeScript.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 7,
+					endLine: 1,
+					endColumn: 33,
 				},
 			],
 		},
@@ -699,6 +796,10 @@ ruleTesterTypeScript.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 7,
+					endLine: 1,
+					endColumn: 36,
 				},
 			],
 		},
@@ -708,6 +809,10 @@ ruleTesterTypeScript.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 7,
+					endLine: 1,
+					endColumn: 36,
 				},
 			],
 		},
@@ -717,6 +822,10 @@ ruleTesterTypeScript.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 7,
+					endLine: 1,
+					endColumn: 58,
 				},
 			],
 		},
@@ -726,6 +835,10 @@ ruleTesterTypeScript.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "expression",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 13,
 				},
 			],
 		},
@@ -735,6 +848,10 @@ ruleTesterTypeScript.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "expression",
+					line: 1,
+					column: 8,
+					endLine: 1,
+					endColumn: 20,
 				},
 			],
 		},
@@ -747,6 +864,10 @@ ruleTesterTypeScript.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "expression",
+					line: 1,
+					column: 8,
+					endLine: 1,
+					endColumn: 20,
 				},
 			],
 		},
@@ -759,6 +880,10 @@ ruleTesterTypeScript.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "expression",
+					line: 1,
+					column: 8,
+					endLine: 1,
+					endColumn: 20,
 				},
 			],
 		},
@@ -768,6 +893,10 @@ ruleTesterTypeScript.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 14,
+					endLine: 1,
+					endColumn: 40,
 				},
 			],
 		},
@@ -780,6 +909,10 @@ ruleTesterTypeScript.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 14,
+					endLine: 1,
+					endColumn: 40,
 				},
 			],
 		},
@@ -792,6 +925,10 @@ ruleTesterTypeScript.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 14,
+					endLine: 1,
+					endColumn: 40,
 				},
 			],
 		},
@@ -801,6 +938,10 @@ ruleTesterTypeScript.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 14,
+					endLine: 1,
+					endColumn: 43,
 				},
 			],
 		},
@@ -813,6 +954,10 @@ ruleTesterTypeScript.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 14,
+					endLine: 1,
+					endColumn: 41,
 				},
 			],
 		},
@@ -825,6 +970,10 @@ ruleTesterTypeScript.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 14,
+					endLine: 1,
+					endColumn: 41,
 				},
 			],
 		},
@@ -837,6 +986,10 @@ ruleTesterTypeScript.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "expression",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 13,
 				},
 			],
 		},
@@ -849,6 +1002,10 @@ ruleTesterTypeScript.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 7,
+					endLine: 1,
+					endColumn: 33,
 				},
 			],
 		},
@@ -861,6 +1018,10 @@ ruleTesterTypeScript.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "declaration",
+					line: 1,
+					column: 7,
+					endLine: 1,
+					endColumn: 36,
 				},
 			],
 		},
@@ -869,6 +1030,10 @@ ruleTesterTypeScript.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "expression",
+					line: 1,
+					column: 5,
+					endLine: 1,
+					endColumn: 16,
 				},
 			],
 		},
@@ -877,6 +1042,10 @@ ruleTesterTypeScript.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "expression",
+					line: 1,
+					column: 10,
+					endLine: 1,
+					endColumn: 22,
 				},
 			],
 		},
@@ -890,6 +1059,10 @@ ruleTesterTypeScript.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "expression",
+					line: 4,
+					column: 4,
+					endLine: 4,
+					endColumn: 18,
 				},
 			],
 		},
@@ -903,6 +1076,10 @@ ruleTesterTypeScript.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "expression",
+					line: 4,
+					column: 11,
+					endLine: 4,
+					endColumn: 25,
 				},
 			],
 		},
@@ -921,6 +1098,10 @@ ruleTesterTypeScript.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "expression",
+					line: 4,
+					column: 14,
+					endLine: 4,
+					endColumn: 28,
 				},
 			],
 		},
@@ -938,6 +1119,10 @@ ruleTesterTypeScript.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "expression",
+					line: 6,
+					column: 5,
+					endLine: 6,
+					endColumn: 19,
 				},
 			],
 		},
@@ -956,6 +1141,10 @@ ruleTesterTypeScript.run("func-style", rule, {
 			errors: [
 				{
 					messageId: "expression",
+					line: 7,
+					column: 5,
+					endLine: 7,
+					endColumn: 19,
 				},
 			],
 		},

--- a/tests/lib/rules/func-style.js
+++ b/tests/lib/rules/func-style.js
@@ -436,7 +436,6 @@ ruleTester.run("func-style", rule, {
 					column: 1,
 					endLine: 1,
 					endColumn: 13,
-
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Updated the error location of `func-style` rule to only highlight the head of the function instead of the entire function to make it visually clean or less disruptive in editors, and also to avoid the override of error lines if a function is declared inside another function, like:

```js
/*eslint func-style: ["error", "expression"]*/

function processNumbers(arr) {
    function double(x) {
        return x * 2;
    }

    return arr.map(double);
}
```
<img width="338" height="158" alt="Screenshot 2026-04-02 231521" src="https://github.com/user-attachments/assets/308dba40-d680-40c7-9e15-d14253b74875" />

Here function `processNumbers` and `double` both are reported, but the error lines of `double` are overlapped by `processNumbers`.

[Playground](https://eslint.org/play/#eyJ0ZXh0IjoiLyplc2xpbnQgZnVuYy1zdHlsZTogW1wiZXJyb3JcIiwgXCJleHByZXNzaW9uXCJdKi9cblxuZnVuY3Rpb24gcHJvY2Vzc051bWJlcnMoYXJyKSB7XG4gICAgZnVuY3Rpb24gZG91YmxlKHgpIHtcbiAgICAgICAgcmV0dXJuIHggKiAyO1xuICAgIH1cblxuICAgIHJldHVybiBhcnIubWFwKGRvdWJsZSk7XG59Iiwib3B0aW9ucyI6eyJydWxlcyI6e30sImxhbmd1YWdlT3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFGZWF0dXJlcyI6e319fX19)

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
