### PR TITLE
docs: use variadic defineConfig examples

### DIFF
--- a/docs/src/extend/custom-parsers.md
+++ b/docs/src/extend/custom-parsers.md
@@ -133,14 +133,12 @@ Then add the custom parser to your ESLint configuration file with the `languageO
 const { defineConfig } = require("eslint/config");
 const myparser = require("eslint-parser-myparser");
 
-module.exports = defineConfig([
-	{
-		languageOptions: {
-			parser: myparser,
-		},
-		// ... rest of configuration
+module.exports = defineConfig({
+	languageOptions: {
+		parser: myparser,
 	},
-]);
+	// ... rest of configuration
+});
 ```
 
 When using legacy configuration, specify the `parser` property as a string:
@@ -187,13 +185,11 @@ Include the custom parser in an ESLint configuration file:
 // eslint.config.js
 const { defineConfig } = require("eslint/config");
 
-module.exports = defineConfig([
-	{
-		languageOptions: {
-			parser: require("./path/to/awesome-custom-parser"),
-		},
+module.exports = defineConfig({
+	languageOptions: {
+		parser: require("./path/to/awesome-custom-parser"),
 	},
-]);
+});
 ```
 
 Or if using legacy configuration:

--- a/docs/src/extend/custom-processors.md
+++ b/docs/src/extend/custom-processors.md
@@ -152,7 +152,7 @@ Example:
 import { defineConfig } from "eslint/config";
 import example from "eslint-plugin-example";
 
-export default defineConfig([
+export default defineConfig(
 	{
 		files: ["**/*.txt"], // apply processor to text files
 		plugins: {
@@ -161,7 +161,7 @@ export default defineConfig([
 		processor: "example/processor-name",
 	},
 	// ... other configs
-]);
+);
 ```
 
 In this example, the processor name is `"example/processor-name"`, and that's the value that will be used for serializing configurations.
@@ -177,13 +177,13 @@ Example:
 import { defineConfig } from "eslint/config";
 import example from "eslint-plugin-example";
 
-export default defineConfig([
+export default defineConfig(
 	{
 		files: ["**/*.txt"],
 		processor: example.processors["processor-name"],
 	},
 	// ... other configs
-]);
+);
 ```
 
 In this example, specifying `example.processors["processor-name"]` directly uses the processor's own `meta` object, which must be defined to ensure proper handling when the processor is not referenced through the plugin name.
@@ -201,15 +201,13 @@ In order to use a processor from a plugin in a configuration file, import the pl
 import { defineConfig } from "eslint/config";
 import example from "eslint-plugin-example";
 
-export default defineConfig([
-	{
-		files: ["**/*.txt"],
-		plugins: {
-			example,
-		},
-		processor: "example/processor-name",
+export default defineConfig({
+	files: ["**/*.txt"],
+	plugins: {
+		example,
 	},
-]);
+	processor: "example/processor-name",
+});
 ```
 
 See [Specify a Processor](../use/configure/plugins#specify-a-processor) in the Plugin Configuration documentation for more details.

--- a/docs/src/extend/custom-rule-tutorial.md
+++ b/docs/src/extend/custom-rule-tutorial.md
@@ -321,20 +321,18 @@ const { defineConfig } = require("eslint/config");
 // Import the ESLint plugin locally
 const eslintPluginExample = require("./eslint-plugin-example");
 
-module.exports = defineConfig([
-	{
-		files: ["**/*.js"],
-		languageOptions: {
-			sourceType: "commonjs",
-			ecmaVersion: "latest",
-		},
-		// Using the eslint-plugin-example plugin defined locally
-		plugins: { example: eslintPluginExample },
-		rules: {
-			"example/enforce-foo-bar": "error",
-		},
+module.exports = defineConfig({
+	files: ["**/*.js"],
+	languageOptions: {
+		sourceType: "commonjs",
+		ecmaVersion: "latest",
 	},
-]);
+	// Using the eslint-plugin-example plugin defined locally
+	plugins: { example: eslintPluginExample },
+	rules: {
+		"example/enforce-foo-bar": "error",
+	},
+});
 ```
 
 Before you can test the rule, you must create a file to test the rule on.

--- a/docs/src/extend/languages.md
+++ b/docs/src/extend/languages.md
@@ -126,15 +126,13 @@ In order to use a language from a plugin in a configuration file, import the plu
 import { defineConfig } from "eslint/config";
 import example from "eslint-plugin-example";
 
-export default defineConfig([
-	{
-		files: ["**/*.my"],
-		plugins: {
-			example,
-		},
-		language: "example/my",
+export default defineConfig({
+	files: ["**/*.my"],
+	plugins: {
+		example,
 	},
-]);
+	language: "example/my",
+});
 ```
 
 See [Specify a Language](../use/configure/plugins#specify-a-language) in the Plugin Configuration documentation for more details.

--- a/docs/src/extend/plugin-migration-flat-config.md
+++ b/docs/src/extend/plugin-migration-flat-config.md
@@ -114,15 +114,13 @@ In order to use this renamed processor, you'll also need to manually specify it 
 import { defineConfig } from "eslint/config";
 import example from "eslint-plugin-example";
 
-export default defineConfig([
-	{
-		files: ["**/*.md"],
-		plugins: {
-			example,
-		},
-		processor: "example/markdown",
+export default defineConfig({
+	files: ["**/*.md"],
+	plugins: {
+		example,
 	},
-]);
+	processor: "example/markdown",
+});
 ```
 
 You should update your plugin's documentation to advise your users if you have renamed a file extension-named processor.
@@ -187,7 +185,7 @@ Your users can then use this exported config like this:
 import { defineConfig } from "eslint/config";
 import example from "eslint-plugin-example";
 
-export default defineConfig([
+export default defineConfig(
 	// use recommended config and provide your own overrides
 	{
 		files: ["**/*.js", "**/*.cjs", "**/*.mjs"],
@@ -199,7 +197,7 @@ export default defineConfig([
 			"example/rule1": "warn",
 		},
 	},
-]);
+);
 ```
 
 If your config extends other configs, you can export an array:
@@ -286,24 +284,22 @@ Your users can then use this exported config like this:
 import { defineConfig } from "eslint/config";
 import example from "eslint-plugin-example";
 
-export default defineConfig([
-	{
-		files: ["**/tests/*.js"],
-		plugins: {
-			example,
-		},
+export default defineConfig({
+	files: ["**/tests/*.js"],
+	plugins: {
+		example,
+	},
 
-		// use the mocha globals
-		extends: ["example/mocha"],
+	// use the mocha globals
+	extends: ["example/mocha"],
 
-		// and provide your own overrides
-		languageOptions: {
-			globals: {
-				it: "readonly",
-			},
+	// and provide your own overrides
+	languageOptions: {
+		globals: {
+			it: "readonly",
 		},
 	},
-]);
+});
 ```
 
 You should update your documentation so your plugin users know how to reference the exported configs.

--- a/docs/src/extend/plugins.md
+++ b/docs/src/extend/plugins.md
@@ -151,17 +151,15 @@ In order to use a rule from a plugin in a configuration file, import the plugin 
 import { defineConfig } from "eslint/config";
 import example from "eslint-plugin-example";
 
-export default defineConfig([
-	{
-		files: ["**/*.js"], // any patterns you want to apply the config to
-		plugins: {
-			example,
-		},
-		rules: {
-			"example/dollar-sign": "error",
-		},
+export default defineConfig({
+	files: ["**/*.js"], // any patterns you want to apply the config to
+	plugins: {
+		example,
 	},
-]);
+	rules: {
+		"example/dollar-sign": "error",
+	},
+});
 ```
 
 ::: warning
@@ -204,15 +202,13 @@ In order to use a processor from a plugin in a configuration file, import the pl
 import { defineConfig } from "eslint/config";
 import example from "eslint-plugin-example";
 
-export default defineConfig([
-	{
-		files: ["**/*.txt"],
-		plugins: {
-			example,
-		},
-		processor: "example/processor-name",
+export default defineConfig({
+	files: ["**/*.txt"],
+	plugins: {
+		example,
 	},
-]);
+	processor: "example/processor-name",
+});
 ```
 
 ### Configs in Plugins
@@ -277,15 +273,13 @@ In order to use a config from a plugin in a configuration file, import the plugi
 import { defineConfig } from "eslint/config";
 import example from "eslint-plugin-example";
 
-export default defineConfig([
-	{
-		files: ["**/*.js"], // any patterns you want to apply the config to
-		plugins: {
-			example,
-		},
-		extends: ["example/recommended"],
+export default defineConfig({
+	files: ["**/*.js"], // any patterns you want to apply the config to
+	plugins: {
+		example,
 	},
-]);
+	extends: ["example/recommended"],
+});
 ```
 
 ::: important

--- a/docs/src/extend/shareable-configs.md
+++ b/docs/src/extend/shareable-configs.md
@@ -74,12 +74,10 @@ To use a shareable config, import the package inside of an `eslint.config.js` fi
 import { defineConfig } from "eslint/config";
 import myconfig from "eslint-config-myconfig";
 
-export default defineConfig([
-	{
-		files: ["**/*.js"],
-		extends: [myconfig],
-	},
-]);
+export default defineConfig({
+	files: ["**/*.js"],
+	extends: [myconfig],
+});
 ```
 
 ::: warning
@@ -95,17 +93,15 @@ You can override settings from the shareable config by adding them directly into
 import { defineConfig } from "eslint/config";
 import myconfig from "eslint-config-myconfig";
 
-export default defineConfig([
-	{
-		files: ["**/*.js"],
-		extends: [myconfig],
+export default defineConfig({
+	files: ["**/*.js"],
+	extends: [myconfig],
 
-		// anything from here will override myconfig
-		rules: {
-			"no-unused-vars": "warn",
-		},
+	// anything from here will override myconfig
+	rules: {
+		"no-unused-vars": "warn",
 	},
-]);
+});
 ```
 
 ## Sharing Multiple Configs
@@ -131,17 +127,15 @@ import { defineConfig } from "eslint/config";
 import myconfig from "eslint-config-myconfig";
 import mySpecialConfig from "eslint-config-myconfig/my-special-config.js";
 
-export default defineConfig([
-	{
-		files: ["**/*.js"],
-		extends: [myconfig, mySpecialConfig],
+export default defineConfig({
+	files: ["**/*.js"],
+	extends: [myconfig, mySpecialConfig],
 
-		// anything from here will override myconfig
-		rules: {
-			"no-unused-vars": "warn",
-		},
+	// anything from here will override myconfig
+	rules: {
+		"no-unused-vars": "warn",
 	},
-]);
+});
 ```
 
 ::: important

--- a/docs/src/use/configure/combine-configs.md
+++ b/docs/src/use/configure/combine-configs.md
@@ -18,18 +18,16 @@ If you are importing a [config object](../core-concepts/glossary#config-object) 
 import js from "@eslint/js";
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		files: ["**/*.js"],
-		plugins: {
-			js,
-		},
-		extends: ["js/recommended"],
-		rules: {
-			"no-unused-vars": "warn",
-		},
+export default defineConfig({
+	files: ["**/*.js"],
+	plugins: {
+		js,
 	},
-]);
+	extends: ["js/recommended"],
+	rules: {
+		"no-unused-vars": "warn",
+	},
+});
 ```
 
 Here, the `"js/recommended"` predefined configuration is applied to files that match the pattern `"**/*.js"` first and then adds the desired configuration for `no-unused-vars`.
@@ -43,15 +41,13 @@ If you are importing a [config array](../core-concepts/glossary#config-array) fr
 import exampleConfigs from "eslint-config-example";
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		files: ["**/*.js"],
-		extends: [exampleConfigs],
-		rules: {
-			"no-unused-vars": "warn",
-		},
+export default defineConfig({
+	files: ["**/*.js"],
+	extends: [exampleConfigs],
+	rules: {
+		"no-unused-vars": "warn",
 	},
-]);
+});
 ```
 
 Here, the `exampleConfigs` shareable configuration is applied to files that match the pattern "`**/*.js"` first and then another configuration object adds the desired configuration for `no-unused-vars`.

--- a/docs/src/use/configure/configuration-files.md
+++ b/docs/src/use/configure/configuration-files.md
@@ -33,14 +33,12 @@ It should be placed in the root directory of your project and export an array of
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		rules: {
-			semi: "error",
-			"prefer-const": "error",
-		},
+export default defineConfig({
+	rules: {
+		semi: "error",
+		"prefer-const": "error",
 	},
-]);
+});
 ```
 
 In this example, the `defineConfig()` helper is used to define a configuration array with just one configuration object. The configuration object enables two rules: `semi` and `prefer-const`. These rules are applied to all of the files ESLint processes using this config file.
@@ -51,14 +49,12 @@ If your project does not specify `"type":"module"` in its `package.json` file, t
 // eslint.config.js
 const { defineConfig } = require("eslint/config");
 
-module.exports = defineConfig([
-	{
-		rules: {
-			semi: "error",
-			"prefer-const": "error",
-		},
+module.exports = defineConfig({
+	rules: {
+		semi: "error",
+		"prefer-const": "error",
 	},
-]);
+});
 ```
 
 ## Configuration Objects
@@ -98,7 +94,7 @@ You can use a combination of `files` and `ignores` to determine which files the 
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
+export default defineConfig(
 	// matches all files ending with .js
 	{
 		files: ["**/*.js"],
@@ -115,7 +111,7 @@ export default defineConfig([
 			"no-console": "error",
 		},
 	},
-]);
+);
 ```
 
 Configuration objects without `files` or `ignores` are automatically applied to any file that is matched by any other configuration object. For example:
@@ -124,14 +120,14 @@ Configuration objects without `files` or `ignores` are automatically applied to 
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
+export default defineConfig(
 	// matches all files because it doesn't specify the `files` or `ignores` key
 	{
 		rules: {
 			semi: "error",
 		},
 	},
-]);
+);
 ```
 
 With this configuration, the `semi` rule is enabled for all files that match the default files in ESLint. So if you pass `example.js` to ESLint, the `semi` rule is applied. If you pass a non-JavaScript file, like `example.txt`, the `semi` rule is not applied because there are no other configuration objects that match that filename. (ESLint outputs an error message letting you know that the file was ignored due to missing configuration.)
@@ -152,12 +148,12 @@ For example, to lint TypeScript files with `.ts`, `.cts` and `.mts` extensions, 
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
+export default defineConfig(
 	{
 		files: ["**/*.ts", "**/*.cts", "**/*.mts"],
 	},
 	// ...other config
-]);
+);
 ```
 
 #### Specify files without extension
@@ -168,12 +164,12 @@ Files without an extension can be matched with the pattern `!(*.*)`. For example
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
+export default defineConfig(
 	{
 		files: ["**/!(*.*)"],
 	},
 	// ...other config
-]);
+);
 ```
 
 The above config lints files without extension besides the default `.js`, `.cjs` and `.mjs` extensions in all directories.
@@ -189,12 +185,12 @@ Multiple patterns can be matched against the same file by using an array of stri
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
+export default defineConfig(
 	{
 		files: [["src/*", "**/.js"]],
 	},
 	// ...other config
-]);
+);
 ```
 
 The pattern `["src/*", "**/.js"]` matches when a file is both inside of the `src` directory and also ends with `.js`. This approach can be helpful when you're dynamically calculating the value of the `files` array and want to avoid potential errors by trying to combine multiple glob patterns into a single string.
@@ -207,14 +203,12 @@ You can limit which files a configuration object applies to by specifying a comb
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		files: ["src/**/*.js"],
-		rules: {
-			semi: "error",
-		},
+export default defineConfig({
+	files: ["src/**/*.js"],
+	rules: {
+		semi: "error",
 	},
-]);
+});
 ```
 
 Here, only the JavaScript files in the `src` directory have the `semi` rule applied. If you run ESLint on files in another directory, this configuration object is skipped. By adding `ignores`, you can also remove some of the files in `src` from this configuration object:
@@ -223,15 +217,13 @@ Here, only the JavaScript files in the `src` directory have the `semi` rule appl
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		files: ["src/**/*.js"],
-		ignores: ["**/*.config.js"],
-		rules: {
-			semi: "error",
-		},
+export default defineConfig({
+	files: ["src/**/*.js"],
+	ignores: ["**/*.config.js"],
+	rules: {
+		semi: "error",
 	},
-]);
+});
 ```
 
 This configuration object matches all JavaScript files in the `src` directory except those that end with `.config.js`. You can also use negation patterns in `ignores` to exclude files from the ignore patterns, such as:
@@ -240,15 +232,13 @@ This configuration object matches all JavaScript files in the `src` directory ex
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		files: ["src/**/*.js"],
-		ignores: ["**/*.config.js", "!**/eslint.config.js"],
-		rules: {
-			semi: "error",
-		},
+export default defineConfig({
+	files: ["src/**/*.js"],
+	ignores: ["**/*.config.js", "!**/eslint.config.js"],
+	rules: {
+		semi: "error",
 	},
-]);
+});
 ```
 
 Here, the configuration object excludes files ending with `.config.js` except for `eslint.config.js`. That file still has `semi` applied.
@@ -261,14 +251,12 @@ If `ignores` is used without `files` and there are other keys (such as `rules`),
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		ignores: ["**/*.config.js"],
-		rules: {
-			semi: "error",
-		},
+export default defineConfig({
+	ignores: ["**/*.config.js"],
+	rules: {
+		semi: "error",
 	},
-]);
+});
 ```
 
 This configuration object applies to all JavaScript files except those ending with `.config.js`. Effectively, this is like having `files` set to `**/*`. In general, it's a good idea to always include `files` if you are specifying `ignores`.
@@ -302,16 +290,16 @@ For all uses of `ignores`:
 import { defineConfig } from "eslint/config";
 
 // Example of global ignores
-export default defineConfig([
+export default defineConfig(
     {
       ignores: [".config/", "dist/", "tsconfig.json"] // acts as global ignores, due to the absence of other properties
     },
     { ... }, // ... other configuration object, inherit global ignores
     { ... }, // ... other configuration object, inherit global ignores
-]);
+);
 
 // Example of non-global ignores
-export default defineConfig([
+export default defineConfig(
     {
       ignores: [".config/**", "dir1/script1.js"],
       rules: { ... } // the presence of this property dictates non-global ignores
@@ -320,7 +308,7 @@ export default defineConfig([
       ignores: ["other-dir/**", "dist/script2.js"],
       rules: { ... } // the presence of this property dictates non-global ignores
     },
-]);
+);
 ```
 
 To avoid confusion, use the `globalIgnores()` helper function to clearly indicate which ignores are meant to be global. Here's the previous example rewritten to use `globalIgnores()`:
@@ -330,14 +318,14 @@ To avoid confusion, use the `globalIgnores()` helper function to clearly indicat
 import { defineConfig, globalIgnores } from "eslint/config";
 
 // Example of global ignores
-export default defineConfig([
+export default defineConfig(
     globalIgnores([".config/", "dist/", "tsconfig.json"]),
     { ... }, // ... other configuration object, inherit global ignores
     { ... }, // ... other configuration object, inherit global ignores
-]);
+);
 
 // Example of non-global ignores
-export default defineConfig([
+export default defineConfig(
     {
       ignores: [".config/**", "dir1/script1.js"],
       rules: { ... } // the presence of this property dictates non-global ignores
@@ -346,7 +334,7 @@ export default defineConfig([
       ignores: ["other-dir/**", "dist/script2.js"],
       rules: { ... } // the presence of this property dictates non-global ignores
     },
-]);
+);
 ```
 
 For more information and examples on configuring rules regarding `ignores`, see [Ignore Files](ignore).
@@ -359,7 +347,7 @@ You can optionally specify `basePath` to apply the configuration object to a spe
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
+export default defineConfig(
 	// matches all files in tests and its subdirectories
 	{
 		basePath: "tests",
@@ -385,7 +373,7 @@ export default defineConfig([
 		basePath: "tests",
 		ignores: ["fixtures/"],
 	},
-]);
+);
 ```
 
 In combination with [`extends`](#extending-configurations), multiple configuration objects can be applied to the same subdirectory by specifying `basePath` only once, like this:
@@ -394,35 +382,33 @@ In combination with [`extends`](#extending-configurations), multiple configurati
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		basePath: "tests",
-		extends: [
-			// matches all files in tests and its subdirectories
-			{
-				rules: {
-					"no-undef": "error",
+export default defineConfig({
+	basePath: "tests",
+	extends: [
+		// matches all files in tests and its subdirectories
+		{
+			rules: {
+				"no-undef": "error",
+			},
+		},
+
+		// matches all files ending with spec.js in tests and its subdirectories
+		{
+			files: ["**/*.spec.js"],
+			languageOptions: {
+				globals: {
+					it: "readonly",
+					describe: "readonly",
 				},
 			},
+		},
 
-			// matches all files ending with spec.js in tests and its subdirectories
-			{
-				files: ["**/*.spec.js"],
-				languageOptions: {
-					globals: {
-						it: "readonly",
-						describe: "readonly",
-					},
-				},
-			},
-
-			// globally ignores tests/fixtures directory
-			{
-				ignores: ["fixtures/"],
-			},
-		],
-	},
-]);
+		// globally ignores tests/fixtures directory
+		{
+			ignores: ["fixtures/"],
+		},
+	],
+});
 ```
 
 #### Cascading Configuration Objects
@@ -433,7 +419,7 @@ When more than one configuration object matches a given filename, the configurat
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
+export default defineConfig(
 	{
 		files: ["**/*.js"],
 		languageOptions: {
@@ -451,7 +437,7 @@ export default defineConfig([
 			},
 		},
 	},
-]);
+);
 ```
 
 Using this configuration, all JavaScript files define a custom global object defined called `MY_CUSTOM_GLOBAL` while those JavaScript files in the `tests` directory have `it` and `describe` defined as global objects in addition to `MY_CUSTOM_GLOBAL`. For any JavaScript file in the `tests` directory, both configuration objects are applied, so `languageOptions.globals` are merged to create a final result.
@@ -468,14 +454,12 @@ Inline configuration is implemented using an `/*eslint*/` comment, such as `/*es
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		files: ["**/*.js"],
-		linterOptions: {
-			noInlineConfig: true,
-		},
+export default defineConfig({
+	files: ["**/*.js"],
+	linterOptions: {
+		noInlineConfig: true,
 	},
-]);
+});
 ```
 
 #### Report Unused Disable Directives
@@ -486,14 +470,12 @@ Disable and enable directives such as `/*eslint-disable*/`, `/*eslint-enable*/` 
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		files: ["**/*.js"],
-		linterOptions: {
-			reportUnusedDisableDirectives: "error",
-		},
+export default defineConfig({
+	files: ["**/*.js"],
+	linterOptions: {
+		reportUnusedDisableDirectives: "error",
 	},
-]);
+});
 ```
 
 This setting defaults to `"warn"`.
@@ -512,14 +494,12 @@ You can enable reporting of these unused inline config comments by setting the `
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		files: ["**/*.js"],
-		linterOptions: {
-			reportUnusedInlineConfigs: "error",
-		},
+export default defineConfig({
+	files: ["**/*.js"],
+	linterOptions: {
+		reportUnusedInlineConfigs: "error",
 	},
-]);
+});
 ```
 
 You can override this setting using the [`--report-unused-inline-configs`](../command-line-interface#--report-unused-inline-configs) command line option.
@@ -532,13 +512,11 @@ You can configure any number of rules in a configuration object by adding a `rul
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		rules: {
-			semi: "error",
-		},
+export default defineConfig({
+	rules: {
+		semi: "error",
 	},
-]);
+});
 ```
 
 This configuration object specifies that the [`semi`](../../rules/semi) rule should be enabled with a severity of `"error"`. You can also provide options to a rule by specifying an array where the first item is the severity and each item after that is an option for the rule. For example, you can switch the `semi` rule to disallow semicolons by passing `"never"` as an option:
@@ -547,13 +525,11 @@ This configuration object specifies that the [`semi`](../../rules/semi) rule sho
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		rules: {
-			semi: ["error", "never"],
-		},
+export default defineConfig({
+	rules: {
+		semi: ["error", "never"],
 	},
-]);
+});
 ```
 
 Each rule specifies its own options and can be any valid JSON data type. Please check the documentation for the rule you want to configure for more information about its available options.
@@ -568,33 +544,31 @@ ESLint supports adding shared settings into configuration files. When you add a 
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		settings: {
-			sharedData: "Hello",
-		},
-		plugins: {
-			customPlugin: {
-				rules: {
-					"my-rule": {
-						meta: {
-							// custom rule's meta information
-						},
-						create(context) {
-							const sharedData = context.settings.sharedData;
-							return {
-								// code
-							};
-						},
+export default defineConfig({
+	settings: {
+		sharedData: "Hello",
+	},
+	plugins: {
+		customPlugin: {
+			rules: {
+				"my-rule": {
+					meta: {
+						// custom rule's meta information
+					},
+					create(context) {
+						const sharedData = context.settings.sharedData;
+						return {
+							// code
+						};
 					},
 				},
 			},
 		},
-		rules: {
-			"customPlugin/my-rule": "error",
-		},
 	},
-]);
+	rules: {
+		"customPlugin/my-rule": "error",
+	},
+});
 ```
 
 ### Extending Configurations
@@ -614,15 +588,13 @@ ESLint plugins can export predefined configurations. These configurations are re
 import examplePlugin from "eslint-plugin-example";
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		files: ["**/*.js"],
-		plugins: {
-			example: examplePlugin,
-		},
-		extends: ["example/recommended"],
+export default defineConfig({
+	files: ["**/*.js"],
+	plugins: {
+		example: examplePlugin,
 	},
-]);
+	extends: ["example/recommended"],
+});
 ```
 
 In this example, the configuration named `recommended` from `eslint-plugin-example` is loaded. The plugin configurations can also be referenced by name inside of the configuration array.
@@ -634,15 +606,13 @@ You can also insert plugin configurations directly into the `extends` array. For
 import pluginExample from "eslint-plugin-example";
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		files: ["**/*.js"],
-		plugins: {
-			example: pluginExample,
-		},
-		extends: [pluginExample.configs.recommended],
+export default defineConfig({
+	files: ["**/*.js"],
+	plugins: {
+		example: pluginExample,
 	},
-]);
+	extends: [pluginExample.configs.recommended],
+});
 ```
 
 In this case, the configuration named `recommended` from `eslint-plugin-example` is accessed directly through the plugin object's `configs` property.
@@ -665,18 +635,16 @@ To include these predefined configurations, install the `@eslint/js` package and
 import js from "@eslint/js";
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		files: ["**/*.js"],
-		plugins: {
-			js,
-		},
-		extends: ["js/recommended"],
-		rules: {
-			"no-unused-vars": "warn",
-		},
+export default defineConfig({
+	files: ["**/*.js"],
+	plugins: {
+		js,
 	},
-]);
+	extends: ["js/recommended"],
+	rules: {
+		"no-unused-vars": "warn",
+	},
+});
 ```
 
 Here, the `js/recommended` predefined configuration is applied first and then another configuration object adds the desired configuration for [`no-unused-vars`](../../rules/no-unused-vars).
@@ -692,15 +660,13 @@ A sharable configuration is an npm package that exports a configuration object o
 import exampleConfig from "eslint-config-example";
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		files: ["**/*.js"],
-		extends: [exampleConfig],
-		rules: {
-			"no-unused-vars": "warn",
-		},
+export default defineConfig({
+	files: ["**/*.js"],
+	extends: [exampleConfig],
+	rules: {
+		"no-unused-vars": "warn",
 	},
-]);
+});
 ```
 
 In this example, `exampleConfig` can be either an object or an array, and either way it can be inserted directly into the `extends` array.

--- a/docs/src/use/configure/ignore.md
+++ b/docs/src/use/configure/ignore.md
@@ -29,7 +29,7 @@ In your `eslint.config.js` file, you can use the `globalIgnores()` helper functi
 // eslint.config.js
 import { defineConfig, globalIgnores } from "eslint/config";
 
-export default defineConfig([globalIgnores([".config/*"])]);
+export default defineConfig(globalIgnores([".config/*"]));
 ```
 
 This configuration specifies that all of the files in the `.config` directory should be ignored. This pattern is added after the default patterns, which are `["**/node_modules/", ".git/"]`.
@@ -40,9 +40,7 @@ By default, ESLint lints files that match the patterns `**/*.js`, `**/*.cjs`, an
 // eslint.config.js
 import { defineConfig, globalIgnores } from "eslint/config";
 
-export default defineConfig([
-	globalIgnores(["**/*.js", "**/*.cjs", "**/*.mjs"]),
-]);
+export default defineConfig(globalIgnores(["**/*.js", "**/*.cjs", "**/*.mjs"]));
 ```
 
 When non-JS files are specified in the `files` property, ESLint still lints files that match the default patterns. To lint only the files specified in the `files` property, you must ignore the default file patterns:
@@ -51,7 +49,7 @@ When non-JS files are specified in the `files` property, ESLint still lints file
 // eslint.config.js
 import { defineConfig, globalIgnores } from "eslint/config";
 
-export default defineConfig([
+export default defineConfig(
 	globalIgnores(["**/*.js", "**/*.cjs", "**/*.mjs"]),
 	{
 		files: ["**/*.ts"],
@@ -60,7 +58,7 @@ export default defineConfig([
 			/* ... */
 		},
 	},
-]);
+);
 ```
 
 You can also ignore files on the command line using [`--ignore-pattern`](../command-line-interface#--ignore-pattern), such as:
@@ -78,7 +76,7 @@ Ignoring directories works the same way as ignoring files, by passing a pattern 
 // eslint.config.js
 import { defineConfig, globalIgnores } from "eslint/config";
 
-export default defineConfig([globalIgnores([".config/"])]);
+export default defineConfig(globalIgnores([".config/"]));
 ```
 
 Unlike `.gitignore`, an ignore pattern like `.config` will only ignore the `.config` directory in the same directory as the configuration file. If you want to recursively ignore all directories named `.config`, you need to use `**/.config/`, as in this example:
@@ -87,7 +85,7 @@ Unlike `.gitignore`, an ignore pattern like `.config` will only ignore the `.con
 // eslint.config.js
 import { defineConfig, globalIgnores } from "eslint/config";
 
-export default defineConfig([globalIgnores(["**/.config/"])]);
+export default defineConfig(globalIgnores(["**/.config/"]));
 ```
 
 ## Unignore Files and Directories
@@ -98,13 +96,13 @@ You can also unignore files and directories that are ignored by previous pattern
 // eslint.config.js
 import { defineConfig, globalIgnores } from "eslint/config";
 
-export default defineConfig([
+export default defineConfig(
 	globalIgnores([
 		"!node_modules/", // unignore `node_modules/` directory
 		"node_modules/*", // ignore its content
 		"!node_modules/mylibrary/", // unignore `node_modules/mylibrary` directory
 	]),
-]);
+);
 ```
 
 If you'd like to ignore a directory except for specific files or subdirectories, then the ignore pattern `directory/**/*` must be used instead of `directory/**`. The pattern `directory/**` ignores the entire directory and its contents, so traversal will skip over the directory completely and you cannot unignore anything inside.
@@ -115,12 +113,12 @@ For example, `build/**` ignores directory `build` and its contents, whereas `bui
 // eslint.config.js
 import { defineConfig, globalIgnores } from "eslint/config";
 
-export default defineConfig([
+export default defineConfig(
 	globalIgnores([
 		"build/**/*", // ignore all contents in and under `build/` directory but not the `build/` directory itself
 		"!build/test.js", // unignore `!build/test.js`
 	]),
-]);
+);
 ```
 
 If you'd like to ignore a directory except for specific files at any level under the directory, you should also ensure that subdirectories are not ignored. Note that while patterns that end with `/` only match directories, patterns that don't end with `/` match both files and directories so it isn't possible to write a single pattern that only ignores files, but you can achieve this with two patterns: one to ignore all contents and another to unignore subdirectories.
@@ -131,13 +129,13 @@ For example, this config ignores all files in and under `build` directory except
 // eslint.config.js
 import { defineConfig, globalIgnores } from "eslint/config";
 
-export default defineConfig([
+export default defineConfig(
 	globalIgnores([
 		"build/**/*", // ignore all contents in and under `build/` directory but not the `build/` directory itself
 		"!build/**/*/", // unignore all subdirectories
 		"!build/**/test.js", // unignore `test.js` files
 	]),
-]);
+);
 ```
 
 If you want to ignore ESLint's default file patterns (`**/*.js`, `**/*.cjs`, and `**/*.mjs`) while still linting specific files or directories, you can use negative patterns to unignore them:
@@ -146,9 +144,9 @@ If you want to ignore ESLint's default file patterns (`**/*.js`, `**/*.cjs`, and
 // eslint.config.js
 import { defineConfig, globalIgnores } from "eslint/config";
 
-export default defineConfig([
+export default defineConfig(
 	globalIgnores(["**/*.js", "**/*.cjs", "**/*.mjs", "!**/src/**/*.js"]),
-]);
+);
 ```
 
 This configuration ignores all files matching the default patterns except for JavaScript files located within `src` directories.
@@ -181,9 +179,9 @@ By default, `globalIgnores()` will assign a name to the config that represents y
 // eslint.config.js
 import { defineConfig, globalIgnores } from "eslint/config";
 
-export default defineConfig([
+export default defineConfig(
 	globalIgnores(["build/**/*"], "Ignore Build Directory"),
-]);
+);
 ```
 
 The `"Ignore Build Directory"` string in this example is the name of the config created for the global ignores. This is useful for debugging purposes.
@@ -196,7 +194,7 @@ When you pass directories to the ESLint CLI, files and directories are silently 
 // eslint.config.js
 import { defineConfig, globalIgnores } from "eslint/config";
 
-export default defineConfig([globalIgnores(["foo.js"])]);
+export default defineConfig(globalIgnores(["foo.js"]));
 ```
 
 And then you run:
@@ -231,12 +229,12 @@ import { fileURLToPath } from "node:url";
 
 const gitignorePath = fileURLToPath(new URL(".gitignore", import.meta.url));
 
-export default defineConfig([
+export default defineConfig(
 	includeIgnoreFile(gitignorePath, "Imported .gitignore patterns"),
 	{
 		// your overrides
 	},
-]);
+);
 ```
 
 This automatically loads the specified file and translates gitignore-style patterns into `ignores` glob patterns.

--- a/docs/src/use/configure/language-options.md
+++ b/docs/src/use/configure/language-options.md
@@ -29,14 +29,12 @@ Here's an example [configuration file](./configuration-files#configuration-file)
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		languageOptions: {
-			ecmaVersion: 5,
-			sourceType: "script",
-		},
+export default defineConfig({
+	languageOptions: {
+		ecmaVersion: 5,
+		sourceType: "script",
 	},
-]);
+});
 ```
 
 ## Specify Parser Options
@@ -55,17 +53,15 @@ Here's an example [configuration file](./configuration-files#configuration-file)
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		languageOptions: {
-			parserOptions: {
-				ecmaFeatures: {
-					jsx: true,
-				},
+export default defineConfig({
+	languageOptions: {
+		parserOptions: {
+			ecmaFeatures: {
+				jsx: true,
 			},
 		},
 	},
-]);
+});
 ```
 
 ::: important
@@ -98,16 +94,14 @@ To configure global variables inside of a [configuration file](./configuration-f
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		languageOptions: {
-			globals: {
-				var1: "writable",
-				var2: "readonly",
-			},
+export default defineConfig({
+	languageOptions: {
+		globals: {
+			var1: "writable",
+			var2: "readonly",
 		},
 	},
-]);
+});
 ```
 
 This configuration allows `var1` to be overwritten in your code, but disallow it for `var2`.
@@ -118,15 +112,13 @@ Globals can be disabled by setting their value to `"off"`. For example, in an en
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		languageOptions: {
-			globals: {
-				Promise: "off",
-			},
+export default defineConfig({
+	languageOptions: {
+		globals: {
+			Promise: "off",
 		},
 	},
-]);
+});
 ```
 
 ::: tip
@@ -142,15 +134,13 @@ Apart from the ECMAScript standard built-in globals, which are automatically ena
 import globals from "globals";
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		languageOptions: {
-			globals: {
-				...globals.browser,
-			},
+export default defineConfig({
+	languageOptions: {
+		globals: {
+			...globals.browser,
 		},
 	},
-]);
+});
 ```
 
 You can include multiple different collections of globals in the same way. The following example includes globals both for web browsers and for [Jest](https://jestjs.io/):
@@ -160,14 +150,12 @@ You can include multiple different collections of globals in the same way. The f
 import globals from "globals";
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		languageOptions: {
-			globals: {
-				...globals.browser,
-				...globals.jest,
-			},
+export default defineConfig({
+	languageOptions: {
+		globals: {
+			...globals.browser,
+			...globals.jest,
 		},
 	},
-]);
+});
 ```

--- a/docs/src/use/configure/migration-guide.md
+++ b/docs/src/use/configure/migration-guide.md
@@ -80,18 +80,16 @@ In flat config, you would do the same thing like this:
 import { defineConfig } from "eslint/config";
 import jsdoc from "eslint-plugin-jsdoc";
 
-export default defineConfig([
-	{
-		files: ["**/*.js"],
-		plugins: {
-			jsdoc: jsdoc,
-		},
-		rules: {
-			"jsdoc/require-description": "error",
-			"jsdoc/check-values": "error",
-		},
+export default defineConfig({
+	files: ["**/*.js"],
+	plugins: {
+		jsdoc: jsdoc,
 	},
-]);
+	rules: {
+		"jsdoc/require-description": "error",
+		"jsdoc/check-values": "error",
+	},
+});
 ```
 
 ::: tip
@@ -124,15 +122,13 @@ In flat config, you would do the same thing like this:
 import { defineConfig } from "eslint/config";
 import babelParser from "@babel/eslint-parser";
 
-export default defineConfig([
-	{
-		// ...other config
-		languageOptions: {
-			parser: babelParser,
-		},
-		// ...other config
+export default defineConfig({
+	// ...other config
+	languageOptions: {
+		parser: babelParser,
 	},
-]);
+	// ...other config
+});
 ```
 
 ### Processors
@@ -189,7 +185,7 @@ In flat config, the following are all valid ways to express the same:
 import { defineConfig } from "eslint/config";
 import somePlugin from "eslint-plugin-someplugin";
 
-export default defineConfig([
+export default defineConfig(
 	{
 		plugins: { somePlugin },
 		processor: "somePlugin/someProcessor",
@@ -203,7 +199,7 @@ export default defineConfig([
 		// We don't need the plugin to be present in the config to use the processor directly
 		processor: somePlugin.processors.someProcessor,
 	},
-]);
+);
 ```
 
 Note that because the `.md` processor is _not_ automatically added by flat config, you also need to specify an extra configuration element:
@@ -268,7 +264,7 @@ For flat config, here is a configuration with the default glob pattern:
 import { defineConfig } from "eslint/config";
 import js from "@eslint/js";
 
-export default defineConfig([
+export default defineConfig(
 	js.configs.recommended, // Recommended config applied to all files
 	// Override the recommended config
 	{
@@ -278,7 +274,7 @@ export default defineConfig([
 		},
 		// ...other configuration
 	},
-]);
+);
 ```
 
 A flat config example configuration supporting multiple configs for different glob patterns:
@@ -289,7 +285,7 @@ A flat config example configuration supporting multiple configs for different gl
 import { defineConfig } from "eslint/config";
 import js from "@eslint/js";
 
-export default defineConfig([
+export default defineConfig(
 	js.configs.recommended, // Recommended config applied to all files
 	// File-pattern specific overrides
 	{
@@ -305,7 +301,7 @@ export default defineConfig([
 		},
 	},
 	// ...other configurations
-]);
+);
 ```
 
 ### Configure Language Options
@@ -343,20 +339,18 @@ Here's the same configuration in flat config:
 import { defineConfig } from "eslint/config";
 import globals from "globals";
 
-export default defineConfig([
-	{
-		languageOptions: {
-			ecmaVersion: 2022,
-			sourceType: "module",
-			globals: {
-				...globals.browser,
-				...globals.node,
-				myCustomGlobal: "readonly",
-			},
+export default defineConfig({
+	languageOptions: {
+		ecmaVersion: 2022,
+		sourceType: "module",
+		globals: {
+			...globals.browser,
+			...globals.node,
+			myCustomGlobal: "readonly",
 		},
-		// ...other config
 	},
-]);
+	// ...other config
+});
 ```
 
 ::: tip
@@ -408,7 +402,7 @@ Another option is to remove the comment from the file being linted and define th
 import { defineConfig } from "eslint/config";
 import globals from "globals";
 
-export default defineConfig([
+export default defineConfig(
 	// ...other config
 	{
 		files: ["tests/**"],
@@ -418,7 +412,7 @@ export default defineConfig([
 			},
 		},
 	},
-]);
+);
 ```
 
 ### Predefined and Shareable Configs
@@ -484,17 +478,12 @@ import js from "@eslint/js";
 import customConfig from "./custom-config.js";
 import myConfig from "eslint-config-my-config";
 
-export default defineConfig([
-	js.configs.recommended,
-	customConfig,
-	myConfig,
-	{
-		rules: {
-			semi: ["warn", "always"],
-		},
-		// ...other config
+export default defineConfig(js.configs.recommended, customConfig, myConfig, {
+	rules: {
+		semi: ["warn", "always"],
 	},
-]);
+	// ...other config
+});
 ```
 
 Note that because you are just importing JavaScript modules, you can mutate the config objects before ESLint uses them. For example, you might want to have a certain config object only apply to your test files:
@@ -506,13 +495,10 @@ import { defineConfig } from "eslint/config";
 import js from "@eslint/js";
 import customTestConfig from "./custom-test-config.js";
 
-export default defineConfig([
-	js.configs.recommended,
-	{
-		...customTestConfig,
-		files: ["**/*.test.js"],
-	},
-]);
+export default defineConfig(js.configs.recommended, {
+	...customTestConfig,
+	files: ["**/*.test.js"],
+});
 ```
 
 #### Use eslintrc Configs in Flat Config
@@ -541,10 +527,10 @@ const compat = new FlatCompat({
 	baseDirectory: __dirname,
 });
 
-export default defineConfig([
+export default defineConfig(
 	// mimic ESLintRC-style extends
 	...compat.extends("eslint-config-my-config"),
-]);
+);
 ```
 
 This example uses the `FlatCompat#extends()` method to insert the `eslint-config-my-config` into the flat config array.
@@ -581,13 +567,13 @@ The equivalent ignore patterns in flat config look like this:
 ```javascript
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
+export default defineConfig(
 	// ...other config
 	{
 		// Note: there should be no other properties in this object
 		ignores: ["**/temp.js", "config/*"],
 	},
-]);
+);
 ```
 
 In `.eslintignore`, `temp.js` ignores all files named `temp.js`, whereas in flat config, you need to specify this as `**/temp.js`. The pattern `temp.js` in flat config only ignores a file named `temp.js` in the same directory as the configuration file.
@@ -621,15 +607,13 @@ Here's the same options in flat config:
 
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		// ...other config
-		linterOptions: {
-			noInlineConfig: true,
-			reportUnusedDisableDirectives: "warn",
-		},
+export default defineConfig({
+	// ...other config
+	linterOptions: {
+		noInlineConfig: true,
+		reportUnusedDisableDirectives: "warn",
 	},
-]);
+});
 ```
 
 ### CLI Flag Changes
@@ -653,16 +637,14 @@ For example, if you previously used `--env browser,node`, you’ll need to updat
 import { defineConfig } from "eslint/config";
 import globals from "globals";
 
-export default defineConfig([
-	{
-		languageOptions: {
-			globals: {
-				...globals.browser,
-				...globals.node,
-			},
+export default defineConfig({
+	languageOptions: {
+		globals: {
+			...globals.browser,
+			...globals.node,
 		},
 	},
-]);
+});
 ```
 
 #### `--ignore-path`
@@ -679,10 +661,10 @@ import { fileURLToPath } from "node:url";
 
 const gitignorePath = fileURLToPath(new URL(".gitignore", import.meta.url));
 
-export default defineConfig([
+export default defineConfig(
 	includeIgnoreFile(gitignorePath, "Imported .gitignore patterns"),
 	// other configs
-]);
+);
 ```
 
 #### `--no-eslintrc`
@@ -704,23 +686,21 @@ The `--rulesdir` flag was used to load additional rules from a specified directo
 import { defineConfig } from "eslint/config";
 import myRule from "./rules/my-rule.js";
 
-export default defineConfig([
-	{
-		// define the plugin
-		plugins: {
-			local: {
-				rules: {
-					"my-rule": myRule,
-				},
+export default defineConfig({
+	// define the plugin
+	plugins: {
+		local: {
+			rules: {
+				"my-rule": myRule,
 			},
 		},
-
-		// configure the rule
-		rules: {
-			"local/my-rule": ["error"],
-		},
 	},
-]);
+
+	// configure the rule
+	rules: {
+		"local/my-rule": ["error"],
+	},
+});
 ```
 
 ### `package.json` Configuration No Longer Supported

--- a/docs/src/use/configure/parser.md
+++ b/docs/src/use/configure/parser.md
@@ -22,14 +22,12 @@ In many cases, you can use the [default parser](https://github.com/eslint/js/tre
 import babelParser from "@babel/eslint-parser";
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		files: ["**/*.js", "**/*.mjs"],
-		languageOptions: {
-			parser: babelParser,
-		},
+export default defineConfig({
+	files: ["**/*.js", "**/*.mjs"],
+	languageOptions: {
+		parser: babelParser,
 	},
-]);
+});
 ```
 
 This configuration ensures that the Babel parser, rather than the default Espree parser, is used to parse all files ending with `.js` and `.mjs`.
@@ -53,21 +51,19 @@ Parsers may accept options to alter the way they behave. The `languageOptions.pa
 import babelParser from "@babel/eslint-parser";
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		languageOptions: {
-			parser: babelParser,
-			parserOptions: {
-				requireConfigFile: false,
-				babelOptions: {
-					babelrc: false,
-					configFile: false,
-					presets: ["@babel/preset-env"],
-				},
+export default defineConfig({
+	languageOptions: {
+		parser: babelParser,
+		parserOptions: {
+			requireConfigFile: false,
+			babelOptions: {
+				babelrc: false,
+				configFile: false,
+				presets: ["@babel/preset-env"],
 			},
 		},
 	},
-]);
+});
 ```
 
 ::: tip

--- a/docs/src/use/configure/plugins.md
+++ b/docs/src/use/configure/plugins.md
@@ -28,16 +28,14 @@ To configure plugins inside of a [configuration file](./configuration-files#conf
 import example from "eslint-plugin-example";
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		plugins: {
-			example,
-		},
-		rules: {
-			"example/rule1": "warn",
-		},
+export default defineConfig({
+	plugins: {
+		example,
 	},
-]);
+	rules: {
+		"example/rule1": "warn",
+	},
+});
 ```
 
 ::: tip
@@ -53,16 +51,14 @@ Plugins don't need to be published to npm for use with ESLint. You can also load
 import local from "./my-local-plugin.js";
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		plugins: {
-			local,
-		},
-		rules: {
-			"local/rule1": "warn",
-		},
+export default defineConfig({
+	plugins: {
+		local,
 	},
-]);
+	rules: {
+		"local/rule1": "warn",
+	},
+});
 ```
 
 Here, the namespace `local` is used, but you can also use any name you'd like instead.
@@ -76,20 +72,18 @@ Plugin definitions can be created virtually directly in your config. For example
 import myRule from "./rules/my-rule.js";
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		plugins: {
-			local: {
-				rules: {
-					"my-rule": myRule,
-				},
+export default defineConfig({
+	plugins: {
+		local: {
+			rules: {
+				"my-rule": myRule,
 			},
 		},
-		rules: {
-			"local/my-rule": "warn",
-		},
 	},
-]);
+	rules: {
+		"local/my-rule": "warn",
+	},
+});
 ```
 
 Here, the namespace `local` is used to define a virtual plugin. The rule `myRule` is then assigned a name of `my-rule` inside of the virtual plugin's `rules` object. (See [Create Plugins](../../extend/plugins) for the complete format of a plugin.) You can then reference the rule as `local/my-rule` to configure it.
@@ -105,18 +99,16 @@ is an object where the name of the plugin is the property name and the value is 
 import jsdoc from "eslint-plugin-jsdoc";
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		files: ["**/*.js"],
-		plugins: {
-			jsdoc: jsdoc,
-		},
-		rules: {
-			"jsdoc/require-description": "error",
-			"jsdoc/check-values": "error",
-		},
+export default defineConfig({
+	files: ["**/*.js"],
+	plugins: {
+		jsdoc: jsdoc,
 	},
-]);
+	rules: {
+		"jsdoc/require-description": "error",
+		"jsdoc/check-values": "error",
+	},
+});
 ```
 
 In this configuration, the JSDoc plugin is defined to have the name `jsdoc`. The prefix `jsdoc/` in each rule name indicates that the rule is coming from the plugin with that name rather than from ESLint itself.
@@ -127,18 +119,16 @@ Because the name of the plugin and the plugin object are both `jsdoc`, you can a
 import jsdoc from "eslint-plugin-jsdoc";
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		files: ["**/*.js"],
-		plugins: {
-			jsdoc,
-		},
-		rules: {
-			"jsdoc/require-description": "error",
-			"jsdoc/check-values": "error",
-		},
+export default defineConfig({
+	files: ["**/*.js"],
+	plugins: {
+		jsdoc,
 	},
-]);
+	rules: {
+		"jsdoc/require-description": "error",
+		"jsdoc/check-values": "error",
+	},
+});
 ```
 
 While this is the most common convention, you don't need to use the same name that the plugin prescribes. You can specify any prefix that you'd like, such as:
@@ -147,18 +137,16 @@ While this is the most common convention, you don't need to use the same name th
 import jsdoc from "eslint-plugin-jsdoc";
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		files: ["**/*.js"],
-		plugins: {
-			jsd: jsdoc,
-		},
-		rules: {
-			"jsd/require-description": "error",
-			"jsd/check-values": "error",
-		},
+export default defineConfig({
+	files: ["**/*.js"],
+	plugins: {
+		jsd: jsdoc,
 	},
-]);
+	rules: {
+		"jsd/require-description": "error",
+		"jsd/check-values": "error",
+	},
+});
 ```
 
 This configuration object uses `jsd` as the prefix plugin instead of `jsdoc`.
@@ -174,15 +162,13 @@ To specify processors in a [configuration file](./configuration-files#configurat
 import markdown from "@eslint/markdown";
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		files: ["**/*.md"],
-		plugins: {
-			markdown,
-		},
-		processor: "markdown/markdown",
+export default defineConfig({
+	files: ["**/*.md"],
+	plugins: {
+		markdown,
 	},
-]);
+	processor: "markdown/markdown",
+});
 ```
 
 Processors may make named code blocks such as `0.js` and `1.js`. ESLint handles such a named code block as a child file of the original file. You can specify additional configurations for named code blocks with additional config objects. For example, the following disables the `strict` rule for the named code blocks which end with `.js` in markdown files.
@@ -192,7 +178,7 @@ Processors may make named code blocks such as `0.js` and `1.js`. ESLint handles 
 import markdown from "@eslint/markdown";
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
+export default defineConfig(
 	// applies to all JavaScript files
 	{
 		rules: {
@@ -216,7 +202,7 @@ export default defineConfig([
 			strict: "off",
 		},
 	},
-]);
+);
 ```
 
 ESLint only lints named code blocks when they are JavaScript files or if they match a `files` entry in a config object. Be sure to add a config object with a matching `files` entry if you want to lint non-JavaScript named code blocks. Also note that [global ignores](./ignore) apply to named code blocks as well.
@@ -226,7 +212,7 @@ ESLint only lints named code blocks when they are JavaScript files or if they ma
 import markdown from "@eslint/markdown";
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
+export default defineConfig(
 	// applies to Markdown files
 	{
 		files: ["**/*.md"],
@@ -252,7 +238,7 @@ export default defineConfig([
 	{
 		ignores: ["**/test.md/*.jsx"],
 	},
-]);
+);
 ```
 
 ## Specify a Language
@@ -264,15 +250,13 @@ Plugins may provide languages. Languages allow ESLint to lint programming langua
 import json from "@eslint/json";
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		files: ["**/*.json"],
-		plugins: {
-			json,
-		},
-		language: "json/jsonc",
+export default defineConfig({
+	files: ["**/*.json"],
+	plugins: {
+		json,
 	},
-]);
+	language: "json/jsonc",
+});
 ```
 
 ::: tip

--- a/docs/src/use/configure/rules.md
+++ b/docs/src/use/configure/rules.md
@@ -80,13 +80,11 @@ To report unused `eslint` inline config comments (those that don't change anythi
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		linterOptions: {
-			reportUnusedInlineConfigs: "error",
-		},
+export default defineConfig({
+	linterOptions: {
+		reportUnusedInlineConfigs: "error",
 	},
-]);
+});
 ```
 
 This setting defaults to `"off"`.
@@ -105,15 +103,13 @@ To configure rules inside of a [configuration file](./configuration-files#config
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		rules: {
-			eqeqeq: "off",
-			"no-unused-vars": "error",
-			"prefer-const": ["error", { ignoreReadBeforeAssign: true }],
-		},
+export default defineConfig({
+	rules: {
+		eqeqeq: "off",
+		"no-unused-vars": "error",
+		"prefer-const": ["error", { ignoreReadBeforeAssign: true }],
 	},
-]);
+});
 ```
 
 When more than one configuration object specifies the same rule, the rule configuration is merged with the later object taking precedence over any previous objects. For example:
@@ -121,7 +117,7 @@ When more than one configuration object specifies the same rule, the rule config
 ```js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
+export default defineConfig(
 	{
 		rules: {
 			semi: ["error", "never"],
@@ -132,7 +128,7 @@ export default defineConfig([
 			semi: ["warn", "always"],
 		},
 	},
-]);
+);
 ```
 
 Using this configuration, the final rule configuration for `semi` is `["warn", "always"]` because it appears last in the array. The array indicates that the configuration is for the severity and any options. You can change just the severity by defining only a string or number, as in this example:
@@ -140,7 +136,7 @@ Using this configuration, the final rule configuration for `semi` is `["warn", "
 ```js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
+export default defineConfig(
 	{
 		rules: {
 			semi: ["error", "never"],
@@ -151,7 +147,7 @@ export default defineConfig([
 			semi: "warn",
 		},
 	},
-]);
+);
 ```
 
 Here, the second configuration object only overrides the severity, so the final configuration for `semi` is `["warn", "never"]`.
@@ -171,16 +167,14 @@ In a [configuration file](./configuration-files#configuration-file), for example
 import example from "eslint-plugin-example";
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		plugins: {
-			example,
-		},
-		rules: {
-			"example/rule1": "warn",
-		},
+export default defineConfig({
+	plugins: {
+		example,
 	},
-]);
+	rules: {
+		"example/rule1": "warn",
+	},
+});
 ```
 
 In this configuration file, the rule `example/rule1` comes from the plugin named `eslint-plugin-example`.
@@ -342,7 +336,7 @@ To disable rules inside of a [configuration file](./configuration-files#configur
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
+export default defineConfig(
 	{
 		rules: {
 			"no-unused-expressions": "error",
@@ -354,7 +348,7 @@ export default defineConfig([
 			"no-unused-expressions": "off",
 		},
 	},
-]);
+);
 ```
 
 ### Disable Inline Comments
@@ -365,16 +359,14 @@ To disable all inline config comments, use the `noInlineConfig` setting in your 
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		linterOptions: {
-			noInlineConfig: true,
-		},
-		rules: {
-			"no-unused-expressions": "error",
-		},
+export default defineConfig({
+	linterOptions: {
+		noInlineConfig: true,
 	},
-]);
+	rules: {
+		"no-unused-expressions": "error",
+	},
+});
 ```
 
 You can also use the [`--no-inline-config`](../command-line-interface#--no-inline-config) CLI option to disable rule comments, in addition to other in-line configuration.
@@ -387,13 +379,11 @@ To report unused `eslint-disable` comments (those that disable rules which would
 // eslint.config.js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		linterOptions: {
-			reportUnusedDisableDirectives: "error",
-		},
+export default defineConfig({
+	linterOptions: {
+		reportUnusedDisableDirectives: "error",
 	},
-]);
+});
 ```
 
 This setting defaults to `"warn"`.

--- a/docs/src/use/core-concepts/glossary.md
+++ b/docs/src/use/core-concepts/glossary.md
@@ -35,13 +35,11 @@ For example, this `eslint.config.js` file enables the `prefer-const` [rule](#rul
 ```js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
-	{
-		rules: {
-			"prefer-const": "error",
-		},
+export default defineConfig({
+	rules: {
+		"prefer-const": "error",
 	},
-]);
+});
 ```
 
 See [Configuration Files](../configure/configuration-files) for more details.
@@ -246,7 +244,7 @@ The following [config file](#config-file-configuration-file) overrides `no-unuse
 ```js
 import { defineConfig } from "eslint/config";
 
-export default defineConfig([
+export default defineConfig(
 	{
 		rules: {
 			"no-unused-expressions": "error",
@@ -258,7 +256,7 @@ export default defineConfig([
 			"no-unused-expressions": "off",
 		},
 	},
-]);
+);
 ```
 
 The following [inline config](#inline-config-configuration-comment) sets `no-unused-expressions` to `"error"`:
@@ -352,7 +350,7 @@ import { defineConfig } from "eslint/config";
 import js from "@eslint/js";
 import solid from "eslint-plugin-solid/configs/recommended";
 
-export default defineConfig([js.configs.recommended, solid]);
+export default defineConfig(js.configs.recommended, solid);
 ```
 
 For information on shareable configs, see [Share Configurations](../../extend/shareable-configs).

--- a/docs/src/use/formatters/index.md
+++ b/docs/src/use/formatters/index.md
@@ -41,7 +41,7 @@ function addOne(i) {
 import { defineConfig } from "eslint/config";
 import js from "@eslint/js";
 
-export default defineConfig([
+export default defineConfig(
 	{
 		files: ["**/*.js"],
 		plugins: {
@@ -56,7 +56,7 @@ export default defineConfig([
 			"space-unary-ops"  : 2
 		}
 	}
-]);
+);
 ```
 
 Tests the formatters with the CLI:

--- a/docs/src/use/getting-started.md
+++ b/docs/src/use/getting-started.md
@@ -61,10 +61,10 @@ import { defineConfig } from "eslint/config";
 import globals from "globals";
 import js from "@eslint/js";
 
-export default defineConfig([
+export default defineConfig(
 	{ files: ["**/*.js"], languageOptions: { globals: globals.browser } },
 	{ files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
-]);
+);
 ```
 
 The `"js/recommended"` configuration ensures all of the rules marked as recommended on the [rules page](../rules) will be turned on. Alternatively, you can use configurations that others have created by searching for "eslint-config" on [npmjs.com](https://www.npmjs.com/search?q=eslint-config). ESLint will not lint your code unless you extend from a shared configuration or explicitly turn rules on in your configuration.
@@ -75,7 +75,7 @@ You can configure rules individually by defining a new object with a `rules` key
 import { defineConfig } from "eslint/config";
 import js from "@eslint/js";
 
-export default defineConfig([
+export default defineConfig(
 	{ files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
 
 	{
@@ -84,7 +84,7 @@ export default defineConfig([
 			"no-undef": "warn",
 		},
 	},
-]);
+);
 ```
 
 The names `"no-unused-vars"` and `"no-undef"` are the names of [rules](../rules) in ESLint. The first value is the error level of the rule and can be one of these values:
@@ -137,19 +137,17 @@ Before you begin, you must already have a `package.json` file. If you don't, mak
     import { defineConfig } from "eslint/config";
     import js from "@eslint/js";
 
-    export default defineConfig([
-    	{
-    		files: ["**/*.js"],
-    		plugins: {
-    			js,
-    		},
-    		extends: ["js/recommended"],
-    		rules: {
-    			"no-unused-vars": "warn",
-    			"no-undef": "warn",
-    		},
+    export default defineConfig({
+    	files: ["**/*.js"],
+    	plugins: {
+    		js,
     	},
-    ]);
+    	extends: ["js/recommended"],
+    	rules: {
+    		"no-unused-vars": "warn",
+    		"no-undef": "warn",
+    	},
+    });
     ```
 
 4. Lint code using the ESLint CLI:


### PR DESCRIPTION
## Summary
- remove redundant array literals from `defineConfig()` examples across the docs
- use `defineConfig({ ... })` for single config objects and `defineConfig(config1, config2)` for multiple configs
- align examples with the intended variadic API and improve copy-paste ergonomics

## Testing
- `npx prettier --check $(git diff --name-only -- docs/src | tr "\n" " ")`
- `npm run lint:docs:js`

Closes #20736

AI-assisted: yes, reviewed and validated before submission.