### PR TITLE
fix: clarify language and processor validation errors

### DIFF
--- a/docs/src/extend/custom-rules.md
+++ b/docs/src/extend/custom-rules.md
@@ -68,9 +68,9 @@ The source file for a rule exports an object with the following properties. Both
 
 - `defaultOptions`: (`array`) Specifies [default options](#option-defaults) for the rule. If present, any user-provided options in their config will be merged on top of them recursively.
 
-- `languages`: (`array`) Specifies the languages the rule is designed to work with. Each entry is a string in the format `"plugin/language"` (e.g., `"js/js"`, `"markdown/gfm"`). Special values:
+- `languages`: (`array`) Specifies the languages the rule is designed to work with. Each entry is a string in the format `"pluginName/languageName"` (e.g., `"js/js"`, `"markdown/gfm"`). Special values:
     - `"*"` — the rule works with any language.
-    - `"plugin/*"` — the rule works with any language provided by the given plugin.
+    - `"pluginName/*"` — the rule works with any language provided by the given plugin.
 
     If `languages` is not specified, the rule is assumed to work with all languages. When `languages` is specified and none of the entries matches the active language, ESLint throws an error.
 

--- a/docs/src/use/configure/configuration-files.md
+++ b/docs/src/use/configure/configuration-files.md
@@ -70,7 +70,7 @@ Each configuration object contains all of the information ESLint needs to execut
 - `files` - An array of glob patterns indicating the files that the configuration object should apply to. If not specified, the configuration object applies to all files matched by any other configuration object.
 - `ignores` - An array of glob patterns indicating the files that the configuration object should not apply to. If not specified, the configuration object applies to all files matched by `files`. If `ignores` is used without any other keys in the configuration object, then the patterns act as [global ignores](#globally-ignore-files-with-ignores) and it gets applied to every configuration object.
 - `extends` - An array of strings, configuration objects, or configuration arrays that contain additional configuration to apply.
-- `language` - A string specifying the [language](../../extend/languages) used for linting, in the format `"plugin/language"`, e.g. `"markdown/commonmark"`. (default: `"js/js"` for JavaScript)
+- `language` - A string specifying the [language](../../extend/languages) used for linting, in the format `"pluginName/languageName"`, e.g. `"markdown/commonmark"`. (default: `"js/js"` for JavaScript)
 - `languageOptions` - An object containing settings related to how the specified language is configured for linting. For JavaScript, the settings are:
     - `ecmaVersion` - The version of ECMAScript to support. May be any year (i.e., `2022`) or version (i.e., `5`). Set to `"latest"` for the most recent supported version. (default: `"latest"`)
     - `sourceType` - The type of JavaScript source code. Possible values are `"script"` for traditional script files, `"module"` for ECMAScript modules (ESM), and `"commonjs"` for CommonJS files. (default: `"module"` for `.js` and `.mjs` files; `"commonjs"` for `.cjs` files)
@@ -81,7 +81,7 @@ Each configuration object contains all of the information ESLint needs to execut
     - `noInlineConfig` - A Boolean value indicating if inline configuration is allowed.
     - `reportUnusedDisableDirectives` - A severity string indicating if and how unused disable and enable directives should be tracked and reported. For legacy compatibility, `true` is equivalent to `"warn"` and `false` is equivalent to `"off"`. (default: `"warn"`).
     - `reportUnusedInlineConfigs` - A severity string indicating if and how unused inline configs should be tracked and reported. (default: `"off"`)
-- `processor` - Either an object containing `preprocess()` and `postprocess()` methods or a string indicating the name of a processor inside of a plugin (i.e., `"plugin/processor"`).
+- `processor` - Either an object containing `preprocess()` and `postprocess()` methods or a string indicating the name of a processor inside of a plugin (i.e., `"pluginName/processorName"`).
 - `plugins` - An object containing a name-value mapping of plugin names to plugin objects. When `files` is specified, these plugins are only available to the matching files.
 - `rules` - An object containing the configured rules. When `files` or `ignores` are specified, these rule configurations are only available to the matching files.
 - `settings` - An object containing name-value pairs of information that should be available to all rules.

--- a/docs/src/use/configure/configuration-files.md
+++ b/docs/src/use/configure/configuration-files.md
@@ -81,7 +81,7 @@ Each configuration object contains all of the information ESLint needs to execut
     - `noInlineConfig` - A Boolean value indicating if inline configuration is allowed.
     - `reportUnusedDisableDirectives` - A severity string indicating if and how unused disable and enable directives should be tracked and reported. For legacy compatibility, `true` is equivalent to `"warn"` and `false` is equivalent to `"off"`. (default: `"warn"`).
     - `reportUnusedInlineConfigs` - A severity string indicating if and how unused inline configs should be tracked and reported. (default: `"off"`)
-- `processor` - Either an object containing `preprocess()` and `postprocess()` methods or a string indicating the name of a processor inside of a plugin (i.e., `"pluginName/processorName"`).
+- `processor` - Either an object containing `preprocess()` and `postprocess()` methods or a string indicating the name of a processor inside of a plugin (i.e., `"plugin/processor"`).
 - `plugins` - An object containing a name-value mapping of plugin names to plugin objects. When `files` is specified, these plugins are only available to the matching files.
 - `rules` - An object containing the configured rules. When `files` or `ignores` are specified, these rule configurations are only available to the matching files.
 - `settings` - An object containing name-value pairs of information that should be available to all rules.

--- a/lib/config/flat-config-schema.js
+++ b/lib/config/flat-config-schema.js
@@ -224,15 +224,16 @@ function assertIsRuleSeverity(ruleId, value) {
 }
 
 /**
- * Validates that a given string is the form pluginName/objectName.
+ * Validates that a given string matches the slash-delimited plugin member reference pattern.
  * @param {string} value The string to check.
+ * @param {string} expectedFormat The human-readable format to use in the error message.
  * @returns {void}
- * @throws {TypeError} If the string isn't in the correct format.
+ * @throws {TypeError} If the string doesn't match the expected pattern.
  */
-function assertIsPluginMemberName(value) {
+function assertIsPluginMemberName(value, expectedFormat) {
 	if (!/[\w\-@$]+(?:\/[\w\-$]+)+$/iu.test(value)) {
 		throw new TypeError(
-			`Expected string in the form "pluginName/objectName" but found "${value}".`,
+			`Expected string in the form "${expectedFormat}" but found "${value}".`,
 		);
 	}
 }
@@ -375,7 +376,9 @@ const languageOptionsSchema = {
 /** @type {ObjectPropertySchema} */
 const languageSchema = {
 	merge: "replace",
-	validate: assertIsPluginMemberName,
+	validate(value) {
+		assertIsPluginMemberName(value, "plugin/language");
+	},
 };
 
 /** @type {ObjectPropertySchema} */
@@ -430,7 +433,7 @@ const processorSchema = {
 	merge: "replace",
 	validate(value) {
 		if (typeof value === "string") {
-			assertIsPluginMemberName(value);
+			assertIsPluginMemberName(value, "plugin/processor");
 		} else if (value && typeof value === "object") {
 			if (
 				typeof value.preprocess !== "function" ||

--- a/lib/config/flat-config-schema.js
+++ b/lib/config/flat-config-schema.js
@@ -226,14 +226,14 @@ function assertIsRuleSeverity(ruleId, value) {
 /**
  * Validates that a given string matches the slash-delimited plugin member reference pattern.
  * @param {string} value The string to check.
- * @param {string} expectedFormat The human-readable format to use in the error message.
+ * @param {string} memberPlaceholder The placeholder for the member portion of the expected format in the error message.
  * @returns {void}
  * @throws {TypeError} If the string doesn't match the expected pattern.
  */
-function assertIsPluginMemberName(value, expectedFormat) {
+function assertIsPluginMemberName(value, memberPlaceholder) {
 	if (!/[\w\-@$]+(?:\/[\w\-$]+)+$/iu.test(value)) {
 		throw new TypeError(
-			`Expected string in the form "${expectedFormat}" but found "${value}".`,
+			`Expected string in the form "pluginName/${memberPlaceholder}" but found "${value}".`,
 		);
 	}
 }
@@ -377,7 +377,7 @@ const languageOptionsSchema = {
 const languageSchema = {
 	merge: "replace",
 	validate(value) {
-		assertIsPluginMemberName(value, "plugin/language");
+		assertIsPluginMemberName(value, "languageName");
 	},
 };
 
@@ -433,7 +433,7 @@ const processorSchema = {
 	merge: "replace",
 	validate(value) {
 		if (typeof value === "string") {
-			assertIsPluginMemberName(value, "plugin/processor");
+			assertIsPluginMemberName(value, "processorName");
 		} else if (value && typeof value === "object") {
 			if (
 				typeof value.preprocess !== "function" ||

--- a/lib/config/flat-config-schema.js
+++ b/lib/config/flat-config-schema.js
@@ -224,7 +224,7 @@ function assertIsRuleSeverity(ruleId, value) {
 }
 
 /**
- * Validates that a given string matches the slash-delimited plugin member reference pattern.
+ * Validates that a given string matches the "pluginName/memberPlaceholder" pattern.
  * @param {string} value The string to check.
  * @param {string} memberPlaceholder The placeholder for the member portion of the expected format in the error message.
  * @returns {void}

--- a/tests/lib/config/flat-config-array.js
+++ b/tests/lib/config/flat-config-array.js
@@ -1330,7 +1330,7 @@ describe("FlatConfigArray", () => {
 							processor: "foo",
 						},
 					],
-					"pluginName/objectName",
+					"plugin/processor",
 				);
 			});
 
@@ -1341,7 +1341,7 @@ describe("FlatConfigArray", () => {
 							processor: "",
 						},
 					],
-					"pluginName/objectName",
+					"plugin/processor",
 				);
 			});
 
@@ -1572,6 +1572,41 @@ describe("FlatConfigArray", () => {
 							},
 						},
 					));
+			});
+		});
+
+		describe("language", () => {
+			it("should error when an invalid string is used", () => {
+				assertInvalidConfig(
+					[
+						{
+							language: "js",
+						},
+					],
+					"plugin/language",
+				);
+			});
+
+			it("should error when an empty string is used", () => {
+				assertInvalidConfig(
+					[
+						{
+							language: "",
+						},
+					],
+					"plugin/language",
+				);
+			});
+
+			it("should error when a language cannot be found in a plugin", () => {
+				assertInvalidConfig(
+					[
+						{
+							language: "foo/bar",
+						},
+					],
+					/Key "language": Could not find "bar" in plugin "foo"\./u,
+				);
 			});
 		});
 

--- a/tests/lib/config/flat-config-array.js
+++ b/tests/lib/config/flat-config-array.js
@@ -1330,7 +1330,7 @@ describe("FlatConfigArray", () => {
 							processor: "foo",
 						},
 					],
-					"plugin/processor",
+					"pluginName/processorName",
 				);
 			});
 
@@ -1341,7 +1341,7 @@ describe("FlatConfigArray", () => {
 							processor: "",
 						},
 					],
-					"plugin/processor",
+					"pluginName/processorName",
 				);
 			});
 
@@ -1583,7 +1583,7 @@ describe("FlatConfigArray", () => {
 							language: "js",
 						},
 					],
-					"plugin/language",
+					"pluginName/languageName",
 				);
 			});
 
@@ -1594,7 +1594,7 @@ describe("FlatConfigArray", () => {
 							language: "",
 						},
 					],
-					"plugin/language",
+					"pluginName/languageName",
 				);
 			});
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What did you do?

Used a config like this:

```js
import { defineConfig } from "eslint/config";

export default defineConfig([
	{
		language: "js",
	},
]);
```

#### What did you expect to happen?

ESLint should report an error that points to the correct language format, such as `plugin/language`.

#### What actually happened?

ESLint reported `Expected string in the form "pluginName/objectName" but found "js".`, which is generic and doesn't match the `language` terminology.

#### What changes did you make? (Give an overview)

- Updated `language` and `processor` validation errors to use `plugin/language` and `plugin/processor`.
- Added tests for invalid `language` values.
- Updated the configuration docs for `processor` to use `plugin/processor` so the format is consistent with `language`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
