### PR TITLE
docs: clarify ecmaVersion placement in languageOptions vs parserOptions

### DIFF
--- a/docs/src/use/configure/language-options.md
+++ b/docs/src/use/configure/language-options.md
@@ -23,6 +23,10 @@ ESLint allows you to specify the JavaScript language options you want to support
     - `commonjs` - CommonJS module (useful if your code uses `require()`). Your code has a top-level function scope and runs in non-strict mode.
     - `script` - non-module. Your code has a shared global scope and runs in non-strict mode.
 
+::: important
+**Note:** When using the flat config format, set `ecmaVersion` and `sourceType` directly in `languageOptions`, not inside `languageOptions.parserOptions`. ESLint automatically passes these values to the parser, so you don't need to specify them again in `parserOptions`.
+:::
+
 Here's an example [configuration file](./configuration-files#configuration-file) you might use when linting ECMAScript 5 code:
 
 ```js
@@ -48,6 +52,10 @@ If you are using the built-in ESLint parser, you can additionally change how ESL
     - `globalReturn` - allow `return` statements in the global scope. This option only applies when `languageOptions.sourceType` is set to `"script"`. When `languageOptions.sourceType` is set to `"commonjs"`, top-level `return` statements are allowed regardless of this option. When `languageOptions.sourceType` is set to `"module"`, top-level `return` statements are not allowed even if this option is set to `true`.
     - `impliedStrict` - enable global [strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) (if `ecmaVersion` is `5` or greater).
     - `jsx` - enable [JSX](https://facebook.github.io/jsx/).
+
+::: tip
+In addition to the options specified in `languageOptions.parserOptions`, ESLint also passes `ecmaVersion` and `sourceType` to all parsers automatically. This allows custom parsers to understand the context in which ESLint is evaluating JavaScript code. You should set these properties directly in `languageOptions`, not in `parserOptions`.
+:::
 
 Here's an example [configuration file](./configuration-files#configuration-file) that enables JSX parsing in the default parser:
 


### PR DESCRIPTION
## Description

This PR addresses the confusion documented in #20522 regarding where to set `ecmaVersion` - whether in `languageOptions` or `languageOptions.parserOptions`.

### Changes Made

1. **Added Important Note in "Specify JavaScript Options" section**:
   - Clearly states that `ecmaVersion` and `sourceType` should be set directly in `languageOptions`, not inside `languageOptions.parserOptions`
   - Explains that ESLint automatically passes these values to the parser

2. **Added Tip in "Specify Parser Options" section**:
   - Reinforces that `ecmaVersion` and `sourceType` are automatically passed to parsers
   - Reminds users to set these properties directly in `languageOptions`

### Why This Helps

- Reduces confusion for users migrating from eslintrc to flat config format
- Prevents misconfiguration where users might unnecessarily duplicate settings
- Provides clear guidance at the point where users are making configuration decisions

### References

Closes #20522 (or helps address the documentation aspect of it)

---

Thanks for maintaining ESLint! 🙏 Let me know if you'd like any adjustments to the wording or placement of these notes.