### PR TITLE
docs: clarify ecmaVersion languageOptions vs parserOptions docs

### DIFF
--- a/docs/src/use/configure/language-options.md
+++ b/docs/src/use/configure/language-options.md
@@ -43,6 +43,8 @@ export default defineConfig([
 
 If you are using the built-in ESLint parser, you can additionally change how ESLint interprets your code by specifying the `languageOptions.parserOptions` key. All options are `false` by default:
 
+For the built-in parser, `ecmaVersion` may be supplied in either `languageOptions` or `languageOptions.parserOptions`. To avoid confusion, prefer setting it in one place only because a parser-level value is not overridden by a later `languageOptions.ecmaVersion` in a downstream configuration object.
+
 - `allowReserved` - allow the use of reserved words as identifiers (if `ecmaVersion` is `3`).
 - `ecmaFeatures` - an object indicating which additional language features you'd like to use:
     - `globalReturn` - allow `return` statements in the global scope. This option only applies when `languageOptions.sourceType` is set to `"script"`. When `languageOptions.sourceType` is set to `"commonjs"`, top-level `return` statements are allowed regardless of this option. When `languageOptions.sourceType` is set to `"module"`, top-level `return` statements are not allowed even if this option is set to `true`.

--- a/docs/src/use/configure/parser.md
+++ b/docs/src/use/configure/parser.md
@@ -72,4 +72,6 @@ export default defineConfig([
 
 ::: tip
 In addition to the options specified in `languageOptions.parserOptions`, ESLint also passes `ecmaVersion` and `sourceType` to all parsers. This allows custom parsers to understand the context in which ESLint is evaluating JavaScript code.
+
+When using the built-in parser, this means `ecmaVersion` can be configured via either `languageOptions` or `languageOptions.parserOptions`. To keep the resulting behavior clear, prefer setting that value in one place only.
 :::


### PR DESCRIPTION
## Summary

Fixes #20522 - _Docs: setting `ecmaVersion` in `languageOptions` versus `parserOptions`_

## Spec

# Spec - Issue #20522

> Source: https://github.com/eslint/eslint/issues/20522

## Problem

The docs currently make it easy to assume that `ecmaVersion` only comes from `languageOptions`, even though the built-in parser can also receive it from `languageOptions.parserOptions`.

## Acceptance criteria

- [x] The language options docs clarify that `ecmaVersion` may be set in `languageOptions` or `languageOptions.parserOptions` when using the built-in parser.
- [x] The parser docs clarify that parser-specific options are passed via `languageOptions.parserOptions`, but ESLint also passes `ecmaVersion` and `sourceType` separately.
- [x] The docs avoid implying that a later `languageOptions.ecmaVersion` overrides a previously supplied parser-level value.

## Approach

Add small clarification notes to the two pages explicitly called out in the issue, without changing unrelated docs structure.

## Work Breakdown

# TODO - Issue #20522

- [x] Review the issue text and identify the two doc pages to update.
- [ ] Update `docs/src/use/configure/language-options.md` with a clarification about built-in parser handling.
- [ ] Update `docs/src/use/configure/parser.md` with a clarification about `ecmaVersion` and `sourceType` handling.
- [ ] Run the relevant docs/lint verification.

## Notes

_None._

## Validation

﻿- [x] `npm install`
- [x] `npm run lint`
- [x] `npm run test`
