### PR TITLE
fix: handle throw before catch overwrite in no-useless-assignment

### DIFF
--- a/lib/rules/no-useless-assignment.js
+++ b/lib/rules/no-useless-assignment.js
@@ -244,6 +244,35 @@ module.exports = {
 				}
 
 				/**
+				 * Checks whether the given assignment appears in a catch block after at least
+				 * one prior statement. In that case, any earlier statement in the catch block
+				 * may throw before this assignment runs, so this assignment cannot be treated
+				 * as a guaranteed overwrite for downstream reads (for example in `finally`).
+				 * @param {AssignmentInfo} assignment The assignment info to check.
+				 * @returns {boolean} `true` if the assignment is in a non-leading catch statement.
+				 */
+				function isCatchAssignmentAfterPriorStatement(assignment) {
+					const ancestors = sourceCode.getAncestors(assignment.node);
+					const catchClauseIndex = ancestors.findIndex(
+						ancestor => ancestor.type === "CatchClause",
+					);
+
+					if (catchClauseIndex === -1) {
+						return false;
+					}
+
+					const catchBlock = ancestors[catchClauseIndex + 1];
+					const statementInCatch = ancestors[catchClauseIndex + 2];
+
+					return (
+						catchBlock &&
+						catchBlock.type === "BlockStatement" &&
+						statementInCatch &&
+						catchBlock.body[0] !== statementInCatch
+					);
+				}
+
+				/**
 				 * @typedef {Object} SubsequentSegmentData
 				 * @property {CodePathSegment} segment The code path segment
 				 * @property {AssignmentInfo} [assignment] The first occurrence of the assignment within the segment.
@@ -313,7 +342,12 @@ module.exports = {
 								),
 						);
 
-						if (!assignmentInSegment) {
+						if (
+							!assignmentInSegment ||
+							isCatchAssignmentAfterPriorStatement(
+								assignmentInSegment,
+							)
+						) {
 							/*
 							 * Stores the next segment to explore.
 							 * If `assignmentInSegment` exists,

--- a/lib/types/rules.d.ts
+++ b/lib/types/rules.d.ts
@@ -4293,6 +4293,7 @@ export interface ESLintRules extends Linter.RulesRecord {
 	 * @since 9.0.0-alpha.1
 	 * @see https://eslint.org/docs/latest/rules/no-useless-assignment
 	 */
+    
 	"no-useless-assignment": Linter.RuleEntry<[]>;
 
 	/**

--- a/lib/types/rules.d.ts
+++ b/lib/types/rules.d.ts
@@ -4293,7 +4293,7 @@ export interface ESLintRules extends Linter.RulesRecord {
 	 * @since 9.0.0-alpha.1
 	 * @see https://eslint.org/docs/latest/rules/no-useless-assignment
 	 */
-    
+
 	"no-useless-assignment": Linter.RuleEntry<[]>;
 
 	/**

--- a/tests/lib/rules/no-useless-assignment.js
+++ b/tests/lib/rules/no-useless-assignment.js
@@ -406,6 +406,19 @@ ruleTester.run("no-useless-assignment", rule, {
                 }
             }
         }`,
+		`function main() {
+            let outcome = "unknown";
+
+            try {
+                helper1();
+                outcome = "success";
+            } catch (err) {
+                helper2();
+                outcome = "exception";
+            } finally {
+                console.log(outcome);
+            }
+        }`,
 
 		// An expression within an assignment.
 		`const obj = { a: 5 };


### PR DESCRIPTION
Fixes #20637.

## Summary

When `no-useless-assignment` walks later segments, it currently treats a later assignment in the same `catch` path as a guaranteed overwrite.

That is too optimistic when the `catch` block does work before the overwrite. If an earlier statement in `catch` throws, execution can jump into `finally` before the later assignment runs, and the older value is still observable.

This change handles that case conservatively by continuing segment traversal when the later assignment appears in a non-leading `catch` statement.

## Tests

Added a regression case where:
- `try` assigns a success value
- `catch` calls a helper that may throw before assigning the exception value
- `finally` reads the fallback value
