### PR TITLE
fix: update dependency file-entry-cache to v11

### DIFF
--- a/lib/cli-engine/lint-result-cache.js
+++ b/lib/cli-engine/lint-result-cache.js
@@ -86,13 +86,27 @@ class LintResultCache {
 
 		debug(`Caching results to ${cacheFileLocation}`);
 
+		const useCheckSum = cacheStrategy === "content";
+
 		debug(`Using "${cacheStrategy}" strategy to detect changes`);
 
+		/*
+		 * useModifiedTime: If `true` (default), use mtime and size to determine if the file has changed.
+		 *     It corresponds to the "metadata" cache strategy.
+		 * useCheckSum: If `true`, use hash of the content to determine if the file has changed.
+		 *     It corresponds to the "content" cache strategy.
+		 *
+		 * For the "content" cache strategy, it is important to set useModifiedTime to `false`.
+		 * Otherwise, file-entry-cache would use _both_ checks to determine if the file has changed,
+		 * which would defeat the purpose of this cache strategy (use cases where the modification time
+		 * of files changes even if their contents have not, e.g., after `git clone`).
+		 */
 		this.fileEntryCache = fileEntryCache.create(
 			path.basename(cacheFileLocation),
 			path.dirname(cacheFileLocation),
 			{
-				useCheckSum: cacheStrategy === "content",
+				useModifiedTime: !useCheckSum,
+				useCheckSum,
 			},
 		);
 		this.cacheFileLocation = cacheFileLocation;

--- a/lib/cli-engine/lint-result-cache.js
+++ b/lib/cli-engine/lint-result-cache.js
@@ -9,6 +9,7 @@
 //-----------------------------------------------------------------------------
 
 const fs = require("node:fs");
+const path = require("node:path");
 const fileEntryCache = require("file-entry-cache");
 const stringify = require("json-stable-stringify-without-jsonify");
 const pkg = require("../../package.json");
@@ -85,14 +86,14 @@ class LintResultCache {
 
 		debug(`Caching results to ${cacheFileLocation}`);
 
-		const useChecksum = cacheStrategy === "content";
-
 		debug(`Using "${cacheStrategy}" strategy to detect changes`);
 
 		this.fileEntryCache = fileEntryCache.create(
-			cacheFileLocation,
-			void 0,
-			useChecksum,
+			path.basename(cacheFileLocation),
+			path.dirname(cacheFileLocation),
+			{
+				useCheckSum: cacheStrategy === "content",
+			},
 		);
 		this.cacheFileLocation = cacheFileLocation;
 	}
@@ -156,17 +157,22 @@ class LintResultCache {
 			return null;
 		}
 
+		if (!fileDescriptor.meta.data) {
+			debug(`Legacy cache entry found: ${filePath}`);
+			return null;
+		}
+
 		const hashOfConfig = hashOfConfigFor(config);
 		const changed =
 			fileDescriptor.changed ||
-			fileDescriptor.meta.hashOfConfig !== hashOfConfig;
+			fileDescriptor.meta.data.hashOfConfig !== hashOfConfig;
 
 		if (changed) {
 			debug(`Cache entry not found or no longer valid: ${filePath}`);
 			return null;
 		}
 
-		return fileDescriptor.meta.results;
+		return fileDescriptor.meta.data.results;
 	}
 
 	/**
@@ -202,8 +208,10 @@ class LintResultCache {
 				resultToSerialize.source = null;
 			}
 
-			fileDescriptor.meta.results = resultToSerialize;
-			fileDescriptor.meta.hashOfConfig = hashOfConfigFor(config);
+			fileDescriptor.meta.data = {
+				results: resultToSerialize,
+				hashOfConfig: hashOfConfigFor(config),
+			};
 		}
 	}
 

--- a/lib/cli-engine/lint-result-cache.js
+++ b/lib/cli-engine/lint-result-cache.js
@@ -61,58 +61,6 @@ function hashOfConfigFor(config) {
 	return configHashCache.get(config);
 }
 
-/**
- * Creates a new FileEntryCache instance.
- * If the given cache file is invalid JSON, it deletes the file.
- * @param {string} cacheFileLocation The cache file location.
- * @param {boolean} useCheckSum Whether to use checksum for change detection.
- * @returns {Object} A new FileEntryCache instance for the given cache file location.
- * @throws {Error} Rethrows errors from `fileEntryCache.create()`, except for invalid JSON.
- */
-function createFileEntryCache(cacheFileLocation, useCheckSum) {
-	/**
-	 * Creates a new FileEntryCache instance.
-	 * @returns {Object} A new FileEntryCache instance for the given cache file location.
-	 */
-	function create() {
-		/*
-		 * useModifiedTime: If `true` (default), use mtime and size to determine if the file has changed.
-		 *     It corresponds to the "metadata" cache strategy.
-		 * useCheckSum: If `true`, use hash of the content to determine if the file has changed.
-		 *     It corresponds to the "content" cache strategy.
-		 *
-		 * For the "content" cache strategy, it is important to set useModifiedTime to `false`.
-		 * Otherwise, file-entry-cache would use _both_ checks to determine if the file has changed,
-		 * which would defeat the purpose of this cache strategy (use cases where the modification time
-		 * of files changes even if their contents have not, e.g., after `git clone`).
-		 */
-		return fileEntryCache.create(
-			path.basename(cacheFileLocation),
-			path.dirname(cacheFileLocation),
-			{
-				useModifiedTime: !useCheckSum,
-				useCheckSum,
-			},
-		);
-	}
-
-	try {
-		return create();
-	} catch (error) {
-		/*
-		 * Delete the file first if its content is not a valid JSON.
-		 * https://github.com/eslint/eslint/issues/7748
-		 */
-		//
-		if (error.name === "SyntaxError" && error.message.includes("JSON")) {
-			fs.unlinkSync(cacheFileLocation);
-			return create();
-		}
-
-		throw error;
-	}
-}
-
 //-----------------------------------------------------------------------------
 // Public Interface
 //-----------------------------------------------------------------------------
@@ -142,10 +90,26 @@ class LintResultCache {
 
 		debug(`Using "${cacheStrategy}" strategy to detect changes`);
 
-		this.fileEntryCache = createFileEntryCache(
-			cacheFileLocation,
-			useCheckSum,
+		/*
+		 * useModifiedTime: If `true` (default), use mtime and size to determine if the file has changed.
+		 *     It corresponds to the "metadata" cache strategy.
+		 * useCheckSum: If `true`, use hash of the content to determine if the file has changed.
+		 *     It corresponds to the "content" cache strategy.
+		 *
+		 * For the "content" cache strategy, it is important to set useModifiedTime to `false`.
+		 * Otherwise, file-entry-cache would use _both_ checks to determine if the file has changed,
+		 * which would defeat the purpose of this cache strategy (use cases where the modification time
+		 * of files changes even if their contents have not, e.g., after `git clone`).
+		 */
+		this.fileEntryCache = fileEntryCache.create(
+			path.basename(cacheFileLocation),
+			path.dirname(cacheFileLocation),
+			{
+				useModifiedTime: !useCheckSum,
+				useCheckSum,
+			},
 		);
+
 		this.cacheFileLocation = cacheFileLocation;
 	}
 

--- a/lib/cli-engine/lint-result-cache.js
+++ b/lib/cli-engine/lint-result-cache.js
@@ -61,6 +61,58 @@ function hashOfConfigFor(config) {
 	return configHashCache.get(config);
 }
 
+/**
+ * Creates a new FileEntryCache instance.
+ * If the given cache file is invalid JSON, it deletes the file.
+ * @param {string} cacheFileLocation The cache file location.
+ * @param {boolean} useCheckSum Whether to use checksum for change detection.
+ * @returns {Object} A new FileEntryCache instance for the given cache file location.
+ * @throws {Error} Rethrows errors from `fileEntryCache.create()`, except for invalid JSON.
+ */
+function createFileEntryCache(cacheFileLocation, useCheckSum) {
+	/**
+	 * Creates a new FileEntryCache instance.
+	 * @returns {Object} A new FileEntryCache instance for the given cache file location.
+	 */
+	function create() {
+		/*
+		 * useModifiedTime: If `true` (default), use mtime and size to determine if the file has changed.
+		 *     It corresponds to the "metadata" cache strategy.
+		 * useCheckSum: If `true`, use hash of the content to determine if the file has changed.
+		 *     It corresponds to the "content" cache strategy.
+		 *
+		 * For the "content" cache strategy, it is important to set useModifiedTime to `false`.
+		 * Otherwise, file-entry-cache would use _both_ checks to determine if the file has changed,
+		 * which would defeat the purpose of this cache strategy (use cases where the modification time
+		 * of files changes even if their contents have not, e.g., after `git clone`).
+		 */
+		return fileEntryCache.create(
+			path.basename(cacheFileLocation),
+			path.dirname(cacheFileLocation),
+			{
+				useModifiedTime: !useCheckSum,
+				useCheckSum,
+			},
+		);
+	}
+
+	try {
+		return create();
+	} catch (error) {
+		/*
+		 * Delete the file first if its content is not a valid JSON.
+		 * https://github.com/eslint/eslint/issues/7748
+		 */
+		//
+		if (error.name === "SyntaxError" && error.message.includes("JSON")) {
+			fs.unlinkSync(cacheFileLocation);
+			return create();
+		}
+
+		throw error;
+	}
+}
+
 //-----------------------------------------------------------------------------
 // Public Interface
 //-----------------------------------------------------------------------------
@@ -90,24 +142,9 @@ class LintResultCache {
 
 		debug(`Using "${cacheStrategy}" strategy to detect changes`);
 
-		/*
-		 * useModifiedTime: If `true` (default), use mtime and size to determine if the file has changed.
-		 *     It corresponds to the "metadata" cache strategy.
-		 * useCheckSum: If `true`, use hash of the content to determine if the file has changed.
-		 *     It corresponds to the "content" cache strategy.
-		 *
-		 * For the "content" cache strategy, it is important to set useModifiedTime to `false`.
-		 * Otherwise, file-entry-cache would use _both_ checks to determine if the file has changed,
-		 * which would defeat the purpose of this cache strategy (use cases where the modification time
-		 * of files changes even if their contents have not, e.g., after `git clone`).
-		 */
-		this.fileEntryCache = fileEntryCache.create(
-			path.basename(cacheFileLocation),
-			path.dirname(cacheFileLocation),
-			{
-				useModifiedTime: !useCheckSum,
-				useCheckSum,
-			},
+		this.fileEntryCache = createFileEntryCache(
+			cacheFileLocation,
+			useCheckSum,
 		);
 		this.cacheFileLocation = cacheFileLocation;
 	}

--- a/lib/cli-engine/lint-result-cache.js
+++ b/lib/cli-engine/lint-result-cache.js
@@ -157,7 +157,7 @@ class LintResultCache {
 			return null;
 		}
 
-		if (!fileDescriptor.meta.data) {
+		if (!fileDescriptor.changed && !fileDescriptor.meta.data) {
 			debug(`Legacy cache entry found: ${filePath}`);
 			return null;
 		}

--- a/lib/cli-engine/lint-result-cache.js
+++ b/lib/cli-engine/lint-result-cache.js
@@ -223,6 +223,12 @@ class LintResultCache {
 				resultToSerialize.source = null;
 			}
 
+			// remove legacy properties set by a previous version of ESLint, if present
+			if (fileDescriptor.meta.hashOfConfig) {
+				delete fileDescriptor.meta.results;
+				delete fileDescriptor.meta.hashOfConfig;
+			}
+
 			fileDescriptor.meta.data = {
 				results: resultToSerialize,
 				hashOfConfig: hashOfConfigFor(config),

--- a/lib/cli-engine/lint-result-cache.js
+++ b/lib/cli-engine/lint-result-cache.js
@@ -173,7 +173,7 @@ class LintResultCache {
 		}
 
 		if (!fileDescriptor.changed && !fileDescriptor.meta.data) {
-			debug(`Legacy cache entry found: ${filePath}`);
+			debug("Legacy cache entry found: %s", filePath);
 			return null;
 		}
 

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "esquery": "^1.7.0",
     "esutils": "^2.0.2",
     "fast-deep-equal": "^3.1.3",
-    "file-entry-cache": "^8.0.0",
+    "file-entry-cache": "^11.1.2",
     "find-up": "^5.0.0",
     "glob-parent": "^6.0.2",
     "ignore": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "esquery": "^1.7.0",
     "esutils": "^2.0.2",
     "fast-deep-equal": "^3.1.3",
-    "file-entry-cache": "^11.1.2",
+    "file-entry-cache": "^11.1.5",
     "find-up": "^5.0.0",
     "glob-parent": "^6.0.2",
     "ignore": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "esquery": "^1.7.0",
     "esutils": "^2.0.2",
     "fast-deep-equal": "^3.1.3",
-    "file-entry-cache": "^8.0.0",
+    "file-entry-cache": "^11.1.2",
     "find-up": "^5.0.0",
     "glob-parent": "^6.0.2",
     "ignore": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "esquery": "^1.7.0",
     "esutils": "^2.0.2",
     "fast-deep-equal": "^3.1.3",
-    "file-entry-cache": "^11.1.5",
+    "file-entry-cache": "11.1.5 || >11.1.6 <12",
     "find-up": "^5.0.0",
     "glob-parent": "^6.0.2",
     "ignore": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "esquery": "^1.7.0",
     "esutils": "^2.0.2",
     "fast-deep-equal": "^3.1.3",
-    "file-entry-cache": "^11.1.2",
+    "file-entry-cache": "^11.1.5",
     "find-up": "^5.0.0",
     "glob-parent": "^6.0.2",
     "ignore": "^5.2.0",

--- a/tests/lib/cli-engine/lint-result-cache.js
+++ b/tests/lib/cli-engine/lint-result-cache.js
@@ -15,7 +15,6 @@ const assert = require("chai").assert,
 	path = require("node:path"),
 	proxyquire = require("proxyquire"),
 	sinon = require("sinon"),
-	fileEntryCache = require("file-entry-cache"),
 	OriginalLintResultCache = require("../../../lib/cli-engine/lint-result-cache");
 
 //-----------------------------------------------------------------------------
@@ -29,15 +28,6 @@ describe("LintResultCache", () => {
 	);
 	const cacheFileLocation = path.join(fixturePath, ".eslintcache");
 	const fileEntryCacheStubs = {};
-
-	/*
-	 * fileEntryCache.create is a getter with `configurable: false`, so we need to set
-	 * it in advance with `configurable: true` to be able to modify it.
-	 */
-	Object.defineProperty(fileEntryCacheStubs, "create", {
-		...Object.getOwnPropertyDescriptor(fileEntryCache, "create"),
-		configurable: true,
-	});
 
 	let LintResultCache,
 		hashStub,
@@ -137,14 +127,8 @@ describe("LintResultCache", () => {
 		before(() => {
 			getFileDescriptorStub = sandbox.stub();
 
-			Object.defineProperty(fileEntryCacheStubs, "create", {
-				...Object.getOwnPropertyDescriptor(fileEntryCache, "create"),
-				get() {
-					return () => ({
-						getFileDescriptor: getFileDescriptorStub,
-					});
-				},
-				configurable: true,
+			fileEntryCacheStubs.create = () => ({
+				getFileDescriptor: getFileDescriptorStub,
 			});
 		});
 
@@ -471,14 +455,8 @@ describe("LintResultCache", () => {
 		before(() => {
 			getFileDescriptorStub = sandbox.stub();
 
-			Object.defineProperty(fileEntryCacheStubs, "create", {
-				...Object.getOwnPropertyDescriptor(fileEntryCache, "create"),
-				get() {
-					return () => ({
-						getFileDescriptor: getFileDescriptorStub,
-					});
-				},
-				configurable: true,
+			fileEntryCacheStubs.create = () => ({
+				getFileDescriptor: getFileDescriptorStub,
 			});
 		});
 
@@ -602,14 +580,8 @@ describe("LintResultCache", () => {
 		before(() => {
 			reconcileStub = sandbox.stub();
 
-			Object.defineProperty(fileEntryCacheStubs, "create", {
-				...Object.getOwnPropertyDescriptor(fileEntryCache, "create"),
-				get() {
-					return () => ({
-						reconcile: reconcileStub,
-					});
-				},
-				configurable: true,
+			fileEntryCacheStubs.create = () => ({
+				reconcile: reconcileStub,
 			});
 		});
 

--- a/tests/lib/cli-engine/lint-result-cache.js
+++ b/tests/lib/cli-engine/lint-result-cache.js
@@ -13,7 +13,8 @@ const assert = require("chai").assert,
 	fs = require("node:fs"),
 	path = require("node:path"),
 	proxyquire = require("proxyquire"),
-	sinon = require("sinon");
+	sinon = require("sinon"),
+	fileEntryCache = require("file-entry-cache");
 
 //-----------------------------------------------------------------------------
 // Tests
@@ -26,6 +27,15 @@ describe("LintResultCache", () => {
 	);
 	const cacheFileLocation = path.join(fixturePath, ".eslintcache");
 	const fileEntryCacheStubs = {};
+
+	/*
+	 * fileEntryCache.create is a getter with `configurable: false`, so we need to set
+	 * it in advance with `configurable: true` to be able to modify it.
+	 */
+	Object.defineProperty(fileEntryCacheStubs, "create", {
+		...Object.getOwnPropertyDescriptor(fileEntryCache, "create"),
+		configurable: true,
+	});
 
 	let LintResultCache,
 		hashStub,
@@ -125,8 +135,14 @@ describe("LintResultCache", () => {
 		before(() => {
 			getFileDescriptorStub = sandbox.stub();
 
-			fileEntryCacheStubs.create = () => ({
-				getFileDescriptor: getFileDescriptorStub,
+			Object.defineProperty(fileEntryCacheStubs, "create", {
+				...Object.getOwnPropertyDescriptor(fileEntryCache, "create"),
+				get() {
+					return () => ({
+						getFileDescriptor: getFileDescriptorStub,
+					});
+				},
+				configurable: true,
 			});
 		});
 
@@ -137,12 +153,14 @@ describe("LintResultCache", () => {
 		beforeEach(() => {
 			cacheEntry = {
 				meta: {
-					// Serialized results will have null source
-					results: Object.assign({}, fakeErrorResults, {
-						source: null,
-					}),
+					data: {
+						// Serialized results will have null source
+						results: Object.assign({}, fakeErrorResults, {
+							source: null,
+						}),
 
-					hashOfConfig,
+						hashOfConfig,
+					},
 				},
 			};
 
@@ -287,8 +305,14 @@ describe("LintResultCache", () => {
 		before(() => {
 			getFileDescriptorStub = sandbox.stub();
 
-			fileEntryCacheStubs.create = () => ({
-				getFileDescriptor: getFileDescriptorStub,
+			Object.defineProperty(fileEntryCacheStubs, "create", {
+				...Object.getOwnPropertyDescriptor(fileEntryCache, "create"),
+				get() {
+					return () => ({
+						getFileDescriptor: getFileDescriptorStub,
+					});
+				},
+				configurable: true,
 			});
 		});
 
@@ -321,8 +345,7 @@ describe("LintResultCache", () => {
 					fakeErrorResultsAutofix,
 				);
 
-				assert.notProperty(cacheEntry.meta, "results");
-				assert.notProperty(cacheEntry.meta, "hashOfConfig");
+				assert.notProperty(cacheEntry.meta, "data");
 			});
 		});
 
@@ -338,8 +361,7 @@ describe("LintResultCache", () => {
 					fakeErrorResults,
 				);
 
-				assert.notProperty(cacheEntry.meta, "results");
-				assert.notProperty(cacheEntry.meta, "hashOfConfig");
+				assert.notProperty(cacheEntry.meta, "data");
 			});
 		});
 
@@ -353,7 +375,10 @@ describe("LintResultCache", () => {
 			});
 
 			it("stores hash of config in file entry", () => {
-				assert.strictEqual(cacheEntry.meta.hashOfConfig, hashOfConfig);
+				assert.strictEqual(
+					cacheEntry.meta.data.hashOfConfig,
+					hashOfConfig,
+				);
 			});
 
 			it("stores results (except source) in file entry", () => {
@@ -366,7 +391,7 @@ describe("LintResultCache", () => {
 				);
 
 				assert.deepStrictEqual(
-					cacheEntry.meta.results,
+					cacheEntry.meta.data.results,
 					expectedCachedResults,
 				);
 			});
@@ -382,7 +407,10 @@ describe("LintResultCache", () => {
 			});
 
 			it("stores hash of config in file entry", () => {
-				assert.strictEqual(cacheEntry.meta.hashOfConfig, hashOfConfig);
+				assert.strictEqual(
+					cacheEntry.meta.data.hashOfConfig,
+					hashOfConfig,
+				);
 			});
 
 			it("stores results (except source) in file entry", () => {
@@ -395,7 +423,7 @@ describe("LintResultCache", () => {
 				);
 
 				assert.deepStrictEqual(
-					cacheEntry.meta.results,
+					cacheEntry.meta.data.results,
 					expectedCachedResults,
 				);
 			});
@@ -408,8 +436,14 @@ describe("LintResultCache", () => {
 		before(() => {
 			reconcileStub = sandbox.stub();
 
-			fileEntryCacheStubs.create = () => ({
-				reconcile: reconcileStub,
+			Object.defineProperty(fileEntryCacheStubs, "create", {
+				...Object.getOwnPropertyDescriptor(fileEntryCache, "create"),
+				get() {
+					return () => ({
+						reconcile: reconcileStub,
+					});
+				},
+				configurable: true,
 			});
 		});
 

--- a/tests/lib/cli-engine/lint-result-cache.js
+++ b/tests/lib/cli-engine/lint-result-cache.js
@@ -421,7 +421,7 @@ describe("LintResultCache", () => {
 					);
 
 					// Modify file. This should make cache entry invalid for all cache strategies.
-					await fs.promises.writeFile(testFile, "bar;");
+					await fs.promises.writeFile(testFile, "barbaz;");
 
 					const testLintResultCache = new OriginalLintResultCache(
 						cacheFile,

--- a/tests/lib/cli-engine/lint-result-cache.js
+++ b/tests/lib/cli-engine/lint-result-cache.js
@@ -11,10 +11,12 @@
 const assert = require("chai").assert,
 	{ ESLint } = require("../../../lib/eslint"),
 	fs = require("node:fs"),
+	os = require("node:os"),
 	path = require("node:path"),
 	proxyquire = require("proxyquire"),
 	sinon = require("sinon"),
-	fileEntryCache = require("file-entry-cache");
+	fileEntryCache = require("file-entry-cache"),
+	OriginalLintResultCache = require("../../../lib/cli-engine/lint-result-cache");
 
 //-----------------------------------------------------------------------------
 // Tests
@@ -292,6 +294,170 @@ describe("LintResultCache", () => {
 					result.source,
 					"source property should be hydrated from filesystem",
 				);
+			});
+		});
+
+		describe("When called multiple times for the same file", () => {
+			let testDir;
+			let testFile;
+			let anotherFile;
+			let cacheFile;
+			let lintResult, anotherLintResult;
+			let config;
+
+			beforeEach(async () => {
+				testDir = await fs.promises.mkdtemp(
+					path.join(os.tmpdir(), "eslint-cache-"),
+				);
+
+				testFile = path.resolve(testDir, "file.js");
+				await fs.promises.writeFile(testFile, "foo;");
+
+				anotherFile = path.resolve(testDir, "anotherfile.js");
+				await fs.promises.writeFile(anotherFile, "bar;");
+
+				const testEslint = new ESLint({
+					cwd: testDir,
+					cache: false,
+					overrideConfigFile: true,
+				});
+
+				[lintResult] = await testEslint.lintFiles([testFile]);
+				assert(lintResult, "Lint result should have been created");
+
+				[anotherLintResult] = await testEslint.lintFiles([anotherFile]);
+				assert(
+					anotherLintResult,
+					"Another lint result should have been created",
+				);
+
+				config = await testEslint.calculateConfigForFile(testFile);
+
+				cacheFile = path.resolve(testDir, ".eslintcache");
+			});
+
+			afterEach(async () => {
+				await fs.promises.rm(testDir, {
+					recursive: true,
+					force: true,
+				});
+				testDir = void 0;
+			});
+
+			["metadata", "content"].forEach(cacheStrategy => {
+				it(`should return null for a file when cache file hasn't been created yet when cacheStrategy is "${cacheStrategy}"`, async () => {
+					const testLintResultCache = new OriginalLintResultCache(
+						cacheFile,
+						cacheStrategy,
+					);
+
+					// Get results from cache multiple times
+					assert.isNull(
+						testLintResultCache.getCachedLintResults(
+							testFile,
+							config,
+						),
+					);
+					assert.isNull(
+						testLintResultCache.getCachedLintResults(
+							testFile,
+							config,
+						),
+					);
+				});
+
+				it(`should return null for a file that hasn't already been cached when cacheStrategy is "${cacheStrategy}"`, async () => {
+					const initLintResultCache = new OriginalLintResultCache(
+						cacheFile,
+						cacheStrategy,
+					);
+
+					initLintResultCache.setCachedLintResults(
+						anotherFile,
+						config,
+						anotherLintResult,
+					);
+					initLintResultCache.reconcile();
+
+					const checkLintResultCache = new OriginalLintResultCache(
+						cacheFile,
+						cacheStrategy,
+					);
+					assert(
+						checkLintResultCache.getCachedLintResults(
+							anotherFile,
+							config,
+						),
+						"Cache entry for another file should have be valid",
+					);
+
+					const testLintResultCache = new OriginalLintResultCache(
+						cacheFile,
+						cacheStrategy,
+					);
+
+					// Get results from cache multiple times
+					assert.isNull(
+						testLintResultCache.getCachedLintResults(
+							testFile,
+							config,
+						),
+					);
+					assert.isNull(
+						testLintResultCache.getCachedLintResults(
+							testFile,
+							config,
+						),
+					);
+				});
+
+				it(`should return null for a file that has already been cached but modified when cacheStrategy is "${cacheStrategy}"`, async () => {
+					const initLintResultCache = new OriginalLintResultCache(
+						cacheFile,
+						cacheStrategy,
+					);
+
+					initLintResultCache.setCachedLintResults(
+						testFile,
+						config,
+						lintResult,
+					);
+					initLintResultCache.reconcile();
+
+					const checkLintResultCache = new OriginalLintResultCache(
+						cacheFile,
+						cacheStrategy,
+					);
+					assert(
+						checkLintResultCache.getCachedLintResults(
+							testFile,
+							config,
+						),
+						"Cache entry should have initially be valid",
+					);
+
+					// Modify file. This should make cache entry invalid for all cache strategies.
+					await fs.promises.writeFile(testFile, "bar;");
+
+					const testLintResultCache = new OriginalLintResultCache(
+						cacheFile,
+						cacheStrategy,
+					);
+
+					// Get results from cache multiple times
+					assert.isNull(
+						testLintResultCache.getCachedLintResults(
+							testFile,
+							config,
+						),
+					);
+					assert.isNull(
+						testLintResultCache.getCachedLintResults(
+							testFile,
+							config,
+						),
+					);
+				});
 			});
 		});
 	});

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -13987,28 +13987,26 @@ describe("ESLint", () => {
 			fs.unlinkSync(toBeDeletedFile);
 
 			/*
-			 * file-entry-cache@2.0.0 will remove from the cache deleted files
+			 * file-entry-cache >= 2.0.0 will remove from the cache deleted files
 			 * even when they were not part of the array of files to be analyzed
 			 */
 			await eslint.lintFiles([badFile, goodFile]);
 
+			// an array
 			cache = JSON.parse(fs.readFileSync(cacheFilePath));
 
-			assert.strictEqual(
-				typeof cache[0][toBeDeletedFile],
-				"undefined",
+			assert(
+				!cache.includes(toBeDeletedFile),
 				"the entry for the file to be deleted should not have been in the cache",
 			);
 
-			// make sure that the previous assertion checks the right place
-			assert.notStrictEqual(
-				typeof cache[0][badFile],
-				"undefined",
+			// make sure that the previous assertion checks properly
+			assert(
+				cache.includes(badFile),
 				"the entry for the bad file should have been in the cache",
 			);
-			assert.notStrictEqual(
-				typeof cache[0][goodFile],
-				"undefined",
+			assert(
+				cache.includes(goodFile),
 				"the entry for the good file should have been in the cache",
 			);
 		});
@@ -14156,7 +14154,7 @@ describe("ESLint", () => {
 				"the cache file already exists and wasn't successfully deleted",
 			);
 
-			fs.writeFileSync(cacheFilePath, "");
+			fs.writeFileSync(cacheFilePath, "[[]]");
 
 			eslint = new ESLint({
 				concurrency,
@@ -14336,7 +14334,10 @@ describe("ESLint", () => {
 					"the cache for eslint should have been created",
 				);
 
-				const fileCache = fCache.create(cacheFilePath);
+				const fileCache = fCache.create(
+					path.basename(cacheFilePath),
+					path.dirname(cacheFilePath),
+				);
 				const descriptor = fileCache.getFileDescriptor(filePath);
 
 				assert(
@@ -14344,11 +14345,11 @@ describe("ESLint", () => {
 					"an entry for the file should have been in the cache file",
 				);
 				assert(
-					typeof descriptor.meta.results === "object",
+					typeof descriptor.meta.data.results === "object",
 					"lint result for the file should have been in its cache entry in the cache file",
 				);
 				assert(
-					typeof descriptor.meta.results.usedDeprecatedRules ===
+					typeof descriptor.meta.data.results.usedDeprecatedRules ===
 						"undefined",
 					"lint result in the cache file contains `usedDeprecatedRules`",
 				);
@@ -14403,7 +14404,10 @@ describe("ESLint", () => {
 					"the cache for eslint should have been created",
 				);
 
-				const fileCache = fCache.create(cacheFilePath);
+				const fileCache = fCache.create(
+					path.basename(cacheFilePath),
+					path.dirname(cacheFilePath),
+				);
 				const descriptor = fileCache.getFileDescriptor(filePath);
 
 				assert(
@@ -14411,13 +14415,13 @@ describe("ESLint", () => {
 					"an entry for the file should have been in the cache file",
 				);
 				assert(
-					typeof descriptor.meta.results === "object",
+					typeof descriptor.meta.data.results === "object",
 					"lint result for the file should have been in its cache entry in the cache file",
 				);
 
 				// if the lint result contains `source`, it should be stored as `null` in the cache file
 				assert.strictEqual(
-					descriptor.meta.results.source,
+					descriptor.meta.data.results.source,
 					null,
 					"lint result in the cache file contains non-null `source`",
 				);
@@ -14512,7 +14516,10 @@ describe("ESLint", () => {
 				);
 
 				await eslint.lintFiles([badFile, goodFile]);
-				let fileCache = fCache.createFromFile(cacheFilePath, true);
+				let fileCache = fCache.createFromFile(cacheFilePath, {
+					useModifiedTime: false,
+					useCheckSum: true,
+				});
 				let entries = fileCache.normalizeEntries([badFile, goodFile]);
 
 				entries.forEach(entry => {
@@ -14524,7 +14531,10 @@ describe("ESLint", () => {
 
 				// this should NOT result in a changed entry
 				shell.touch(goodFile);
-				fileCache = fCache.createFromFile(cacheFilePath, true);
+				fileCache = fCache.createFromFile(cacheFilePath, {
+					useModifiedTime: false,
+					useCheckSum: true,
+				});
 				entries = fileCache.normalizeEntries([badFile, goodFile]);
 				entries.forEach(entry => {
 					assert(
@@ -14572,7 +14582,9 @@ describe("ESLint", () => {
 				shell.cp(goodFile, goodFileCopy);
 
 				await eslint.lintFiles([badFile, goodFileCopy]);
-				let fileCache = fCache.createFromFile(cacheFilePath, true);
+				let fileCache = fCache.createFromFile(cacheFilePath, {
+					useCheckSum: true,
+				});
 				const entries = fileCache.normalizeEntries([
 					badFile,
 					goodFileCopy,
@@ -14587,7 +14599,9 @@ describe("ESLint", () => {
 
 				// this should result in a changed entry
 				shell.sed("-i", "abc", "xzy", goodFileCopy);
-				fileCache = fCache.createFromFile(cacheFilePath, true);
+				fileCache = fCache.createFromFile(cacheFilePath, {
+					useCheckSum: true,
+				});
 				assert(
 					fileCache.getFileDescriptor(badFile).changed === false,
 					`the entry for ${badFile} should have been unchanged`,

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -13173,6 +13173,50 @@ describe("ESLint", () => {
 				);
 				assert.strictEqual(actualWorkerCount, 2);
 			});
+
+			it("should not have side effects on cache entries validity", async () => {
+				// Use cache temporary directory to create a new file in it
+				const cwd = cacheLocation;
+				const filePath = path.join(cwd, "foo.js");
+				fs.writeFileSync(filePath, "");
+
+				const eslint = new ESLint({
+					baseConfig: {
+						rules: {
+							"no-unused-vars": "error",
+						},
+					},
+					cache: true,
+					cacheLocation,
+					cacheStrategy: "metadata",
+					concurrency: "auto",
+					cwd,
+					overrideConfigFile: true,
+				});
+
+				// Create cache entry for the file
+				const [oldResult] = await eslint.lintFiles([filePath]);
+				assert.strictEqual(oldResult.messages.length, 0);
+
+				// Overwrite the file
+				fs.writeFileSync(filePath, "let bar;");
+
+				// Call calculateWorkerCount with arguments that should trigger cache check
+				calculateWorkerCount(
+					eslint,
+					Array(AUTO_FILES_PER_WORKER * 2).fill(filePath),
+					{ availableParallelism: () => 4 },
+				);
+
+				const [newresult] = await eslint.lintFiles([filePath]);
+
+				// Assert that lint results are for the new content
+				assert.strictEqual(newresult.messages.length, 1);
+				assert.strictEqual(
+					newresult.messages[0].ruleId,
+					"no-unused-vars",
+				);
+			});
 		});
 	});
 

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -38,6 +38,7 @@ const { defaultConfig } = require("../../../lib/config/default-config");
 const coreRules = require("../../../lib/rules");
 const espree = require("espree");
 const { WarningService } = require("../../../lib/services/warning-service");
+const LintResultCache = require("../../../lib/cli-engine/lint-result-cache");
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -78,6 +79,15 @@ const eslintConfigFiles = {
 	mjs: "eslint.config.mjs",
 	cjs: "eslint.config.cjs",
 };
+
+/**
+ * Check if a value is a non-null object.
+ * @param {any} value The value to check.
+ * @returns {boolean} `true` if the value is a non-null object.
+ */
+function isNonNullObject(value) {
+	return typeof value === "object" && value !== null;
+}
 
 //------------------------------------------------------------------------------
 // Tests
@@ -14471,16 +14481,53 @@ describe("ESLint", () => {
 					);
 				});
 
+				let lintResultCache = new LintResultCache(
+					cacheFilePath,
+					"metadata",
+				);
+
+				for (const file of [badFile, goodFile]) {
+					assert(
+						isNonNullObject(
+							lintResultCache.getValidCachedLintResults(
+								file,
+								await eslint.calculateConfigForFile(file),
+							),
+						),
+						`lintResultCache should have initially returned cached lint results for ${file}`,
+					);
+				}
+
 				// this should result in a changed entry
 				shell.touch(goodFile);
 				fileCache = fCache.createFromFile(cacheFilePath);
+				lintResultCache = new LintResultCache(
+					cacheFilePath,
+					"metadata",
+				);
 				assert(
 					fileCache.getFileDescriptor(badFile).changed === false,
 					`the entry for ${badFile} should have been unchanged`,
 				);
 				assert(
+					isNonNullObject(
+						lintResultCache.getValidCachedLintResults(
+							badFile,
+							await eslint.calculateConfigForFile(badFile),
+						),
+					),
+					`lintResultCache should have returned cached lint results for ${badFile}`,
+				);
+				assert(
 					fileCache.getFileDescriptor(goodFile).changed === true,
 					`the entry for ${goodFile} should have been changed`,
+				);
+				assert(
+					lintResultCache.getValidCachedLintResults(
+						goodFile,
+						await eslint.calculateConfigForFile(goodFile),
+					) === null,
+					`lintResultCache should have returned null for ${goodFile}`,
 				);
 			});
 
@@ -14529,6 +14576,23 @@ describe("ESLint", () => {
 					);
 				});
 
+				let lintResultCache = new LintResultCache(
+					cacheFilePath,
+					"content",
+				);
+
+				for (const file of [badFile, goodFile]) {
+					assert(
+						isNonNullObject(
+							lintResultCache.getValidCachedLintResults(
+								file,
+								await eslint.calculateConfigForFile(file),
+							),
+						),
+						`lintResultCache should have initially returned cached lint results for ${file}`,
+					);
+				}
+
 				// this should NOT result in a changed entry
 				shell.touch(goodFile);
 				fileCache = fCache.createFromFile(cacheFilePath, {
@@ -14542,6 +14606,18 @@ describe("ESLint", () => {
 						`the entry for ${entry.key} should have remained unchanged`,
 					);
 				});
+				lintResultCache = new LintResultCache(cacheFilePath, "content");
+				for (const file of [badFile, goodFile]) {
+					assert(
+						isNonNullObject(
+							lintResultCache.getValidCachedLintResults(
+								file,
+								await eslint.calculateConfigForFile(file),
+							),
+						),
+						`lintResultCache should have returned cached lint results for ${file}`,
+					);
+				}
 			});
 
 			it("should detect changes using a file's contents when set to 'content'", async () => {
@@ -14598,19 +14674,53 @@ describe("ESLint", () => {
 					);
 				});
 
+				let lintResultCache = new LintResultCache(
+					cacheFilePath,
+					"content",
+				);
+
+				for (const file of [badFile, goodFileCopy]) {
+					assert(
+						isNonNullObject(
+							lintResultCache.getValidCachedLintResults(
+								file,
+								await eslint.calculateConfigForFile(file),
+							),
+						),
+						`lintResultCache should have initially returned cached lint results for ${file}`,
+					);
+				}
+
 				// this should result in a changed entry
 				shell.sed("-i", "abc", "xzy", goodFileCopy);
 				fileCache = fCache.createFromFile(cacheFilePath, {
 					useModifiedTime: false,
 					useCheckSum: true,
 				});
+				lintResultCache = new LintResultCache(cacheFilePath, "content");
 				assert(
 					fileCache.getFileDescriptor(badFile).changed === false,
 					`the entry for ${badFile} should have been unchanged`,
 				);
 				assert(
+					isNonNullObject(
+						lintResultCache.getValidCachedLintResults(
+							badFile,
+							await eslint.calculateConfigForFile(badFile),
+						),
+					),
+					`lintResultCache should have returned cached lint results for ${badFile}`,
+				);
+				assert(
 					fileCache.getFileDescriptor(goodFileCopy).changed === true,
 					`the entry for ${goodFileCopy} should have been changed`,
+				);
+				assert(
+					lintResultCache.getValidCachedLintResults(
+						goodFileCopy,
+						await eslint.calculateConfigForFile(goodFileCopy),
+					) === null,
+					`lintResultCache should have returned null for ${goodFileCopy}`,
 				);
 			});
 		});

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -14583,6 +14583,7 @@ describe("ESLint", () => {
 
 				await eslint.lintFiles([badFile, goodFileCopy]);
 				let fileCache = fCache.createFromFile(cacheFilePath, {
+					useModifiedTime: false,
 					useCheckSum: true,
 				});
 				const entries = fileCache.normalizeEntries([
@@ -14600,6 +14601,7 @@ describe("ESLint", () => {
 				// this should result in a changed entry
 				shell.sed("-i", "abc", "xzy", goodFileCopy);
 				fileCache = fCache.createFromFile(cacheFilePath, {
+					useModifiedTime: false,
 					useCheckSum: true,
 				});
 				assert(

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -13115,6 +13115,33 @@ describe("ESLint", () => {
 				assert.strictEqual(actualWorkerCount, 2);
 			});
 
+			it('should consider cached files that have outdated cache entries with cache strategy "metadata"', async () => {
+				const cwd = getFixturePath("files");
+				const eslint = new ESLint({
+					cache: true,
+					cacheLocation,
+					cacheStrategy: "metadata",
+					concurrency: "auto",
+					cwd,
+					overrideConfigFile: true,
+				});
+
+				// Make sure the config array for `cwd` is loaded and the cache is created.
+				const filePath = path.join(cwd, "foo.js");
+				await eslint.lintFiles([filePath]);
+
+				// modify mtime to make the cache entry outdated
+				shell.touch(filePath);
+
+				// Multitreading expected because files have outdated cache entries.
+				const actualWorkerCount = calculateWorkerCount(
+					eslint,
+					Array(AUTO_FILES_PER_WORKER * 2).fill(filePath),
+					{ availableParallelism: () => 4 },
+				);
+				assert.strictEqual(actualWorkerCount, 2);
+			});
+
 			it('should consider unchanged cached files with violations with cache strategy "metadata" and autofix enabled', async () => {
 				const cwd = getFixturePath();
 				const eslintOptions = {

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -14153,6 +14153,137 @@ describe("ESLint", () => {
 			);
 		});
 
+		describe("when some cached files are not visited", () => {
+			let file1, file2, goodFile, badFile;
+
+			beforeEach(() => {
+				goodFile = fs.realpathSync(
+					getFixturePath("cache/src", "test-file.js"),
+				);
+
+				badFile = fs.realpathSync(
+					getFixturePath("cache/src", "fail-file.js"),
+				);
+
+				file1 = path.resolve(
+					`${path.dirname(goodFile)}`,
+					"tmp-file-1.js",
+				);
+				shell.cp(goodFile, file1);
+
+				file2 = path.resolve(
+					`${path.dirname(goodFile)}`,
+					"tmp-file-2.js",
+				);
+				shell.cp(goodFile, file2);
+			});
+
+			afterEach(() => {
+				doDelete(file1);
+				doDelete(file2);
+			});
+
+			["metadata", "content"].forEach(cacheStrategy => {
+				it(`should not make existing cache entries valid for files that were not visited when cacheStrategy is "${cacheStrategy}" (same instance of eslint)`, async () => {
+					cacheFilePath = getFixturePath(".eslintcache");
+					doDelete(cacheFilePath);
+					assert(
+						!shell.test("-f", cacheFilePath),
+						"the cache file already exists and wasn't successfully deleted",
+					);
+
+					const eslintOptions = {
+						concurrency,
+						cwd: path.join(fixtureDir, ".."),
+						overrideConfigFile: true,
+
+						// specifying cache true the cache will be created
+						cache: true,
+						cacheLocation: cacheFilePath,
+						cacheStrategy,
+						overrideConfig: {
+							rules: {
+								"no-console": 0,
+								"no-unused-vars": 2,
+							},
+						},
+					};
+
+					eslint = new ESLint(eslintOptions);
+					const results = await eslint.lintFiles([file1, file2]);
+					assert(
+						results.every(result => result.messages.length === 0),
+						"There should have been no lint messages for valid files",
+					);
+
+					// Make lint errors in file2
+					doDelete(file2);
+					shell.cp(badFile, file2);
+
+					eslint = new ESLint(eslintOptions);
+
+					// Make a run that doesn't visit file2
+					await eslint.lintFiles([file1]);
+
+					// Now check file2 in another run
+					const [result] = await eslint.lintFiles([file2]);
+					assert(
+						result.messages.length > 0,
+						"There should have been lint messages for an invalid file",
+					);
+				});
+
+				it(`should not make existing cache entries valid for files that were not visited when cacheStrategy is "${cacheStrategy}" (another instance of eslint)`, async () => {
+					cacheFilePath = getFixturePath(".eslintcache");
+					doDelete(cacheFilePath);
+					assert(
+						!shell.test("-f", cacheFilePath),
+						"the cache file already exists and wasn't successfully deleted",
+					);
+
+					const eslintOptions = {
+						concurrency,
+						cwd: path.join(fixtureDir, ".."),
+						overrideConfigFile: true,
+
+						// specifying cache true the cache will be created
+						cache: true,
+						cacheLocation: cacheFilePath,
+						cacheStrategy,
+						overrideConfig: {
+							rules: {
+								"no-console": 0,
+								"no-unused-vars": 2,
+							},
+						},
+					};
+
+					eslint = new ESLint(eslintOptions);
+					const results = await eslint.lintFiles([file1, file2]);
+					assert(
+						results.every(result => result.messages.length === 0),
+						"There should have been no lint messages for valid files",
+					);
+
+					// Make lint errors in file2
+					doDelete(file2);
+					shell.cp(badFile, file2);
+
+					// Make a run that doesn't visit file2
+					eslint = new ESLint(eslintOptions);
+					await eslint.lintFiles([file1]);
+
+					// Now check file2 in another run
+					eslint = new ESLint(eslintOptions);
+					const [result] = await eslint.lintFiles([file2]);
+					assert(
+						result.messages.length > 0,
+						"There should have been lint messages for an invalid file",
+					);
+				});
+			});
+		});
+
 		it("should not delete cache when executing on text", async () => {
 			cacheFilePath = getFixturePath(".eslintcache");
 			doDelete(cacheFilePath);

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -13208,12 +13208,12 @@ describe("ESLint", () => {
 					{ availableParallelism: () => 4 },
 				);
 
-				const [newresult] = await eslint.lintFiles([filePath]);
+				const [newResult] = await eslint.lintFiles([filePath]);
 
 				// Assert that lint results are for the new content
-				assert.strictEqual(newresult.messages.length, 1);
+				assert.strictEqual(newResult.messages.length, 1);
 				assert.strictEqual(
-					newresult.messages[0].ruleId,
+					newResult.messages[0].ruleId,
 					"no-unused-vars",
 				);
 			});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Updates dependency file-entry-cache to the latest v11 release line.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

* Updated `file-entry-cache` dependency from ^8.0.0 to ^11.1.5.
* Updated `fileEntryCache.create()` call due to API changes.
* Switched storing our custom properties `results` and `hashOfConfig` from `fileDescriptor.meta` to `fileDescriptor.meta.data`, as advised in `file-entry-cache` docs.
* Improved test coverage by adding tests for several issues that weren't caught when attempting the upgrade to ^11.1.3.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved lint-result caching to reliably detect changed files and outdated metadata.
  - Fixed cache handling across repeated ESLint runs, including previously unvisited and uncached files.
  - Updated cache compatibility to preserve and validate stored lint results correctly.
  - Improved reliability for metadata-based and content-based cache validation.
  - Fixed cache revalidation across separate ESLint runs and worker configurations.
  - Improved handling of missing, modified, and invalid cached results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->