### PR TITLE
fix: handle unavailable require cache

### DIFF
--- a/lib/config/config-loader.js
+++ b/lib/config/config-loader.js
@@ -230,7 +230,9 @@ async function loadConfigFile(filePath, hasUnstableNativeNodeJsTSConfigFlag) {
 	 * the require cache only if the file has been changed.
 	 */
 	if (importedConfigFileModificationTime.get(filePath) !== mtime) {
-		delete require.cache[filePath];
+		if (require.cache) {
+			delete require.cache[filePath];
+		}
 	}
 
 	const isTS = isFileTS(filePath);

--- a/lib/config/config-loader.js
+++ b/lib/config/config-loader.js
@@ -230,10 +230,7 @@ async function loadConfigFile(filePath, hasUnstableNativeNodeJsTSConfigFlag) {
 	 * the require cache only if the file has been changed.
 	 */
 	if (importedConfigFileModificationTime.get(filePath) !== mtime) {
-		/* c8 ignore next */
-		if (require.cache) {
-			delete require.cache[filePath];
-		}
+		delete require.cache?.[filePath];
 	}
 
 	const isTS = isFileTS(filePath);

--- a/lib/config/config-loader.js
+++ b/lib/config/config-loader.js
@@ -230,6 +230,7 @@ async function loadConfigFile(filePath, hasUnstableNativeNodeJsTSConfigFlag) {
 	 * the require cache only if the file has been changed.
 	 */
 	if (importedConfigFileModificationTime.get(filePath) !== mtime) {
+		/* c8 ignore next */
 		if (require.cache) {
 			delete require.cache[filePath];
 		}

--- a/tests/lib/config/config-loader.js
+++ b/tests/lib/config/config-loader.js
@@ -12,6 +12,7 @@
 const assert = require("node:assert");
 const fs = require("node:fs");
 const Module = require("node:module");
+const os = require("node:os");
 const path = require("node:path");
 const vm = require("node:vm");
 const sinon = require("sinon");
@@ -90,7 +91,10 @@ describe("ConfigLoader", () => {
 				const compiledWrapper = vm.runInThisContext(
 					Module.wrap(configLoaderSource),
 					{
-						filename: configLoaderPath,
+						filename: path.join(
+							os.tmpdir(),
+							"eslint-config-loader-without-require-cache.js",
+						),
 						importModuleDynamically:
 							vm.constants.USE_MAIN_CONTEXT_DEFAULT_LOADER,
 					},

--- a/tests/lib/config/config-loader.js
+++ b/tests/lib/config/config-loader.js
@@ -10,7 +10,10 @@
 //------------------------------------------------------------------------------
 
 const assert = require("node:assert");
+const fs = require("node:fs");
+const Module = require("node:module");
 const path = require("node:path");
+const vm = require("node:vm");
 const sinon = require("sinon");
 const { ConfigLoader } = require("../../../lib/config/config-loader");
 const { WarningService } = require("../../../lib/services/warning-service");
@@ -68,6 +71,60 @@ describe("ConfigLoader", () => {
 		});
 
 		describe("loadConfigArrayForFile()", () => {
+			it("should not error when require.cache is unavailable", async () => {
+				const cwd = path.resolve(fixtureDir, "simple-valid-project-2");
+				const configLoaderPath = path.resolve(
+					__dirname,
+					"../../../lib/config/config-loader.js",
+				);
+				const configLoaderSource = fs.readFileSync(
+					configLoaderPath,
+					"utf8",
+				);
+				const module = { exports: {} };
+				const requireWithoutCache =
+					Module.createRequire(configLoaderPath);
+
+				requireWithoutCache.cache = void 0;
+
+				const compiledWrapper = vm.runInThisContext(
+					Module.wrap(configLoaderSource),
+					{
+						filename: configLoaderPath,
+						importModuleDynamically:
+							vm.constants.USE_MAIN_CONTEXT_DEFAULT_LOADER,
+					},
+				);
+
+				compiledWrapper.call(
+					module.exports,
+					module.exports,
+					requireWithoutCache,
+					module,
+					configLoaderPath,
+					path.dirname(configLoaderPath),
+				);
+
+				const { ConfigLoader: ConfigLoaderWithoutRequireCache } =
+					module.exports;
+
+				const configArray =
+					await ConfigLoaderWithoutRequireCache.calculateConfigArray(
+						path.resolve(cwd, "eslint.config.js"),
+						cwd,
+						{
+							cwd,
+							ignoreEnabled: true,
+							warningService: new WarningService(),
+						},
+					);
+
+				assert(
+					Array.isArray(configArray),
+					"Expected `calculateConfigArray()` to return a config array",
+				);
+			});
+
 			// https://github.com/eslint/eslint/issues/19025
 			it("should lookup config file only once and create config array only once for multiple files in same directory", async () => {
 				const cwd = path.resolve(fixtureDir, "simple-valid-project-2");


### PR DESCRIPTION
## Summary
- Guard `require.cache` access while reloading config files so ESLint does not crash when the CommonJS `require` object has no cache.
- Add a focused regression test for config loading with `require.cache` unavailable.

## Root Cause
`loadConfigFile()` clears `require.cache[filePath]` before dynamically importing config files so changed CommonJS configs are reloaded consistently with ESM configs. In some loader environments, the `require` function available to `config-loader.js` can exist without a `cache` object. In that case, `delete require.cache[filePath]` throws before ESLint can load the config.

The failure reproduced as:

```text
TypeError: Cannot convert undefined or null to object
    at loadConfigFile (lib/config/config-loader.js:233:24)
```

## Reproduction Test
The new test loads `lib/config/config-loader.js` through a VM wrapper using a `require` created by `Module.createRequire()`, then sets that wrapper's `require.cache` to unavailable. Calling `ConfigLoader.calculateConfigArray()` then exercises the same cache-clearing path without depending on a specific package manager or loader implementation.

Without the fix, the test fails with the `require.cache` TypeError. With the fix, config loading completes and returns the expected config array.

## Backport
This should be backported to v9 because the crash affects ESLint 9.x users in loader environments where `require.cache` is unavailable.