### PR TITLE
fix: guard against missing require.cache in config loader

### DIFF
--- a/lib/config/config-loader.js
+++ b/lib/config/config-loader.js
@@ -230,7 +230,7 @@ async function loadConfigFile(filePath, hasUnstableNativeNodeJsTSConfigFlag) {
 	 * the require cache only if the file has been changed.
 	 */
 	if (importedConfigFileModificationTime.get(filePath) !== mtime) {
-		delete require.cache[filePath];
+		delete require.cache?.[filePath];
 	}
 
 	const isTS = isFileTS(filePath);


### PR DESCRIPTION
## Summary

`loadConfigFile` in `lib/config/config-loader.js` unconditionally accesses `require.cache` to evict the stale CJS module:

```js
delete require.cache[filePath];
```

In environments where `require` exists but does not expose a `cache` object (e.g. Yarn PnP ESM loaders, sandboxed `vm.runInThisContext` contexts, and some bundler runtimes), `require.cache` is `undefined`. The `delete` then throws:

```
TypeError: Cannot convert undefined or null to object
    at loadConfigFile (eslint/lib/config/config-loader.js:233:24)
```

This crashes ESLint during config loading, before any linting takes place.

## Fix

Use optional chaining so the delete is a no-op when `require.cache` is absent:

```js
delete require.cache?.[filePath];
```

When `require.cache` is `undefined`, the cache cannot be cleared — but the consequence is simply that the config module is not reloaded on change in those environments (the same behavior as before the cache-busting code was introduced). This is far preferable to crashing.

Fixes #20813