### PR TITLE
fix: rule suggestions cause continuation in class body

### DIFF
--- a/lib/rules/no-unused-private-class-members.js
+++ b/lib/rules/no-unused-private-class-members.js
@@ -133,8 +133,7 @@ module.exports = {
 			const nextToken = sourceCode.getTokenAfter(classMemberNode);
 
 			if (
-				nextToken.type === "Punctuator" &&
-				(nextToken.value === "[" || nextToken.value === "*") &&
+				astUtils.canContinueExpressionInClassBody(nextToken) &&
 				astUtils.needsPrecedingSemicolon(sourceCode, classMemberNode)
 			) {
 				return sourceCode.getTokenBefore(classMemberNode);

--- a/lib/rules/no-useless-constructor.js
+++ b/lib/rules/no-useless-constructor.js
@@ -237,8 +237,9 @@ module.exports = {
 								const nextToken =
 									sourceCode.getTokenAfter(node);
 								const addSemiColon =
-									nextToken.type === "Punctuator" &&
-									nextToken.value === "[" &&
+									astUtils.canContinueExpressionInClassBody(
+										nextToken,
+									) &&
 									astUtils.needsPrecedingSemicolon(
 										sourceCode,
 										node,

--- a/lib/rules/require-await.js
+++ b/lib/rules/require-await.js
@@ -110,12 +110,14 @@ module.exports = {
 				 */
 				const nextToken = sourceCode.getTokenAfter(asyncToken);
 				const addSemiColon =
-					nextToken.type === "Punctuator" &&
-					(nextToken.value === "[" || nextToken.value === "(") &&
-					(nodeWithAsyncKeyword.type === "MethodDefinition" ||
+					((astUtils.isOpeningParenToken(nextToken) &&
 						astUtils.isStartOfExpressionStatement(
 							nodeWithAsyncKeyword,
-						)) &&
+						)) ||
+						(nodeWithAsyncKeyword.type === "MethodDefinition" &&
+							astUtils.canContinueExpressionInClassBody(
+								nextToken,
+							))) &&
 					astUtils.needsPrecedingSemicolon(
 						sourceCode,
 						nodeWithAsyncKeyword,

--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -1258,12 +1258,31 @@ function isStartOfExpressionStatement(node) {
 }
 
 /**
- * Determines whether an opening parenthesis `(`, bracket `[` or backtick ``` ` ``` needs to be preceded by a semicolon.
- * This opening parenthesis or bracket should be at the start of an `ExpressionStatement`, a `MethodDefinition` or at
- * the start of the body of an `ArrowFunctionExpression`.
+ * Checks whether a token can cause continuation of a preceding expression
+ * (for example, of a class field initializer expression) in a class body.
+ * This function checks specifically for tokens that can appear at the start
+ * of a class member: `[` (computed key), `*` (generator method), `in` or `instanceof` (valid keys)
+ * Without a preceding semicolon, these tokens would be parsed as index access or operators.
+ * @param {Token} token The token to check.
+ * @returns {boolean} Whether the token can cause continuation of a preceding expression.
+ */
+function canContinueExpressionInClassBody(token) {
+	return (
+		(token.type === "Punctuator" &&
+			(token.value === "[" || token.value === "*")) ||
+		// Different parsers may return these tokens as either "Identifier" or "Keyword"
+		((token.type === "Identifier" || token.type === "Keyword") &&
+			(token.value === "in" || token.value === "instanceof"))
+	);
+}
+
+/**
+ * Determines whether an opening parenthesis `(`, bracket `[`, asterisk `*`, or backtick ``` ` ``` needs to be preceded by a semicolon.
+ * This opening parenthesis or bracket should be at the start of an `ExpressionStatement`, a `MethodDefinition`, a `PropertyDefinition`,
+ * or at the start of the body of an `ArrowFunctionExpression`.
  * @type {(sourceCode: SourceCode, node: ASTNode) => boolean}
  * @param {SourceCode} sourceCode The source code object.
- * @param {ASTNode} node A node at the position where an opening parenthesis or bracket will be inserted.
+ * @param {ASTNode} node A node at the position where an opening parenthesis, bracket, or asterisk will be inserted.
  * @returns {boolean} Whether a semicolon is required before the opening parenthesis or bracket.
  */
 let needsPrecedingSemicolon;
@@ -1353,6 +1372,18 @@ let needsPrecedingSemicolon;
 		}
 
 		const prevNode = sourceCode.getNodeByRangeIndex(prevToken.range[0]);
+
+		// Uninitialized class fields don't need a semicolon
+		if (
+			// Key
+			(prevNode.parent.type === "PropertyDefinition" &&
+				prevNode.parent.key === prevNode) ||
+			// Closing bracket of a computed key
+			(prevNode.type === "PropertyDefinition" &&
+				isClosingBracketToken(prevToken))
+		) {
+			return false;
+		}
 
 		if (
 			prevNode.type === "TSDeclareFunction" ||
@@ -2842,6 +2873,7 @@ module.exports = {
 	isTopLevelExpressionStatement,
 	isDirective,
 	isStartOfExpressionStatement,
+	canContinueExpressionInClassBody,
 	needsPrecedingSemicolon,
 	isImportAttributeKey,
 	getOpeningParenOfParams,

--- a/tests/lib/rules/no-unused-private-class-members.js
+++ b/tests/lib/rules/no-unused-private-class-members.js
@@ -1108,6 +1108,68 @@ class Second {}`,
 			],
 		},
 		{
+			code: `class Foo {
+    foo = 1
+    #unusedMethod() {}
+    in = 2
+}`,
+			errors: [
+				{
+					messageId: "unusedPrivateClassMember",
+					data: {
+						classMemberName: "#unusedMethod",
+					},
+					line: 3,
+					column: 5,
+					endLine: 3,
+					endColumn: 18,
+					suggestions: [
+						{
+							messageId: "removeUnusedPrivateClassMember",
+							data: {
+								classMemberName: "#unusedMethod",
+							},
+							output: `class Foo {
+    foo = 1;
+    in = 2
+}`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `class Foo {
+    foo = 1
+    #unused
+    instanceof() {}
+}`,
+			errors: [
+				{
+					messageId: "unusedPrivateClassMember",
+					data: {
+						classMemberName: "#unused",
+					},
+					line: 3,
+					column: 5,
+					endLine: 3,
+					endColumn: 12,
+					suggestions: [
+						{
+							messageId: "removeUnusedPrivateClassMember",
+							data: {
+								classMemberName: "#unused",
+							},
+							output: `class Foo {
+    foo = 1;
+    instanceof() {}
+}`,
+						},
+					],
+				},
+			],
+		},
+		{
 			code: `class C {
     foo = () => {}
     #unused
@@ -1131,6 +1193,37 @@ class Second {}`,
 							},
 							output: `class C {
     foo = () => {}
+    [bar]
+}`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `class C {
+    foo
+    #unused
+    [bar]
+}`,
+			errors: [
+				{
+					messageId: "unusedPrivateClassMember",
+					data: {
+						classMemberName: "#unused",
+					},
+					line: 3,
+					column: 5,
+					endLine: 3,
+					endColumn: 12,
+					suggestions: [
+						{
+							messageId: "removeUnusedPrivateClassMember",
+							data: {
+								classMemberName: "#unused",
+							},
+							output: `class C {
+    foo
     [bar]
 }`,
 						},

--- a/tests/lib/rules/no-useless-constructor.js
+++ b/tests/lib/rules/no-useless-constructor.js
@@ -257,6 +257,267 @@ ruleTester.run("no-useless-constructor", rule, {
 				},
 			],
 		},
+		{
+			code: unIndent`
+              class A {
+                foo = 'bar'
+                constructor() { }
+                *baz() {}
+              }`,
+			languageOptions: { ecmaVersion: 2022 },
+			errors: [
+				{
+					...error,
+					line: 3,
+					column: 3,
+					endLine: 3,
+					endColumn: 14,
+					suggestions: [
+						{
+							messageId: "removeConstructor",
+							output: unIndent`
+                              class A {
+                                foo = 'bar'
+                                ;
+                                *baz() {}
+                              }`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: unIndent`
+              class A {
+                foo = 'bar'
+                constructor() { }
+                in
+              }`,
+			languageOptions: { ecmaVersion: 2022 },
+			errors: [
+				{
+					...error,
+					line: 3,
+					column: 3,
+					endLine: 3,
+					endColumn: 14,
+					suggestions: [
+						{
+							messageId: "removeConstructor",
+							output: unIndent`
+                              class A {
+                                foo = 'bar'
+                                ;
+                                in
+                              }`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: unIndent`
+              class A {
+                foo = 'bar'
+                constructor() { }
+                instanceof
+              }`,
+			languageOptions: { ecmaVersion: 2022 },
+			errors: [
+				{
+					...error,
+					line: 3,
+					column: 3,
+					endLine: 3,
+					endColumn: 14,
+					suggestions: [
+						{
+							messageId: "removeConstructor",
+							output: unIndent`
+                              class A {
+                                foo = 'bar'
+                                ;
+                                instanceof
+                              }`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: unIndent`
+              class A {
+                foo = 'bar'
+                constructor() { }
+                #instanceof
+              }`,
+			languageOptions: { ecmaVersion: 2022 },
+			errors: [
+				{
+					...error,
+					line: 3,
+					column: 3,
+					endLine: 3,
+					endColumn: 14,
+					suggestions: [
+						{
+							messageId: "removeConstructor",
+							output: unIndent`
+                              class A {
+                                foo = 'bar'
+                                
+                                #instanceof
+                              }`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: unIndent`
+              class A {
+                foo
+                constructor() { }
+                [0]() { }
+              }`,
+			languageOptions: { ecmaVersion: 2022 },
+			errors: [
+				{
+					...error,
+					line: 3,
+					column: 3,
+					endLine: 3,
+					endColumn: 14,
+					suggestions: [
+						{
+							messageId: "removeConstructor",
+							output: unIndent`
+                              class A {
+                                foo
+                                
+                                [0]() { }
+                              }`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: unIndent`
+              class A {
+                "foo"
+                constructor() { }
+                [0]() { }
+              }`,
+			languageOptions: { ecmaVersion: 2022 },
+			errors: [
+				{
+					...error,
+					line: 3,
+					column: 3,
+					endLine: 3,
+					endColumn: 14,
+					suggestions: [
+						{
+							messageId: "removeConstructor",
+							output: unIndent`
+                              class A {
+                                "foo"
+                                
+                                [0]() { }
+                              }`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: unIndent`
+              class A {
+                42
+                constructor() { }
+                [0]() { }
+              }`,
+			languageOptions: { ecmaVersion: 2022 },
+			errors: [
+				{
+					...error,
+					line: 3,
+					column: 3,
+					endLine: 3,
+					endColumn: 14,
+					suggestions: [
+						{
+							messageId: "removeConstructor",
+							output: unIndent`
+                              class A {
+                                42
+                                
+                                [0]() { }
+                              }`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: unIndent`
+              class A {
+                [foo]
+                constructor() { }
+                [0]() { }
+              }`,
+			languageOptions: { ecmaVersion: 2022 },
+			errors: [
+				{
+					...error,
+					line: 3,
+					column: 3,
+					endLine: 3,
+					endColumn: 14,
+					suggestions: [
+						{
+							messageId: "removeConstructor",
+							output: unIndent`
+                              class A {
+                                [foo]
+                                
+                                [0]() { }
+                              }`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: unIndent`
+              class A {
+                #foo
+                constructor() { }
+                [0]() { }
+              }`,
+			languageOptions: { ecmaVersion: 2022 },
+			errors: [
+				{
+					...error,
+					line: 3,
+					column: 3,
+					endLine: 3,
+					endColumn: 14,
+					suggestions: [
+						{
+							messageId: "removeConstructor",
+							output: unIndent`
+                              class A {
+                                #foo
+                                
+                                [0]() { }
+                              }`,
+						},
+					],
+				},
+			],
+		},
 	],
 });
 

--- a/tests/lib/rules/require-await.js
+++ b/tests/lib/rules/require-await.js
@@ -308,6 +308,50 @@ ruleTester.run("require-await", rule, {
 			],
 		},
 		{
+			code: `class A {
+                a
+                async [b](){ return 0; }
+            }`,
+			languageOptions: { ecmaVersion: 2022 },
+			errors: [
+				{
+					messageId: "missingAwait",
+					data: { name: "Async method" },
+					suggestions: [
+						{
+							output: `class A {
+                a
+                [b](){ return 0; }
+            }`,
+							messageId: "removeAsync",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `class A {
+                a = 0
+                async in(){ return 0; }
+            }`,
+			languageOptions: { ecmaVersion: 2022 },
+			errors: [
+				{
+					messageId: "missingAwait",
+					data: { name: "Async method 'in'" },
+					suggestions: [
+						{
+							output: `class A {
+                a = 0
+                ;in(){ return 0; }
+            }`,
+							messageId: "removeAsync",
+						},
+					],
+				},
+			],
+		},
+		{
 			code: `foo
                 async () => { return 0; }
             `,

--- a/tests/lib/rules/require-await.js
+++ b/tests/lib/rules/require-await.js
@@ -352,6 +352,27 @@ ruleTester.run("require-await", rule, {
 			],
 		},
 		{
+			code: `const obj = {
+                foo,
+                async in(){ return 0; }
+            }`,
+			errors: [
+				{
+					messageId: "missingAwait",
+					data: { name: "Async method 'in'" },
+					suggestions: [
+						{
+							output: `const obj = {
+                foo,
+                in(){ return 0; }
+            }`,
+							messageId: "removeAsync",
+						},
+					],
+				},
+			],
+		},
+		{
 			code: `foo
                 async () => { return 0; }
             `,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:** 22.14.0
- **npm version:** 10.9.2
- **Local ESLint version:** 10.2.1
- **Global ESLint version:** no
- **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->

```js
export default [{}];
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint no-useless-constructor: 2 */

class A {
    foo = 'bar'
    constructor() {}
    *baz() {}
}
```

**What did you expect to happen?**

The `no-useless-constructor` rule to report the constructor as useless and provide a valid suggestion to remove it.

**What actually happened? Please include the actual, raw output from ESLint.**

The `no-useless-constructor` rule reports the constructor as useless and provides suggestion to remove it. However, applying the suggestion causes a parsing error:

```js
/*eslint no-useless-constructor: 2 */

class A {
    foo = 'bar'
    
    *baz() {}
}


```

```
Parsing error: Unexpected token {
```

[Playground link](https://eslint.org/play/#eyJ0ZXh0IjoiLyplc2xpbnQgbm8tdXNlbGVzcy1jb25zdHJ1Y3RvcjogMiAqL1xuXG5jbGFzcyBBIHtcbiAgICBmb28gPSAnYmFyJ1xuICAgIGNvbnN0cnVjdG9yKCkge31cbiAgICAqYmF6KCkge31cbn1cblxuIiwib3B0aW9ucyI6eyJydWxlcyI6e30sImxhbmd1YWdlT3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFGZWF0dXJlcyI6e319fX19)

The suggestion should insert a semicolon to prevent continuation.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Updated the `no-useless-constructor` rule to use a new helper `astUtils.canContinueExpressionInClassBody(token)` that checks for the following tokens that can cause continuation: `[`, `*`, `in`, `instanceof`.
* Updated the `require-await` rule in the same way.
* Also updated `astUtils.needsPrecedingSemicolon` to avoid unnecessary semicolons in case of uninitialized class fields.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
