### PR TITLE
chore: add missing continue-on-error to ecosystem-tests.yml

### DIFF
--- a/.github/workflows/ecosystem-tests.yml
+++ b/.github/workflows/ecosystem-tests.yml
@@ -21,7 +21,8 @@ jobs:
               with:
                   node-version: "lts/*"
             - run: npm install
-            - id: tester
+            - continue-on-error: true
+              id: tester
               run: npm run test:ecosystem -- --plugin all
             - if: steps.tester.outcome == 'failure' && github.head_ref == 'main'
               env:


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: Tooling fix

#### What changes did you make? (Give an overview)

Adds [`continue-on-error`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepscontinue-on-error) so the Discord action runs on failure.

Fixes #20817.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
