### PR TITLE
test: add unit tests for SuppressionsService.suppress() method

### DIFF
--- a/tests/lib/services/suppressions-service.js
+++ b/tests/lib/services/suppressions-service.js
@@ -362,7 +362,7 @@ describe("SuppressionsService", () => {
 				createResult({
 					filePath: path.join(cwd, "src", "app.js"),
 					messages: [
-						createMessage(null, "error"), // parser error — no ruleId
+						createMessage(null, "error"),
 						createMessage("no-unused-vars", "error"),
 					],
 				}),

--- a/tests/lib/services/suppressions-service.js
+++ b/tests/lib/services/suppressions-service.js
@@ -203,7 +203,8 @@ describe("SuppressionsService", () => {
 				}),
 			];
 
-			await suppressionsService.suppress(results, void 0);
+			const rules = void 0; // No rule filter
+			await suppressionService.suppress(results, rules);
 
 			assert.ok(writeStub.calledOnce, "Expected save to be called");
 			const written = JSON.parse(writeStub.firstCall.args[1]);

--- a/tests/lib/services/suppressions-service.js
+++ b/tests/lib/services/suppressions-service.js
@@ -44,17 +44,14 @@ function createResult({ filePath, messages = [], suppressedMessages = [] }) {
 
 /**
  * Creates a lint message for testing.
- * @param {string} ruleId The rule ID.
- * @param {number} severity 1=warning, 2=error.
+ * @param {string|null} ruleId The rule ID.
+ * @param {"warn"|"error"} [severityLabel] The severity label. Defaults to "error".
  * @returns {Object} A LintMessage-like object.
  */
-function createMessage(ruleId, severity = 2) {
+function createMessage(ruleId, severityLabel = "error") {
 	return {
 		ruleId,
-		severity,
-		message: `${ruleId} violation`,
-		line: 1,
-		column: 1,
+		severity: severityLabel === "warn" ? 1 : 2,
 	};
 }
 
@@ -199,9 +196,9 @@ describe("SuppressionsService", () => {
 				createResult({
 					filePath: path.join(cwd, "src", "app.js"),
 					messages: [
-						createMessage("no-unused-vars"),
-						createMessage("no-unused-vars"),
-						createMessage("no-console"),
+						createMessage("no-unused-vars", "error"),
+						createMessage("no-unused-vars", "error"),
+						createMessage("no-console", "error"),
 					],
 				}),
 			];
@@ -239,8 +236,8 @@ describe("SuppressionsService", () => {
 				createResult({
 					filePath: path.join(cwd, "src", "app.js"),
 					messages: [
-						createMessage("no-unused-vars"),
-						createMessage("no-console"),
+						createMessage("no-unused-vars", "error"),
+						createMessage("no-console", "error"),
 					],
 				}),
 			];
@@ -280,8 +277,8 @@ describe("SuppressionsService", () => {
 				createResult({
 					filePath: path.join(cwd, "src", "app.js"),
 					messages: [
-						createMessage("no-unused-vars"),
-						createMessage("no-console"),
+						createMessage("no-unused-vars", "error"),
+						createMessage("no-console", "error"),
 					],
 				}),
 			];
@@ -319,8 +316,8 @@ describe("SuppressionsService", () => {
 				createResult({
 					filePath: path.join(cwd, "src", "app.js"),
 					messages: [
-						createMessage("no-console", 1), // warning — should be ignored
-						createMessage("no-unused-vars", 2), // error
+						createMessage("no-console", "warn"),
+						createMessage("no-unused-vars", "error"),
 					],
 				}),
 			];
@@ -337,6 +334,131 @@ describe("SuppressionsService", () => {
 				written[relPath]?.["no-console"],
 				void 0,
 				"Expected warnings to be excluded from suppressions",
+			);
+		});
+
+		it("should ignore messages with a null ruleId", async () => {
+			const cwd = path.resolve("/project");
+			const suppressionsService = new SuppressionsService({
+				filePath: path.join(cwd, "eslint-suppressions.json"),
+				cwd,
+			});
+
+			sinon.stub(fs.promises, "readFile").callsFake(() => {
+				const err = new Error("ENOENT");
+
+				err.code = "ENOENT";
+				return Promise.reject(err);
+			});
+			const writeStub = sinon.stub(fs.promises, "writeFile").resolves();
+
+			const results = [
+				createResult({
+					filePath: path.join(cwd, "src", "app.js"),
+					messages: [
+						createMessage(null, "error"), // parser error — no ruleId
+						createMessage("no-unused-vars", "error"),
+					],
+				}),
+			];
+
+			await suppressionsService.suppress(results, void 0);
+
+			const written = JSON.parse(writeStub.firstCall.args[1]);
+			const relPath = path.posix.join("src", "app.js");
+
+			// only the rule with a non-null ruleId should be recorded
+			assert.deepStrictEqual(Object.keys(written[relPath]), [
+				"no-unused-vars",
+			]);
+			assert.deepStrictEqual(written[relPath]["no-unused-vars"], {
+				count: 1,
+			});
+		});
+
+		it("should use cwd to compute relative file paths", async () => {
+			const cwd = path.resolve("/workspace/team");
+			const suppressionsService = new SuppressionsService({
+				filePath: path.join(cwd, "eslint-suppressions.json"),
+				cwd,
+			});
+
+			sinon.stub(fs.promises, "readFile").callsFake(() => {
+				const err = new Error("ENOENT");
+
+				err.code = "ENOENT";
+				return Promise.reject(err);
+			});
+			const writeStub = sinon.stub(fs.promises, "writeFile").resolves();
+
+			const results = [
+				createResult({
+					filePath: path.join(cwd, "src", "utils.js"),
+					messages: [createMessage("no-console", "error")],
+				}),
+			];
+
+			await suppressionsService.suppress(results, void 0);
+
+			const written = JSON.parse(writeStub.firstCall.args[1]);
+
+			// key must be relative to the given cwd, in POSIX format
+			const expectedRelPath = "src/utils.js";
+
+			assert.ok(
+				Object.hasOwn(written, expectedRelPath),
+				`Expected key "${expectedRelPath}" in written suppressions`,
+			);
+			assert.deepStrictEqual(written[expectedRelPath]["no-console"], {
+				count: 1,
+			});
+		});
+
+		it("should preserve existing suppressions for rules that no longer report (prune() removes them)", async () => {
+			const cwd = path.resolve("/project");
+			const suppressionsService = new SuppressionsService({
+				filePath: path.join(cwd, "eslint-suppressions.json"),
+				cwd,
+			});
+			const relPath = path.posix.join("src", "app.js");
+
+			// Pre-existing suppression for a rule that is no longer reported
+			const existing = {
+				[relPath]: {
+					"no-console": { count: 2 },
+					"no-unused-vars": { count: 1 },
+				},
+			};
+
+			sinon
+				.stub(fs.promises, "readFile")
+				.resolves(JSON.stringify(existing));
+			const writeStub = sinon.stub(fs.promises, "writeFile").resolves();
+
+			// Only "no-unused-vars" is still reported; "no-console" is gone
+			const results = [
+				createResult({
+					filePath: path.join(cwd, "src", "app.js"),
+					messages: [createMessage("no-unused-vars", "error")],
+				}),
+			];
+
+			await suppressionsService.suppress(results, void 0);
+
+			const written = JSON.parse(writeStub.firstCall.args[1]);
+
+			// "no-unused-vars" count should be updated to 1
+			assert.deepStrictEqual(written[relPath]["no-unused-vars"], {
+				count: 1,
+			});
+			/*
+			 * suppress() only updates rules that still appear in results;
+			 * stale entries are preserved as-is — prune() is responsible for removal.
+			 */
+			assert.deepStrictEqual(
+				written[relPath]["no-console"],
+				{ count: 2 },
+				"Expected suppress() to leave stale suppression intact; use prune() to remove it",
 			);
 		});
 	});

--- a/tests/lib/services/suppressions-service.js
+++ b/tests/lib/services/suppressions-service.js
@@ -203,8 +203,7 @@ describe("SuppressionsService", () => {
 				}),
 			];
 
-			const rules = void 0; // No rule filter
-			await suppressionService.suppress(results, rules);
+			await suppressionsService.suppress(results, void 0);
 
 			assert.ok(writeStub.calledOnce, "Expected save to be called");
 			const written = JSON.parse(writeStub.firstCall.args[1]);

--- a/tests/lib/services/suppressions-service.js
+++ b/tests/lib/services/suppressions-service.js
@@ -203,7 +203,9 @@ describe("SuppressionsService", () => {
 				}),
 			];
 
-			await suppressionsService.suppress(results, void 0);
+			const rules = void 0; // No rule filter
+
+			await suppressionsService.suppress(results, rules);
 
 			assert.ok(writeStub.calledOnce, "Expected save to be called");
 			const written = JSON.parse(writeStub.firstCall.args[1]);
@@ -283,7 +285,9 @@ describe("SuppressionsService", () => {
 				}),
 			];
 
-			await suppressionsService.suppress(results, void 0);
+			const rules = void 0; // No rule filter
+
+			await suppressionsService.suppress(results, rules);
 
 			const written = JSON.parse(writeStub.firstCall.args[1]);
 
@@ -322,7 +326,9 @@ describe("SuppressionsService", () => {
 				}),
 			];
 
-			await suppressionsService.suppress(results, void 0);
+			const rules = void 0; // No rule filter
+
+			await suppressionsService.suppress(results, rules);
 
 			const written = JSON.parse(writeStub.firstCall.args[1]);
 			const relPath = path.posix.join("src", "app.js");
@@ -362,7 +368,9 @@ describe("SuppressionsService", () => {
 				}),
 			];
 
-			await suppressionsService.suppress(results, void 0);
+			const rules = void 0; // No rule filter
+
+			await suppressionsService.suppress(results, rules);
 
 			const written = JSON.parse(writeStub.firstCall.args[1]);
 			const relPath = path.posix.join("src", "app.js");
@@ -398,7 +406,9 @@ describe("SuppressionsService", () => {
 				}),
 			];
 
-			await suppressionsService.suppress(results, void 0);
+			const rules = void 0; // No rule filter
+
+			await suppressionsService.suppress(results, rules);
 
 			const written = JSON.parse(writeStub.firstCall.args[1]);
 
@@ -422,7 +432,6 @@ describe("SuppressionsService", () => {
 			});
 			const relPath = path.posix.join("src", "app.js");
 
-			// Pre-existing suppression for a rule that is no longer reported
 			const existing = {
 				[relPath]: {
 					"no-console": { count: 2 },
@@ -435,7 +444,6 @@ describe("SuppressionsService", () => {
 				.resolves(JSON.stringify(existing));
 			const writeStub = sinon.stub(fs.promises, "writeFile").resolves();
 
-			// Only "no-unused-vars" is still reported; "no-console" is gone
 			const results = [
 				createResult({
 					filePath: path.join(cwd, "src", "app.js"),
@@ -443,18 +451,15 @@ describe("SuppressionsService", () => {
 				}),
 			];
 
-			await suppressionsService.suppress(results, void 0);
+			const rules = void 0; // No rule filter
+
+			await suppressionsService.suppress(results, rules);
 
 			const written = JSON.parse(writeStub.firstCall.args[1]);
 
-			// "no-unused-vars" count should be updated to 1
 			assert.deepStrictEqual(written[relPath]["no-unused-vars"], {
 				count: 1,
 			});
-			/*
-			 * suppress() only updates rules that still appear in results;
-			 * stale entries are preserved as-is — prune() is responsible for removal.
-			 */
 			assert.deepStrictEqual(
 				written[relPath]["no-console"],
 				{ count: 2 },

--- a/tests/lib/services/suppressions-service.js
+++ b/tests/lib/services/suppressions-service.js
@@ -15,6 +15,48 @@ const {
 const assert = require("node:assert");
 const fs = require("node:fs");
 const sinon = require("sinon");
+const path = require("node:path");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Creates a minimal LintResult object for testing.
+ * @param {Object} options The result options.
+ * @param {string} options.filePath The absolute file path.
+ * @param {Array} [options.messages] The lint messages.
+ * @param {Array} [options.suppressedMessages] Already-suppressed messages.
+ * @returns {Object} A LintResult-like object.
+ */
+function createResult({ filePath, messages = [], suppressedMessages = [] }) {
+	return {
+		filePath,
+		messages,
+		suppressedMessages,
+		errorCount: messages.filter(m => m.severity === 2).length,
+		fatalErrorCount: messages.filter(m => m.fatal).length,
+		warningCount: messages.filter(m => m.severity === 1).length,
+		fixableErrorCount: 0,
+		fixableWarningCount: 0,
+	};
+}
+
+/**
+ * Creates a lint message for testing.
+ * @param {string} ruleId The rule ID.
+ * @param {number} severity 1=warning, 2=error.
+ * @returns {Object} A LintMessage-like object.
+ */
+function createMessage(ruleId, severity = 2) {
+	return {
+		ruleId,
+		severity,
+		message: `${ruleId} violation`,
+		line: 1,
+		column: 1,
+	};
+}
 
 //------------------------------------------------------------------------------
 // Tests
@@ -132,6 +174,169 @@ describe("SuppressionsService", () => {
 					assert.ok(err.cause instanceof SyntaxError);
 					return true;
 				},
+			);
+		});
+	});
+
+	describe("suppress()", () => {
+		it("should suppress all violations when no rules filter is provided", async () => {
+			const cwd = path.resolve("/project");
+			const suppressionsService = new SuppressionsService({
+				filePath: path.join(cwd, "eslint-suppressions.json"),
+				cwd,
+			});
+
+			// load() returns empty (no prior suppressions)
+			sinon.stub(fs.promises, "readFile").callsFake(() => {
+				const err = new Error("ENOENT");
+
+				err.code = "ENOENT";
+				return Promise.reject(err);
+			});
+			const writeStub = sinon.stub(fs.promises, "writeFile").resolves();
+
+			const results = [
+				createResult({
+					filePath: path.join(cwd, "src", "app.js"),
+					messages: [
+						createMessage("no-unused-vars"),
+						createMessage("no-unused-vars"),
+						createMessage("no-console"),
+					],
+				}),
+			];
+
+			await suppressionsService.suppress(results, void 0);
+
+			assert.ok(writeStub.calledOnce, "Expected save to be called");
+			const written = JSON.parse(writeStub.firstCall.args[1]);
+			const relPath = path.posix.join("src", "app.js");
+
+			assert.deepStrictEqual(written[relPath]["no-unused-vars"], {
+				count: 2,
+			});
+			assert.deepStrictEqual(written[relPath]["no-console"], {
+				count: 1,
+			});
+		});
+
+		it("should only suppress violations matching the provided rules filter", async () => {
+			const cwd = path.resolve("/project");
+			const suppressionsService = new SuppressionsService({
+				filePath: path.join(cwd, "eslint-suppressions.json"),
+				cwd,
+			});
+
+			sinon.stub(fs.promises, "readFile").callsFake(() => {
+				const err = new Error("ENOENT");
+
+				err.code = "ENOENT";
+				return Promise.reject(err);
+			});
+			const writeStub = sinon.stub(fs.promises, "writeFile").resolves();
+
+			const results = [
+				createResult({
+					filePath: path.join(cwd, "src", "app.js"),
+					messages: [
+						createMessage("no-unused-vars"),
+						createMessage("no-console"),
+					],
+				}),
+			];
+
+			await suppressionsService.suppress(results, ["no-console"]);
+
+			const written = JSON.parse(writeStub.firstCall.args[1]);
+			const relPath = path.posix.join("src", "app.js");
+
+			assert.deepStrictEqual(written[relPath]["no-console"], {
+				count: 1,
+			});
+			assert.strictEqual(
+				written[relPath]["no-unused-vars"],
+				void 0,
+				"Expected non-matching rule to be excluded",
+			);
+		});
+
+		it("should merge new suppressions with existing ones", async () => {
+			const cwd = path.resolve("/project");
+			const suppressionsService = new SuppressionsService({
+				filePath: path.join(cwd, "eslint-suppressions.json"),
+				cwd,
+			});
+			const relPath = path.posix.join("src", "app.js");
+			const existing = {
+				[relPath]: { "no-console": { count: 3 } },
+			};
+
+			sinon
+				.stub(fs.promises, "readFile")
+				.resolves(JSON.stringify(existing));
+			const writeStub = sinon.stub(fs.promises, "writeFile").resolves();
+
+			const results = [
+				createResult({
+					filePath: path.join(cwd, "src", "app.js"),
+					messages: [
+						createMessage("no-unused-vars"),
+						createMessage("no-console"),
+					],
+				}),
+			];
+
+			await suppressionsService.suppress(results, void 0);
+
+			const written = JSON.parse(writeStub.firstCall.args[1]);
+
+			// no-console should be overwritten with the new count
+			assert.deepStrictEqual(written[relPath]["no-console"], {
+				count: 1,
+			});
+			// no-unused-vars should be added
+			assert.deepStrictEqual(written[relPath]["no-unused-vars"], {
+				count: 1,
+			});
+		});
+
+		it("should ignore warnings (severity 1) and only count errors", async () => {
+			const cwd = path.resolve("/project");
+			const suppressionsService = new SuppressionsService({
+				filePath: path.join(cwd, "eslint-suppressions.json"),
+				cwd,
+			});
+
+			sinon.stub(fs.promises, "readFile").callsFake(() => {
+				const err = new Error("ENOENT");
+
+				err.code = "ENOENT";
+				return Promise.reject(err);
+			});
+			const writeStub = sinon.stub(fs.promises, "writeFile").resolves();
+
+			const results = [
+				createResult({
+					filePath: path.join(cwd, "src", "app.js"),
+					messages: [
+						createMessage("no-console", 1), // warning — should be ignored
+						createMessage("no-unused-vars", 2), // error
+					],
+				}),
+			];
+
+			await suppressionsService.suppress(results, void 0);
+
+			const written = JSON.parse(writeStub.firstCall.args[1]);
+			const relPath = path.posix.join("src", "app.js");
+
+			assert.deepStrictEqual(written[relPath]["no-unused-vars"], {
+				count: 1,
+			});
+			assert.strictEqual(
+				written[relPath]?.["no-console"],
+				void 0,
+				"Expected warnings to be excluded from suppressions",
 			);
 		});
 	});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:
Add unit tests for `SuppressionsService.suppress()` method.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This is a follow-up to #20734 which added tests for `SuppressionsService.load()`. This PR adds focused unit tests for the `suppress()` method in `lib/services/suppressions-service.js`.

**Test cases added (4):**

| Test Case | Code Path | What It Verifies |
|---|---|---|
| No rules filter provided | All violations suppressed (L60–74) | Counts all error-severity violations by rule and saves them |
| Rules filter provided | Filtered suppression (L67–69) | Only suppresses violations matching the provided rules array |
| Merge with existing suppressions | Existing data preserved (L71–73) | New violations overwrite counts; unrelated rules remain |
| Warnings ignored | Severity check (L66) via `countViolationsByRule` | Only `severity: 2` (errors) are counted; warnings are excluded |

**Implementation details:**
- Adds helper functions `createResult()` and `createMessage()` for constructing test fixtures
- Uses `sinon.stub` on `fs.promises.readFile` and `fs.promises.writeFile` to isolate the method
- Uses `path.resolve()` and `path.posix.join()` for cross-platform relative path assertions
- Follows the existing test patterns established in `tests/lib/services/warning-service.js`

**Files modified:**
- `tests/lib/services/suppressions-service.js` (updated)

#### Is there anything you'd like reviewers to focus on?

- Whether the helper functions (`createResult`, `createMessage`) are appropriately structured for reuse by future test cases covering the remaining methods (`prune()`, `applySuppressions()`, `save()`).
- The merge behavior test — it verifies that `suppress()` overwrites counts for existing rules rather than accumulating them, which matches the current implementation.

<!-- markdownlint-disable-file MD004 -->
