### PR TITLE
test: cover nested relative formatter paths

### DIFF
--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -10029,6 +10029,18 @@ describe("ESLint", () => {
 			assert.strictEqual(typeof formatter.format, "function");
 		});
 
+		it("should return a formatter object when a nested custom formatter is requested with a relative path", async () => {
+			const engine = new ESLint({
+				cwd: path.join(fixtureDir, ".."),
+			});
+			const formatter = await engine.loadFormatter(
+				"./fixtures/formatters/test/simple.js",
+			);
+
+			assert.strictEqual(typeof formatter, "object");
+			assert.strictEqual(typeof formatter.format, "function");
+		});
+
 		it("should return a formatter object when a formatter prefixed with eslint-formatter is requested", async () => {
 			const engine = new ESLint({
 				cwd: getFixturePath("cli-engine"),


### PR DESCRIPTION

**Repo:** eslint/eslint (⭐ 25000)
**Type:** test
**Files changed:** 1
**Lines:** +12/-0

## What
Adds a focused `ESLint#loadFormatter()` test that covers loading a custom formatter from a nested relative POSIX path such as `./fixtures/formatters/test/simple.js`. The new case sits alongside the existing bundled, absolute-path, and Windows-style path coverage in the main ESLint class test file.

## Why
`loadFormatter()` has explicit path-resolution logic for formatter names containing path separators, but the current test coverage only exercised absolute custom paths and a Windows-style relative path. Adding a nested relative POSIX-path case protects a common user-facing input shape and reduces the chance of regressions in formatter path handling without changing runtime behavior.

## Testing
Verified the edited test file parses with `node -c tests/lib/eslint/eslint.js`.
Did not run the Mocha test suite because this clone does not have installed dependencies (`node_modules` is absent).

## Risk
Low - this is a test-only change that adds coverage for an existing code path.
