### PR TITLE
fix: detect wrong direction in for-loop SequenceExpression update

### DIFF
--- a/lib/rules/for-direction.js
+++ b/lib/rules/for-direction.js
@@ -159,6 +159,45 @@ module.exports = {
 								wrongDirection
 						) {
 							report(node);
+						} else if (update.type === "SequenceExpression") {
+							/*
+							 * Check each expression in the sequence for
+							 * counter modifications. Only report when the
+							 * counter is modified exactly once and in the
+							 * wrong direction; skip when modified multiple
+							 * times (ambiguous net effect).
+							 */
+							let directionSum = 0;
+							let counterUpdates = 0;
+
+							for (const expr of update.expressions) {
+								let dir = 0;
+
+								if (expr.type === "UpdateExpression") {
+									dir = getUpdateDirection(expr, counter);
+								} else if (
+									expr.type === "AssignmentExpression"
+								) {
+									dir = getAssignmentDirection(expr, counter);
+								}
+
+								if (dir !== 0) {
+									counterUpdates++;
+									directionSum += dir;
+								}
+							}
+
+							/*
+							 * Report only when exactly one expression
+							 * modifies the counter in the wrong direction.
+							 * Multiple updates make the net effect ambiguous.
+							 */
+							if (
+								counterUpdates === 1 &&
+								directionSum === wrongDirection
+							) {
+								report(node);
+							}
 						}
 					}
 				}

--- a/tests/lib/rules/for-direction.js
+++ b/tests/lib/rules/for-direction.js
@@ -88,6 +88,17 @@ ruleTester.run("for-direction", rule, {
 		"for(var i = 0; i === 10; i+=1){}",
 		"for(var i = 0; i == 10; i+=1){}",
 		"for(var i = 0; i != 10; i+=1){}",
+
+		// SequenceExpression: counter not modified
+		"for (let i = 0; i < 10; j++, k++) {}",
+
+		// SequenceExpression: counter modified in correct direction
+		"for (let i = 0; i < 10; j--, i++) {}",
+		"for (let i = 10; i > 0; j++, i--) {}",
+
+		// SequenceExpression: counter modified multiple times (ambiguous)
+		"for (let i = 10; i < 20; i--, i += 2) {}",
+		"for (let i = 10; i < 20; i--, i++) {}",
 	],
 	invalid: [
 		// test if '++', '--'
@@ -370,6 +381,40 @@ ruleTester.run("for-direction", rule, {
 					column: 1,
 					endLine: 1,
 					endColumn: 29,
+				},
+			],
+		},
+
+		// SequenceExpression: counter modified once in wrong direction (Case 1)
+		{
+			code: "for (let i = 10; i < 20; i--, j++) {}",
+			errors: [
+				{
+					...incorrectDirection,
+				},
+			],
+		},
+		{
+			code: "for (let i = 0; i < 10; j++, i--) {}",
+			errors: [
+				{
+					...incorrectDirection,
+				},
+			],
+		},
+		{
+			code: "for (let i = 0; i > 10; j--, i++) {}",
+			errors: [
+				{
+					...incorrectDirection,
+				},
+			],
+		},
+		{
+			code: "for (let i = 0; i < 10; j++, i -= 1) {}",
+			errors: [
+				{
+					...incorrectDirection,
 				},
 			],
 		},


### PR DESCRIPTION
## Summary

Fixes #20726

The `for-direction` rule did not handle `SequenceExpression` update clauses. When a for-loop used comma-separated expressions (e.g. `i--, j++`), the rule silently passed.

## Changes

- Add a `SequenceExpression` branch in the `ForStatement` handler
- Iterate expressions to find counter modifications
- Report when exactly **one** expression modifies the counter in the wrong direction
- Skip when the counter is modified **multiple times** (ambiguous net effect per issue discussion)

## Examples

| Code | Before | After |
|------|--------|-------|
| `for (let i = 10; i < 20; i--, j++) {}` | ✅ no error | ❌ error |
| `for (let i = 0; i < 10; j--, i++) {}` | ✅ no error | ✅ no error (correct direction) |
| `for (let i = 10; i < 20; i--, i += 2) {}` | ✅ no error | ✅ no error (multiple updates, ambiguous) |

## Tests

Added valid and invalid test cases for all scenarios described in the issue.