### PR TITLE
fix: skip no-async-promise-executor when Promise is shadowed

### DIFF
--- a/lib/rules/no-async-promise-executor.js
+++ b/lib/rules/no-async-promise-executor.js
@@ -28,12 +28,18 @@ module.exports = {
 	},
 
 	create(context) {
+		const sourceCode = context.sourceCode;
+
 		return {
 			"NewExpression[callee.name='Promise'][arguments.0.async=true]"(
 				node,
 			) {
+				if (!sourceCode.isGlobalReference(node.callee)) {
+					return;
+				}
+
 				context.report({
-					node: context.sourceCode.getFirstToken(
+					node: sourceCode.getFirstToken(
 						node.arguments[0],
 						token => token.value === "async",
 					),

--- a/tests/lib/rules/no-async-promise-executor.js
+++ b/tests/lib/rules/no-async-promise-executor.js
@@ -22,6 +22,15 @@ ruleTester.run("no-async-promise-executor", rule, {
 		"new Promise((resolve, reject) => {})",
 		"new Promise((resolve, reject) => {}, async function unrelated() {})",
 		"new Foo(async (resolve, reject) => {})",
+
+		// Shadowed Promise should not be flagged
+		"function Promise() {} new Promise(async (resolve, reject) => {})",
+		"const Promise = function() {}; new Promise(async (resolve, reject) => {})",
+		"class Promise {} new Promise(async (resolve, reject) => {})",
+		{
+			code: "import Promise from 'bluebird'; new Promise(async (resolve) => {})",
+			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+		},
 	],
 
 	invalid: [


### PR DESCRIPTION
## What changed

`no-async-promise-executor` uses an AST selector that checks `callee.name === 'Promise'` but never verifies the identifier actually refers to the global `Promise` constructor. When `Promise` is shadowed by a local variable, import, class, or parameter, the rule produces a false positive.

This is the same pattern that was already fixed in `no-promise-executor-return` (which uses `sourceCode.isGlobalReference()`).

## Fix

Added a `sourceCode.isGlobalReference(node.callee)` guard, returning early when the identifier doesn't resolve to the global.

## Tests

Added four valid test cases covering shadowed `Promise` via:
- function declaration
- const assignment
- class declaration
- ESM import