### PR TITLE
docs: reuse markdown-it instance for markdown filter

### DIFF
--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -21,6 +21,8 @@ const prismESLintHook = require("./tools/prism-eslint-hook");
 const preWrapperPlugin = require("./src/_plugins/pre-wrapper.js");
 const typescriptESLintParser = require("@typescript-eslint/parser");
 
+const markdownForFilter = markdownIt({ html: true });
+
 module.exports = function (eleventyConfig) {
 	/*
 	 * The docs stored in the eslint repo are loaded through eslint.org at
@@ -126,13 +128,9 @@ module.exports = function (eleventyConfig) {
 	 * parse markdown from includes, used for author bios
 	 * Source: https://github.com/11ty/eleventy/issues/658
 	 */
-	eleventyConfig.addFilter("markdown", value => {
-		const markdown = markdownIt({
-			html: true,
-		});
-
-		return markdown.render(value);
-	});
+	eleventyConfig.addFilter("markdown", value =>
+		markdownForFilter.render(value),
+	);
 
 	/*
 	 * Removes `.html` suffix from the given url.


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

That filter runs many times during site generation which created unnecessary allocation, CPU overhead and GC pressure during builds. Hoist and reuse a single markdown-it instance instead, which is more efficient.

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Hoist a single markdown-it instance and use it in the markdown Eleventy filter instead of instantiating a new markdown-it object on every filter call.


#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
