### PR TITLE
fix: re-export ESTree namespace to fix TS2742 with pnpm strict isolation

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -1523,3 +1523,9 @@ export namespace RuleTester {
 }
 
 // #endregion
+
+// Re-export the ESTree namespace so that TypeScript can form a self-contained
+// reference (e.g. `import("eslint").ESTree`) in generated declaration files,
+// instead of requiring a portable path to @types/estree. This avoids TS2742
+// for downstream consumers using pnpm's strict node_modules isolation.
+export type { ESTree };

--- a/tests/pnpm/test-scope-manager.js
+++ b/tests/pnpm/test-scope-manager.js
@@ -12,6 +12,11 @@
 export default {
 	scopes: [],
 	globalScope: null,
+	/**
+	 * Acquires a scope for the given node.
+	 * @param {import("eslint").ESTree.Node} node The node to acquire scope for.
+	 * @returns {import("eslint").Scope.Scope | null} The acquired scope.
+	 */
 	acquire(node) {
 		void node;
 		return null;

--- a/tests/pnpm/test-scope-manager.js
+++ b/tests/pnpm/test-scope-manager.js
@@ -1,0 +1,23 @@
+/*
+ * Regression test for https://github.com/eslint/eslint/issues/19418
+ * Scope.ScopeManager was unusable in pnpm projects because TypeScript couldn't
+ * form a portable reference to @types/estree when generating declaration files.
+ */
+
+/** @import { Scope } from "eslint" */
+
+/**
+ * @satisfies {Scope.ScopeManager}
+ */
+export default {
+	scopes: [],
+	globalScope: null,
+	acquire(node) {
+		void node;
+		return null;
+	},
+	getDeclaredVariables() {
+		return [];
+	},
+	addGlobals() {},
+};

--- a/tests/pnpm/tsconfig.json
+++ b/tests/pnpm/tsconfig.json
@@ -5,5 +5,5 @@
     "module": "nodenext",
     "noEmit": true
   },
-  "files": ["test-eslint.config.js"]
+  "files": ["test-eslint.config.js", "test-scope-manager.js"]
 }


### PR DESCRIPTION
## What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

## Tell us about your environment

* ESLint Version: 10.x
* Node.js version: any
* npm version: n/a
* Operating System: any

## What problem does this fix?

Closes #19418

When using pnpm with strict module isolation, TypeScript emits TS2742 for any code that satisfies or exports types from ESLint that internally reference `ESTree.*`:

```
The inferred type of 'default' cannot be named without a reference to
'.pnpm/@types+estree@1.0.6/node_modules/@types/estree'. This is likely not portable.
A type annotation is necessary.
```

This affects `Scope.ScopeManager`, `Scope.Scope`, `AST.SourceLocation`, and other ESLint types that expose `ESTree.Node` / `ESTree.Position` etc. in their public signatures.

**Root cause:** ESLint's type definitions import `import * as ESTree from "estree"` and use `ESTree.*` types throughout. When TypeScript generates `.d.ts` files in a pnpm project, it needs to write a portable path to those types. Because pnpm isolates packages, `@types/estree` is not directly accessible from the user's project — only ESLint's own `node_modules` can see it.

**Fix:** Add `export type { ESTree }` to `lib/types/index.d.ts`. This re-exports the imported `ESTree` namespace as a public export of the `eslint` package. TypeScript can now form portable references like `import type { ESTree } from "eslint"` in generated declaration files, avoiding the TS2742 error entirely.

## What changes did you make? (Give an overview)

- `lib/types/index.d.ts`: Add `export type { ESTree }` at the bottom of the file
- `tests/pnpm/test-scope-manager.js`: Add regression test covering `Scope.ScopeManager` (the case from `fasttime`'s comment that was still broken after 9.23.0)
- `tests/pnpm/tsconfig.json`: Add the new test file to the pnpm type check

## Is there anything you'd like reviewers to focus on?

Whether `export type { ESTree }` is the right approach, vs. changing individual type signatures to avoid exposing ESTree in the public API surface. The re-export approach is minimal and avoids changing any existing type signatures.

## AI usage disclosure

This PR was developed with AI assistance (Claude). All code was reviewed and tested by the human submitter.