### PR TITLE
test: add unit tests for ForkContext

### DIFF
--- a/tests/lib/linter/code-path-analysis/fork-context.js
+++ b/tests/lib/linter/code-path-analysis/fork-context.js
@@ -1,189 +1,199 @@
 /**
  * @fileoverview Tests for ForkContext.
+ * @author kuldeep kumar
  */
 
 "use strict";
 
-//------------------------------------------------------------------------------
-// Requirements
-//------------------------------------------------------------------------------
-
 const assert = require("node:assert");
 const ForkContext = require("../../../../lib/linter/code-path-analysis/fork-context");
-const CodePathSegment = require("../../../../lib/linter/code-path-analysis/code-path-segment");
 const IdGenerator = require("../../../../lib/linter/code-path-analysis/id-generator");
-
-//------------------------------------------------------------------------------
-// Tests
-//------------------------------------------------------------------------------
+const CodePathSegment = require("../../../../lib/linter/code-path-analysis/code-path-segment");
 
 describe("ForkContext", () => {
-	describe("constructor", () => {
-		it("should initialize with the given parameters", () => {
-			const idGenerator = new IdGenerator("s");
-			const upper = {};
-			const context = new ForkContext(idGenerator, upper, 2);
+	let idGenerator;
 
-			assert.strictEqual(context.idGenerator, idGenerator);
-			assert.strictEqual(context.upper, upper);
-			assert.strictEqual(context.count, 2);
-			assert.deepStrictEqual(context.segmentsList, []);
-		});
+	beforeEach(() => {
+		idGenerator = new IdGenerator("s");
 	});
 
 	describe("newRoot()", () => {
-		it("should create a root context", () => {
-			const idGenerator = new IdGenerator("s");
+		it("should create a new root context with one initial segment", () => {
 			const context = ForkContext.newRoot(idGenerator);
 
-			assert.strictEqual(context.idGenerator, idGenerator);
 			assert.strictEqual(context.upper, null);
 			assert.strictEqual(context.count, 1);
 			assert.strictEqual(context.segmentsList.length, 1);
-			assert.strictEqual(context.head.length, 1);
-			assert.strictEqual(context.head[0].id, "s1");
-			assert.strictEqual(context.head[0].reachable, true);
+			assert.strictEqual(context.segmentsList[0].length, 1);
+			assert.strictEqual(context.segmentsList[0][0].id, "s1");
+			assert.strictEqual(context.segmentsList[0][0].reachable, true);
 		});
 	});
 
 	describe("newEmpty()", () => {
-		it("should create an empty context from parent", () => {
-			const idGenerator = new IdGenerator("s");
-			const parent = ForkContext.newRoot(idGenerator);
-			const context = ForkContext.newEmpty(parent, false);
+		it("should create a new empty context with the given parent context", () => {
+			const parentContext = ForkContext.newRoot(idGenerator);
+			const context = ForkContext.newEmpty(parentContext, false);
 
-			assert.strictEqual(context.idGenerator, idGenerator);
-			assert.strictEqual(context.upper, parent);
+			assert.strictEqual(context.upper, parentContext);
 			assert.strictEqual(context.count, 1);
-			assert.deepStrictEqual(context.segmentsList, []);
+			assert.strictEqual(context.segmentsList.length, 0);
 			assert.strictEqual(context.empty, true);
 		});
 
-		it("should create an empty context with doubled count if shouldForkLeavingPath is true", () => {
-			const idGenerator = new IdGenerator("s");
-			const parent = ForkContext.newRoot(idGenerator);
-			const context = ForkContext.newEmpty(parent, true);
+		it("should create a new empty context with double count when shouldForkLeavingPath is true", () => {
+			const parentContext = ForkContext.newRoot(idGenerator);
+			const context = ForkContext.newEmpty(parentContext, true);
 
-			assert.strictEqual(context.idGenerator, idGenerator);
-			assert.strictEqual(context.upper, parent);
+			assert.strictEqual(context.upper, parentContext);
 			assert.strictEqual(context.count, 2);
-			assert.deepStrictEqual(context.segmentsList, []);
+			assert.strictEqual(context.segmentsList.length, 0);
 			assert.strictEqual(context.empty, true);
 		});
 	});
 
 	describe("properties", () => {
-		it("should return empty state correctly", () => {
-			const idGenerator = new IdGenerator("s");
-			const context = new ForkContext(idGenerator, null, 1);
+		it("head should return the last segments", () => {
+			const context = ForkContext.newRoot(idGenerator);
+			assert.strictEqual(context.head, context.segmentsList[0]);
+		});
 
-			assert.strictEqual(context.empty, true);
+		it("head should return an empty array if empty", () => {
+			const parentContext = ForkContext.newRoot(idGenerator);
+			const context = ForkContext.newEmpty(parentContext, false);
 			assert.deepStrictEqual(context.head, []);
-			assert.strictEqual(context.reachable, false);
+		});
 
-			const segment = CodePathSegment.newRoot(idGenerator.next());
-			context.add([segment]);
-
-			assert.strictEqual(context.empty, false);
-			assert.deepStrictEqual(context.head, [segment]);
+		it("reachable should return true if any head segment is reachable", () => {
+			const context = ForkContext.newRoot(idGenerator);
 			assert.strictEqual(context.reachable, true);
 		});
-	});
 
-	describe("segment creation methods", () => {
-		let idGenerator;
-		let context;
-
-		beforeEach(() => {
-			idGenerator = new IdGenerator("s");
-			context = ForkContext.newRoot(idGenerator);
-			CodePathSegment.markUsed(context.head[0]);
+		it("reachable should return false if no head segment is reachable", () => {
+			const context = ForkContext.newRoot(idGenerator);
+			const unreachableSegment = CodePathSegment.newUnreachable("s2", []);
+			context.replaceHead([unreachableSegment]);
+			assert.strictEqual(context.reachable, false);
 		});
 
-		describe("makeNext()", () => {
-			it("should create next segments", () => {
-				const nextSegments = context.makeNext(-1, -1);
-				assert.strictEqual(nextSegments.length, 1);
-				assert.strictEqual(nextSegments[0].id, "s2");
-				assert.strictEqual(nextSegments[0].reachable, true);
-				assert.strictEqual(nextSegments[0].allPrevSegments.length, 1);
-				assert.strictEqual(nextSegments[0].allPrevSegments[0].id, "s1");
-			});
-		});
-
-		describe("makeUnreachable()", () => {
-			it("should create unreachable segments", () => {
-				const unreachableSegments = context.makeUnreachable(-1, -1);
-				assert.strictEqual(unreachableSegments.length, 1);
-				assert.strictEqual(unreachableSegments[0].id, "s2");
-				assert.strictEqual(unreachableSegments[0].reachable, false);
-				assert.strictEqual(
-					unreachableSegments[0].allPrevSegments.length,
-					1,
-				);
-				assert.strictEqual(
-					unreachableSegments[0].allPrevSegments[0].id,
-					"s1",
-				);
-			});
-		});
-
-		describe("makeDisconnected()", () => {
-			it("should create disconnected segments", () => {
-				const disconnectedSegments = context.makeDisconnected(-1, -1);
-				assert.strictEqual(disconnectedSegments.length, 1);
-				assert.strictEqual(disconnectedSegments[0].id, "s2");
-				assert.strictEqual(disconnectedSegments[0].reachable, true);
-				assert.strictEqual(
-					disconnectedSegments[0].allPrevSegments.length,
-					0,
-				);
-			});
+		it("reachable should return false if empty", () => {
+			const parentContext = ForkContext.newRoot(idGenerator);
+			const context = ForkContext.newEmpty(parentContext, false);
+			assert.strictEqual(context.reachable, false);
 		});
 	});
 
-	describe("modification methods", () => {
-		let idGenerator;
-		let context;
+	describe("makeNext()", () => {
+		it("should create next segments using elements from startIndex to endIndex", () => {
+			const context = ForkContext.newRoot(idGenerator);
+			const seg1 = CodePathSegment.newNext(idGenerator.next(), [
+				context.head[0],
+			]);
+			context.add([seg1]);
+			const seg2 = CodePathSegment.newNext(idGenerator.next(), [
+				context.head[0],
+			]);
+			context.add([seg2]);
 
-		beforeEach(() => {
-			idGenerator = new IdGenerator("s");
-			context = ForkContext.newRoot(idGenerator);
+			/*
+			 * segmentsList has 3 elements: [root], [seg1], [seg2]
+			 * We need to mark segments used so that flattenUnusedSegments returns them
+			 */
+			CodePathSegment.markUsed(seg1);
+			CodePathSegment.markUsed(seg2);
+
+			const nextSegments = context.makeNext(-2, -1);
+			assert.strictEqual(nextSegments.length, 1);
+			assert.strictEqual(nextSegments[0].allPrevSegments.length, 2);
+			assert.strictEqual(nextSegments[0].reachable, true);
+		});
+	});
+
+	describe("makeUnreachable()", () => {
+		it("should create unreachable next segments", () => {
+			const context = ForkContext.newRoot(idGenerator);
+			const nextSegments = context.makeUnreachable(-1, -1);
+			assert.strictEqual(nextSegments.length, 1);
+			// newUnreachable flattens unused segments
+			assert.strictEqual(nextSegments[0].reachable, false);
+		});
+	});
+
+	describe("makeDisconnected()", () => {
+		it("should create disconnected segments", () => {
+			const context = ForkContext.newRoot(idGenerator);
+			const nextSegments = context.makeDisconnected(-1, -1);
+			assert.strictEqual(nextSegments.length, 1);
+			assert.strictEqual(nextSegments[0].allPrevSegments.length, 0); // Disconnected doesn't connect
+			assert.strictEqual(nextSegments[0].reachable, true); // Inherits reachable from prev segments
+		});
+	});
+
+	describe("add()", () => {
+		it("should add segments to segmentsList", () => {
+			const context = ForkContext.newRoot(idGenerator);
+			const newSegment = CodePathSegment.newNext("s2", [context.head[0]]);
+			context.add([newSegment]);
+			assert.strictEqual(context.segmentsList.length, 2);
+			assert.strictEqual(context.head[0], newSegment);
 		});
 
-		describe("add()", () => {
-			it("should add segments to the context list", () => {
-				const segment = CodePathSegment.newRoot("s2");
-				context.add([segment]);
-				assert.strictEqual(context.segmentsList.length, 2);
-				assert.deepStrictEqual(context.head, [segment]);
-			});
-		});
+		it("should merge extra segments when segments length is greater than count", () => {
+			const context = ForkContext.newRoot(idGenerator); // count is 1
+			const seg1 = CodePathSegment.newNext(idGenerator.next(), [
+				context.head[0],
+			]);
+			const seg2 = CodePathSegment.newNext(idGenerator.next(), [
+				context.head[0],
+			]);
 
-		describe("replaceHead()", () => {
-			it("should replace the head segment", () => {
-				const replaceSegment = CodePathSegment.newRoot("s2");
-				context.replaceHead([replaceSegment]);
-				assert.strictEqual(context.segmentsList.length, 1);
-				assert.deepStrictEqual(context.head, [replaceSegment]);
-			});
-		});
+			// Mark segments used so they aren't flattened during merge
+			CodePathSegment.markUsed(seg1);
+			CodePathSegment.markUsed(seg2);
 
-		describe("addAll()", () => {
-			it("should add all segments from another context", () => {
-				const otherContext = ForkContext.newRoot(new IdGenerator("t"));
-				context.addAll(otherContext);
-				assert.strictEqual(context.segmentsList.length, 2);
-				assert.deepStrictEqual(context.head, otherContext.head);
-			});
-		});
+			context.add([seg1, seg2]);
 
-		describe("clear()", () => {
-			it("should clear the context list", () => {
-				context.clear();
-				assert.strictEqual(context.segmentsList.length, 0);
-				assert.deepStrictEqual(context.head, []);
-			});
+			assert.strictEqual(context.segmentsList.length, 2);
+			assert.strictEqual(context.head.length, 1);
+			assert.strictEqual(context.head[0].allPrevSegments.length, 2);
+			assert.ok(context.head[0].allPrevSegments.includes(seg1));
+			assert.ok(context.head[0].allPrevSegments.includes(seg2));
+		});
+	});
+
+	describe("replaceHead()", () => {
+		it("should replace head segments", () => {
+			const context = ForkContext.newRoot(idGenerator);
+			const newSegment = CodePathSegment.newNext("s2", [context.head[0]]);
+			context.replaceHead([newSegment]);
+
+			assert.strictEqual(context.segmentsList.length, 1);
+			assert.strictEqual(context.head[0], newSegment);
+		});
+	});
+
+	describe("addAll()", () => {
+		it("should add all segments from another context", () => {
+			const context1 = ForkContext.newRoot(idGenerator);
+			const context2 = ForkContext.newRoot(idGenerator);
+
+			const newSegment = CodePathSegment.newNext("s3", [
+				context2.head[0],
+			]);
+			context2.add([newSegment]);
+
+			context1.addAll(context2);
+
+			assert.strictEqual(context1.segmentsList.length, 3);
+			assert.strictEqual(context1.head[0], newSegment);
+		});
+	});
+
+	describe("clear()", () => {
+		it("should clear segmentsList", () => {
+			const context = ForkContext.newRoot(idGenerator);
+			context.clear();
+			assert.strictEqual(context.segmentsList.length, 0);
 		});
 	});
 });

--- a/tests/lib/linter/code-path-analysis/fork-context.js
+++ b/tests/lib/linter/code-path-analysis/fork-context.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Tests for ForkContext.
- * @author kuldeep kumar
+ * @author kuldeep2822k
  */
 
 "use strict";
@@ -49,26 +49,6 @@ function createSegment(id, allPrevSegments, reachable) {
 			loopedPrevSegments: [],
 		},
 	};
-}
-
-/**
- * Marks a stub segment as used, mirroring the minimal behaviour needed
- * for ForkContext's internal flattenUnusedSegments to work correctly.
- * @param {Object} segment The segment to mark as used.
- * @returns {void}
- */
-function markUsed(segment) {
-	if (segment.internal.used) {
-		return;
-	}
-	segment.internal.used = true;
-
-	for (const prevSegment of segment.allPrevSegments) {
-		prevSegment.allNextSegments.push(segment);
-		if (segment.reachable) {
-			prevSegment.nextSegments.push(segment);
-		}
-	}
 }
 
 //------------------------------------------------------------------------------
@@ -231,8 +211,8 @@ describe("ForkContext", () => {
 			 * segmentsList has 3 elements: [root], [seg1], [seg2]
 			 * We need to mark segments used so that flattenUnusedSegments returns them
 			 */
-			markUsed(seg1);
-			markUsed(seg2);
+			seg1.internal.used = true;
+			seg2.internal.used = true;
 
 			const nextSegments = context.makeNext(1, 2);
 
@@ -259,8 +239,8 @@ describe("ForkContext", () => {
 
 			context.add([seg2]);
 
-			markUsed(seg1);
-			markUsed(seg2);
+			seg1.internal.used = true;
+			seg2.internal.used = true;
 
 			const nextSegments = context.makeNext(-2, -1);
 
@@ -297,8 +277,8 @@ describe("ForkContext", () => {
 
 			context.add([seg2]);
 
-			markUsed(seg1);
-			markUsed(seg2);
+			seg1.internal.used = true;
+			seg2.internal.used = true;
 
 			const nextSegments = context.makeUnreachable(-2, -1);
 
@@ -337,8 +317,8 @@ describe("ForkContext", () => {
 
 			context.add([seg2]);
 
-			markUsed(seg1);
-			markUsed(seg2);
+			seg1.internal.used = true;
+			seg2.internal.used = true;
 
 			const nextSegments = context.makeDisconnected(-2, -1);
 
@@ -380,8 +360,8 @@ describe("ForkContext", () => {
 			);
 
 			// Mark segments used so they aren't flattened during merge
-			markUsed(seg1);
-			markUsed(seg2);
+			seg1.internal.used = true;
+			seg2.internal.used = true;
 
 			context.add([seg1, seg2]);
 
@@ -412,7 +392,7 @@ describe("ForkContext", () => {
 			assert.strictEqual(context.head[0], newSegment);
 		});
 
-		it("should only modify the last element of segmentsList", () => {
+		it("should only modify the head", () => {
 			const context = ForkContext.newRoot(idGenerator);
 			const seg1 = context.head[0];
 			const seg2 = createSegment("s2", [seg1], true);
@@ -443,10 +423,10 @@ describe("ForkContext", () => {
 			const seg6 = createSegment("s6", [rootSeg], true);
 
 			// Mark used so they don't get flattened
-			markUsed(seg3);
-			markUsed(seg4);
-			markUsed(seg5);
-			markUsed(seg6);
+			seg3.internal.used = true;
+			seg4.internal.used = true;
+			seg5.internal.used = true;
+			seg6.internal.used = true;
 
 			context.replaceHead([seg3, seg4, seg5, seg6]);
 

--- a/tests/lib/linter/code-path-analysis/fork-context.js
+++ b/tests/lib/linter/code-path-analysis/fork-context.js
@@ -1,0 +1,189 @@
+/**
+ * @fileoverview Tests for ForkContext.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const assert = require("node:assert");
+const ForkContext = require("../../../../lib/linter/code-path-analysis/fork-context");
+const CodePathSegment = require("../../../../lib/linter/code-path-analysis/code-path-segment");
+const IdGenerator = require("../../../../lib/linter/code-path-analysis/id-generator");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("ForkContext", () => {
+	describe("constructor", () => {
+		it("should initialize with the given parameters", () => {
+			const idGenerator = new IdGenerator("s");
+			const upper = {};
+			const context = new ForkContext(idGenerator, upper, 2);
+
+			assert.strictEqual(context.idGenerator, idGenerator);
+			assert.strictEqual(context.upper, upper);
+			assert.strictEqual(context.count, 2);
+			assert.deepStrictEqual(context.segmentsList, []);
+		});
+	});
+
+	describe("newRoot()", () => {
+		it("should create a root context", () => {
+			const idGenerator = new IdGenerator("s");
+			const context = ForkContext.newRoot(idGenerator);
+
+			assert.strictEqual(context.idGenerator, idGenerator);
+			assert.strictEqual(context.upper, null);
+			assert.strictEqual(context.count, 1);
+			assert.strictEqual(context.segmentsList.length, 1);
+			assert.strictEqual(context.head.length, 1);
+			assert.strictEqual(context.head[0].id, "s1");
+			assert.strictEqual(context.head[0].reachable, true);
+		});
+	});
+
+	describe("newEmpty()", () => {
+		it("should create an empty context from parent", () => {
+			const idGenerator = new IdGenerator("s");
+			const parent = ForkContext.newRoot(idGenerator);
+			const context = ForkContext.newEmpty(parent, false);
+
+			assert.strictEqual(context.idGenerator, idGenerator);
+			assert.strictEqual(context.upper, parent);
+			assert.strictEqual(context.count, 1);
+			assert.deepStrictEqual(context.segmentsList, []);
+			assert.strictEqual(context.empty, true);
+		});
+
+		it("should create an empty context with doubled count if shouldForkLeavingPath is true", () => {
+			const idGenerator = new IdGenerator("s");
+			const parent = ForkContext.newRoot(idGenerator);
+			const context = ForkContext.newEmpty(parent, true);
+
+			assert.strictEqual(context.idGenerator, idGenerator);
+			assert.strictEqual(context.upper, parent);
+			assert.strictEqual(context.count, 2);
+			assert.deepStrictEqual(context.segmentsList, []);
+			assert.strictEqual(context.empty, true);
+		});
+	});
+
+	describe("properties", () => {
+		it("should return empty state correctly", () => {
+			const idGenerator = new IdGenerator("s");
+			const context = new ForkContext(idGenerator, null, 1);
+
+			assert.strictEqual(context.empty, true);
+			assert.deepStrictEqual(context.head, []);
+			assert.strictEqual(context.reachable, false);
+
+			const segment = CodePathSegment.newRoot(idGenerator.next());
+			context.add([segment]);
+
+			assert.strictEqual(context.empty, false);
+			assert.deepStrictEqual(context.head, [segment]);
+			assert.strictEqual(context.reachable, true);
+		});
+	});
+
+	describe("segment creation methods", () => {
+		let idGenerator;
+		let context;
+
+		beforeEach(() => {
+			idGenerator = new IdGenerator("s");
+			context = ForkContext.newRoot(idGenerator);
+			CodePathSegment.markUsed(context.head[0]);
+		});
+
+		describe("makeNext()", () => {
+			it("should create next segments", () => {
+				const nextSegments = context.makeNext(-1, -1);
+				assert.strictEqual(nextSegments.length, 1);
+				assert.strictEqual(nextSegments[0].id, "s2");
+				assert.strictEqual(nextSegments[0].reachable, true);
+				assert.strictEqual(nextSegments[0].allPrevSegments.length, 1);
+				assert.strictEqual(nextSegments[0].allPrevSegments[0].id, "s1");
+			});
+		});
+
+		describe("makeUnreachable()", () => {
+			it("should create unreachable segments", () => {
+				const unreachableSegments = context.makeUnreachable(-1, -1);
+				assert.strictEqual(unreachableSegments.length, 1);
+				assert.strictEqual(unreachableSegments[0].id, "s2");
+				assert.strictEqual(unreachableSegments[0].reachable, false);
+				assert.strictEqual(
+					unreachableSegments[0].allPrevSegments.length,
+					1,
+				);
+				assert.strictEqual(
+					unreachableSegments[0].allPrevSegments[0].id,
+					"s1",
+				);
+			});
+		});
+
+		describe("makeDisconnected()", () => {
+			it("should create disconnected segments", () => {
+				const disconnectedSegments = context.makeDisconnected(-1, -1);
+				assert.strictEqual(disconnectedSegments.length, 1);
+				assert.strictEqual(disconnectedSegments[0].id, "s2");
+				assert.strictEqual(disconnectedSegments[0].reachable, true);
+				assert.strictEqual(
+					disconnectedSegments[0].allPrevSegments.length,
+					0,
+				);
+			});
+		});
+	});
+
+	describe("modification methods", () => {
+		let idGenerator;
+		let context;
+
+		beforeEach(() => {
+			idGenerator = new IdGenerator("s");
+			context = ForkContext.newRoot(idGenerator);
+		});
+
+		describe("add()", () => {
+			it("should add segments to the context list", () => {
+				const segment = CodePathSegment.newRoot("s2");
+				context.add([segment]);
+				assert.strictEqual(context.segmentsList.length, 2);
+				assert.deepStrictEqual(context.head, [segment]);
+			});
+		});
+
+		describe("replaceHead()", () => {
+			it("should replace the head segment", () => {
+				const replaceSegment = CodePathSegment.newRoot("s2");
+				context.replaceHead([replaceSegment]);
+				assert.strictEqual(context.segmentsList.length, 1);
+				assert.deepStrictEqual(context.head, [replaceSegment]);
+			});
+		});
+
+		describe("addAll()", () => {
+			it("should add all segments from another context", () => {
+				const otherContext = ForkContext.newRoot(new IdGenerator("t"));
+				context.addAll(otherContext);
+				assert.strictEqual(context.segmentsList.length, 2);
+				assert.deepStrictEqual(context.head, otherContext.head);
+			});
+		});
+
+		describe("clear()", () => {
+			it("should clear the context list", () => {
+				context.clear();
+				assert.strictEqual(context.segmentsList.length, 0);
+				assert.deepStrictEqual(context.head, []);
+			});
+		});
+	});
+});

--- a/tests/lib/linter/code-path-analysis/fork-context.js
+++ b/tests/lib/linter/code-path-analysis/fork-context.js
@@ -7,22 +7,126 @@
 
 const assert = require("node:assert");
 const ForkContext = require("../../../../lib/linter/code-path-analysis/fork-context");
-const IdGenerator = require("../../../../lib/linter/code-path-analysis/id-generator");
-const CodePathSegment = require("../../../../lib/linter/code-path-analysis/code-path-segment");
+
+//------------------------------------------------------------------------------
+// Stubs
+//------------------------------------------------------------------------------
+
+/**
+ * Creates a stub id generator for testing.
+ * Provides the same interface as IdGenerator without coupling to it.
+ * @returns {Object} A stub id generator with a `next()` method.
+ */
+function createIdGenerator() {
+	return {
+		n: 0,
+		next() {
+			this.n++;
+			return `s${this.n}`;
+		},
+	};
+}
+
+/**
+ * Creates a stub code path segment for testing.
+ * Provides the minimal shape expected by ForkContext without coupling
+ * to the real CodePathSegment class.
+ * @param {string} id The segment identifier.
+ * @param {Array<Object>} allPrevSegments An array of previous segments.
+ * @param {boolean} reachable Whether the segment is reachable.
+ * @returns {Object} A stub segment object.
+ */
+function createSegment(id, allPrevSegments, reachable) {
+	return {
+		id,
+		reachable,
+		allPrevSegments,
+		prevSegments: allPrevSegments.filter(s => s.reachable),
+		nextSegments: [],
+		allNextSegments: [],
+		internal: {
+			used: false,
+			loopedPrevSegments: [],
+		},
+	};
+}
+
+/**
+ * Marks a stub segment as used, mirroring the minimal behaviour needed
+ * for ForkContext's internal flattenUnusedSegments to work correctly.
+ * @param {Object} segment The segment to mark as used.
+ * @returns {void}
+ */
+function markUsed(segment) {
+	if (segment.internal.used) {
+		return;
+	}
+	segment.internal.used = true;
+
+	for (const prevSegment of segment.allPrevSegments) {
+		prevSegment.allNextSegments.push(segment);
+		if (segment.reachable) {
+			prevSegment.nextSegments.push(segment);
+		}
+	}
+}
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
 
 describe("ForkContext", () => {
 	let idGenerator;
 
 	beforeEach(() => {
-		idGenerator = new IdGenerator("s");
+		idGenerator = createIdGenerator();
+	});
+
+	describe("constructor", () => {
+		it("should set idGenerator", () => {
+			const context = new ForkContext(idGenerator, null, 1);
+
+			assert.strictEqual(context.idGenerator, idGenerator);
+		});
+
+		it("should set upper to null when no parent is given", () => {
+			const context = new ForkContext(idGenerator, null, 1);
+
+			assert.strictEqual(context.upper, null);
+		});
+
+		it("should set upper to the given parent context", () => {
+			const parentContext = new ForkContext(idGenerator, null, 1);
+			const context = new ForkContext(idGenerator, parentContext, 1);
+
+			assert.strictEqual(context.upper, parentContext);
+		});
+
+		it("should set count", () => {
+			const context = new ForkContext(idGenerator, null, 3);
+
+			assert.strictEqual(context.count, 3);
+		});
+
+		it("should initialize segmentsList as an empty array", () => {
+			const context = new ForkContext(idGenerator, null, 1);
+
+			assert.ok(Array.isArray(context.segmentsList));
+			assert.strictEqual(context.segmentsList.length, 0);
+		});
 	});
 
 	describe("newRoot()", () => {
-		it("should create a new root context with one initial segment", () => {
+		it("should create a new root context with null upper and count 1", () => {
 			const context = ForkContext.newRoot(idGenerator);
 
 			assert.strictEqual(context.upper, null);
 			assert.strictEqual(context.count, 1);
+		});
+
+		it("should add one initial segment to segmentsList", () => {
+			const context = ForkContext.newRoot(idGenerator);
+
 			assert.strictEqual(context.segmentsList.length, 1);
 			assert.strictEqual(context.segmentsList[0].length, 1);
 			assert.strictEqual(context.segmentsList[0][0].id, "s1");
@@ -52,33 +156,55 @@ describe("ForkContext", () => {
 		});
 	});
 
-	describe("properties", () => {
-		it("head should return the last segments", () => {
+	describe("head", () => {
+		it("should return the last segments", () => {
 			const context = ForkContext.newRoot(idGenerator);
+
 			assert.strictEqual(context.head, context.segmentsList[0]);
 		});
 
-		it("head should return an empty array if empty", () => {
+		it("should return an empty array if empty", () => {
 			const parentContext = ForkContext.newRoot(idGenerator);
 			const context = ForkContext.newEmpty(parentContext, false);
+
 			assert.deepStrictEqual(context.head, []);
 		});
+	});
 
-		it("reachable should return true if any head segment is reachable", () => {
+	describe("empty", () => {
+		it("should return true if segmentsList is empty", () => {
+			const parentContext = ForkContext.newRoot(idGenerator);
+			const context = ForkContext.newEmpty(parentContext, false);
+
+			assert.strictEqual(context.empty, true);
+		});
+
+		it("should return false if segmentsList is not empty", () => {
 			const context = ForkContext.newRoot(idGenerator);
+
+			assert.strictEqual(context.empty, false);
+		});
+	});
+
+	describe("reachable", () => {
+		it("should return true if any head segment is reachable", () => {
+			const context = ForkContext.newRoot(idGenerator);
+
 			assert.strictEqual(context.reachable, true);
 		});
 
-		it("reachable should return false if no head segment is reachable", () => {
+		it("should return false if no head segment is reachable", () => {
 			const context = ForkContext.newRoot(idGenerator);
-			const unreachableSegment = CodePathSegment.newUnreachable("s2", []);
+			const unreachableSegment = createSegment("s2", [], false);
+
 			context.replaceHead([unreachableSegment]);
 			assert.strictEqual(context.reachable, false);
 		});
 
-		it("reachable should return false if empty", () => {
+		it("should return false if empty", () => {
 			const parentContext = ForkContext.newRoot(idGenerator);
 			const context = ForkContext.newEmpty(parentContext, false);
+
 			assert.strictEqual(context.reachable, false);
 		});
 	});
@@ -86,53 +212,155 @@ describe("ForkContext", () => {
 	describe("makeNext()", () => {
 		it("should create next segments using elements from startIndex to endIndex", () => {
 			const context = ForkContext.newRoot(idGenerator);
-			const seg1 = CodePathSegment.newNext(idGenerator.next(), [
-				context.head[0],
-			]);
+			const seg1 = createSegment(
+				idGenerator.next(),
+				[context.head[0]],
+				true,
+			);
+
 			context.add([seg1]);
-			const seg2 = CodePathSegment.newNext(idGenerator.next(), [
-				context.head[0],
-			]);
+			const seg2 = createSegment(
+				idGenerator.next(),
+				[context.head[0]],
+				true,
+			);
+
 			context.add([seg2]);
 
 			/*
 			 * segmentsList has 3 elements: [root], [seg1], [seg2]
 			 * We need to mark segments used so that flattenUnusedSegments returns them
 			 */
-			CodePathSegment.markUsed(seg1);
-			CodePathSegment.markUsed(seg2);
+			markUsed(seg1);
+			markUsed(seg2);
 
-			const nextSegments = context.makeNext(-2, -1);
+			const nextSegments = context.makeNext(1, 2);
+
 			assert.strictEqual(nextSegments.length, 1);
 			assert.strictEqual(nextSegments[0].allPrevSegments.length, 2);
-			assert.strictEqual(nextSegments[0].reachable, true);
+			assert.strictEqual(nextSegments[0].allPrevSegments[0], seg1);
+			assert.strictEqual(nextSegments[0].allPrevSegments[1], seg2);
+		});
+
+		it("should normalize negative values for startIndex and endIndex", () => {
+			const context = ForkContext.newRoot(idGenerator);
+			const seg1 = createSegment(
+				idGenerator.next(),
+				[context.head[0]],
+				true,
+			);
+
+			context.add([seg1]);
+			const seg2 = createSegment(
+				idGenerator.next(),
+				[context.head[0]],
+				true,
+			);
+
+			context.add([seg2]);
+
+			markUsed(seg1);
+			markUsed(seg2);
+
+			const nextSegments = context.makeNext(-2, -1);
+
+			assert.strictEqual(nextSegments.length, 1);
+			assert.strictEqual(nextSegments[0].allPrevSegments.length, 2);
+			assert.strictEqual(nextSegments[0].allPrevSegments[0], seg1);
+			assert.strictEqual(nextSegments[0].allPrevSegments[1], seg2);
 		});
 	});
 
 	describe("makeUnreachable()", () => {
 		it("should create unreachable next segments", () => {
 			const context = ForkContext.newRoot(idGenerator);
-			const nextSegments = context.makeUnreachable(-1, -1);
+			const nextSegments = context.makeUnreachable(0, 0);
+
 			assert.strictEqual(nextSegments.length, 1);
-			// newUnreachable flattens unused segments
 			assert.strictEqual(nextSegments[0].reachable, false);
+		});
+
+		it("should normalize negative values for startIndex and endIndex", () => {
+			const context = ForkContext.newRoot(idGenerator);
+			const seg1 = createSegment(
+				idGenerator.next(),
+				[context.head[0]],
+				true,
+			);
+
+			context.add([seg1]);
+			const seg2 = createSegment(
+				idGenerator.next(),
+				[context.head[0]],
+				true,
+			);
+
+			context.add([seg2]);
+
+			markUsed(seg1);
+			markUsed(seg2);
+
+			const nextSegments = context.makeUnreachable(-2, -1);
+
+			assert.strictEqual(nextSegments.length, 1);
+			assert.strictEqual(nextSegments[0].reachable, false);
+			assert.strictEqual(nextSegments[0].allPrevSegments.length, 2);
+			assert.strictEqual(nextSegments[0].allPrevSegments[0], seg1);
+			assert.strictEqual(nextSegments[0].allPrevSegments[1], seg2);
 		});
 	});
 
 	describe("makeDisconnected()", () => {
 		it("should create disconnected segments", () => {
 			const context = ForkContext.newRoot(idGenerator);
-			const nextSegments = context.makeDisconnected(-1, -1);
+			const nextSegments = context.makeDisconnected(0, 0);
+
 			assert.strictEqual(nextSegments.length, 1);
-			assert.strictEqual(nextSegments[0].allPrevSegments.length, 0); // Disconnected doesn't connect
-			assert.strictEqual(nextSegments[0].reachable, true); // Inherits reachable from prev segments
+			assert.strictEqual(nextSegments[0].allPrevSegments.length, 0);
+			assert.strictEqual(nextSegments[0].reachable, true);
+		});
+
+		it("should normalize negative values for startIndex and endIndex", () => {
+			const context = ForkContext.newRoot(idGenerator);
+			const seg1 = createSegment(
+				idGenerator.next(),
+				[context.head[0]],
+				true,
+			);
+
+			context.add([seg1]);
+			const seg2 = createSegment(
+				idGenerator.next(),
+				[context.head[0]],
+				true,
+			);
+
+			context.add([seg2]);
+
+			markUsed(seg1);
+			markUsed(seg2);
+
+			const nextSegments = context.makeDisconnected(-2, -1);
+
+			assert.strictEqual(nextSegments.length, 1);
+			assert.strictEqual(nextSegments[0].allPrevSegments.length, 0);
+			assert.strictEqual(nextSegments[0].reachable, true);
 		});
 	});
 
 	describe("add()", () => {
+		it("should throw an error when segments length is less than count", () => {
+			const context = ForkContext.newRoot(idGenerator); // count is 1
+
+			assert.throws(() => {
+				context.add([]);
+			}, /0 >= 1/u);
+		});
+
 		it("should add segments to segmentsList", () => {
 			const context = ForkContext.newRoot(idGenerator);
-			const newSegment = CodePathSegment.newNext("s2", [context.head[0]]);
+			const newSegment = createSegment("s2", [context.head[0]], true);
+
 			context.add([newSegment]);
 			assert.strictEqual(context.segmentsList.length, 2);
 			assert.strictEqual(context.head[0], newSegment);
@@ -140,16 +368,20 @@ describe("ForkContext", () => {
 
 		it("should merge extra segments when segments length is greater than count", () => {
 			const context = ForkContext.newRoot(idGenerator); // count is 1
-			const seg1 = CodePathSegment.newNext(idGenerator.next(), [
-				context.head[0],
-			]);
-			const seg2 = CodePathSegment.newNext(idGenerator.next(), [
-				context.head[0],
-			]);
+			const seg1 = createSegment(
+				idGenerator.next(),
+				[context.head[0]],
+				true,
+			);
+			const seg2 = createSegment(
+				idGenerator.next(),
+				[context.head[0]],
+				true,
+			);
 
 			// Mark segments used so they aren't flattened during merge
-			CodePathSegment.markUsed(seg1);
-			CodePathSegment.markUsed(seg2);
+			markUsed(seg1);
+			markUsed(seg2);
 
 			context.add([seg1, seg2]);
 
@@ -162,24 +394,84 @@ describe("ForkContext", () => {
 	});
 
 	describe("replaceHead()", () => {
+		it("should throw an error when segments length is less than count", () => {
+			const context = ForkContext.newRoot(idGenerator); // count is 1
+
+			assert.throws(() => {
+				context.replaceHead([]);
+			}, /0 >= 1/u);
+		});
+
 		it("should replace head segments", () => {
 			const context = ForkContext.newRoot(idGenerator);
-			const newSegment = CodePathSegment.newNext("s2", [context.head[0]]);
+			const newSegment = createSegment("s2", [context.head[0]], true);
+
 			context.replaceHead([newSegment]);
 
 			assert.strictEqual(context.segmentsList.length, 1);
 			assert.strictEqual(context.head[0], newSegment);
 		});
+
+		it("should only modify the last element of segmentsList", () => {
+			const context = ForkContext.newRoot(idGenerator);
+			const seg1 = context.head[0];
+			const seg2 = createSegment("s2", [seg1], true);
+
+			context.add([seg2]);
+			const seg3 = createSegment("s3", [seg1], true);
+
+			context.replaceHead([seg3]);
+
+			assert.strictEqual(context.segmentsList.length, 2);
+			assert.strictEqual(context.segmentsList[0][0], seg1);
+			assert.strictEqual(context.segmentsList[1][0], seg3);
+		});
+
+		it("should merge extra segments when replacementHeadSegments length is greater than count", () => {
+			const parent = ForkContext.newRoot(idGenerator);
+			const context = ForkContext.newEmpty(parent, true); // count is 2
+			const rootSeg = parent.head[0];
+
+			const seg1 = createSegment("s1", [rootSeg], true);
+			const seg2 = createSegment("s2", [rootSeg], true);
+
+			context.add([seg1, seg2]);
+
+			const seg3 = createSegment("s3", [rootSeg], true);
+			const seg4 = createSegment("s4", [rootSeg], true);
+			const seg5 = createSegment("s5", [rootSeg], true);
+			const seg6 = createSegment("s6", [rootSeg], true);
+
+			// Mark used so they don't get flattened
+			markUsed(seg3);
+			markUsed(seg4);
+			markUsed(seg5);
+			markUsed(seg6);
+
+			context.replaceHead([seg3, seg4, seg5, seg6]);
+
+			assert.strictEqual(context.segmentsList.length, 1);
+			assert.strictEqual(context.head.length, 2);
+		});
 	});
 
 	describe("addAll()", () => {
+		it("should throw an error when context counts do not match", () => {
+			const context1 = ForkContext.newRoot(idGenerator); // count is 1
+			const parent2 = ForkContext.newRoot(idGenerator);
+			const context2 = ForkContext.newEmpty(parent2, true); // count is 2
+
+			assert.throws(() => {
+				context1.addAll(context2);
+			}, /Assertion failed./u);
+		});
+
 		it("should add all segments from another context", () => {
 			const context1 = ForkContext.newRoot(idGenerator);
 			const context2 = ForkContext.newRoot(idGenerator);
 
-			const newSegment = CodePathSegment.newNext("s3", [
-				context2.head[0],
-			]);
+			const newSegment = createSegment("s3", [context2.head[0]], true);
+
 			context2.add([newSegment]);
 
 			context1.addAll(context2);


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Added unit tests for `ForkContext` class (`lib/linter/code-path-analysis/fork-context.js`), which previously had no dedicated test coverage.

#### What changes did you make? (Give an overview)

Added `tests/lib/linter/code-path-analysis/fork-context.js` with 16 tests covering the full public API of `ForkContext`:

- **Static factories:** `newRoot()`, `newEmpty()` (both `shouldForkLeavingPath` true and false)
- **Getters:** `head`, `empty`, `reachable` (reachable, unreachable, and empty states)
- **Segment creation:** `makeNext()`, `makeUnreachable()`, `makeDisconnected()`
- **Mutation methods:** `add()` (basic + `mergeExtraSegments` path), `replaceHead()`, `addAll()`, `clear()`

#### Is there anything you'd like reviewers to focus on?

- The `makeNext()` test requires calling `CodePathSegment.markUsed()` on previous segments before invoking `makeNext()`, so that `flattenUnusedSegments` returns them correctly. Would appreciate a check that this setup accurately reflects real-world usage.
- The `add()` merge test passes more segments than `context.count` to exercise the `mergeExtraSegments` helper.

<!-- markdownlint-disable-file MD004 -->
