### PR TITLE
docs: use import.meta.dirname in config examples

### DIFF
--- a/docs/src/use/configure/ignore.md
+++ b/docs/src/use/configure/ignore.md
@@ -227,9 +227,9 @@ By default, `includeIgnoreFile()` will assign a name to the config that represen
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 import { includeIgnoreFile } from "@eslint/compat";
-import { fileURLToPath } from "node:url";
+import path from "node:path";
 
-const gitignorePath = fileURLToPath(new URL(".gitignore", import.meta.url));
+const gitignorePath = path.join(import.meta.dirname, ".gitignore");
 
 export default defineConfig([
 	includeIgnoreFile(gitignorePath, "Imported .gitignore patterns"),

--- a/docs/src/use/configure/migration-guide.md
+++ b/docs/src/use/configure/migration-guide.md
@@ -530,15 +530,9 @@ Then, import `FlatCompat` and create a new instance to convert an existing eslin
 ```js
 import { defineConfig } from "eslint/config";
 import { FlatCompat } from "@eslint/eslintrc";
-import path from "path";
-import { fileURLToPath } from "url";
-
-// mimic CommonJS variables -- not needed if using CommonJS
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 const compat = new FlatCompat({
-	baseDirectory: __dirname,
+	baseDirectory: import.meta.dirname,
 });
 
 export default defineConfig([
@@ -675,9 +669,9 @@ For example, if you previously used `--ignore-path .gitignore`:
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 import { includeIgnoreFile } from "@eslint/compat";
-import { fileURLToPath } from "node:url";
+import path from "node:path";
 
-const gitignorePath = fileURLToPath(new URL(".gitignore", import.meta.url));
+const gitignorePath = path.join(import.meta.dirname, ".gitignore");
 
 export default defineConfig([
 	includeIgnoreFile(gitignorePath, "Imported .gitignore patterns"),


### PR DESCRIPTION
## Summary
- replace old `fileURLToPath(import.meta.url)` and `new URL(..., import.meta.url)` examples with `import.meta.dirname`-based examples
- update both the ignore files docs and the migration guide for current supported Node versions

## Testing
- `npx prettier --check docs/src/use/configure/ignore.md docs/src/use/configure/migration-guide.md`

Closes #20737

AI-assisted: yes, reviewed and validated before submission.