### PR TITLE
fix: handle non-array deprecated rule replacements

### DIFF
--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -107,6 +107,30 @@ function createRulesMeta(rules) {
 	}, {});
 }
 
+/**
+ * Gets the replacement rule names from a deprecated rule's metadata.
+ * @param {RulesMeta} meta The rule metadata.
+ * @returns {string[]} Replacement rule names.
+ */
+function getDeprecatedRuleReplacements(meta) {
+	if (typeof meta.deprecated !== "object") {
+		return meta.replacedBy || [];
+	}
+
+	const { replacedBy } = meta.deprecated;
+
+	if (!Array.isArray(replacedBy)) {
+		return [];
+	}
+
+	return replacedBy.map(replacement => {
+		const pluginName = replacement.plugin?.name;
+		const ruleName = replacement.rule?.name ?? "";
+
+		return `${pluginName !== void 0 ? `${getShorthandName(pluginName, "eslint-plugin")}/` : ""}${ruleName}`;
+	});
+}
+
 /** @type {WeakMap<CalculatedConfig, DeprecatedRuleInfo[]>} */
 const usedDeprecatedRulesCache = new WeakMap();
 
@@ -144,12 +168,7 @@ function getOrFindUsedDeprecatedRules(eslint, maybeFilePath) {
 
 					retv.push({
 						ruleId,
-						replacedBy: usesNewFormat
-							? (meta.deprecated.replacedBy?.map(
-									replacement =>
-										`${replacement.plugin?.name !== void 0 ? `${getShorthandName(replacement.plugin.name, "eslint-plugin")}/` : ""}${replacement.rule?.name ?? ""}`,
-								) ?? [])
-							: meta.replacedBy || [],
+						replacedBy: getDeprecatedRuleReplacements(meta),
 						info: usesNewFormat ? meta.deprecated : void 0,
 					});
 				}

--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -124,10 +124,14 @@ function getDeprecatedRuleReplacements(meta) {
 	}
 
 	return replacedBy.map(replacement => {
-		const pluginName = replacement.plugin?.name;
-		const ruleName = replacement.rule?.name ?? "";
+		if (typeof replacement !== "object" || replacement === null) {
+			return "";
+		}
 
-		return `${pluginName !== void 0 ? `${getShorthandName(pluginName, "eslint-plugin")}/` : ""}${ruleName}`;
+		const pluginName = replacement.plugin?.name;
+		const ruleName = replacement.rule?.name;
+
+		return `${typeof pluginName === "string" ? `${getShorthandName(pluginName, "eslint-plugin")}/` : ""}${typeof ruleName === "string" ? ruleName : ""}`;
 	});
 }
 

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -4389,6 +4389,45 @@ describe("ESLint", () => {
 					},
 				]);
 			});
+
+			it("should handle invalid replacement metadata entries", async () => {
+				const deprecated = {
+					replacedBy: [
+						null,
+						{ plugin: { name: null } },
+						{ plugin: { name: null }, rule: { name: "name" } },
+					],
+				};
+
+				eslint = new ESLint({
+					cwd: originalDir,
+					overrideConfigFile: true,
+					overrideConfig: {
+						plugins: {
+							test: {
+								rules: {
+									deprecated: {
+										meta: { deprecated },
+										create: () => ({}),
+									},
+								},
+							},
+						},
+						rules: {
+							"test/deprecated": "error",
+						},
+					},
+				});
+				const results = await eslint.lintFiles(["lib/cli*.js"]);
+
+				assert.deepStrictEqual(results[0].usedDeprecatedRules, [
+					{
+						ruleId: "test/deprecated",
+						replacedBy: ["", "", "name"],
+						info: deprecated,
+					},
+				]);
+			});
 		});
 
 		// working

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -4354,6 +4354,41 @@ describe("ESLint", () => {
 					},
 				]);
 			});
+
+			it("should ignore replacement metadata that is not an array", async () => {
+				const deprecated = {
+					replacedBy: "replacement",
+				};
+
+				eslint = new ESLint({
+					cwd: originalDir,
+					overrideConfigFile: true,
+					overrideConfig: {
+						plugins: {
+							test: {
+								rules: {
+									deprecated: {
+										meta: { deprecated },
+										create: () => ({}),
+									},
+								},
+							},
+						},
+						rules: {
+							"test/deprecated": "error",
+						},
+					},
+				});
+				const results = await eslint.lintFiles(["lib/cli*.js"]);
+
+				assert.deepStrictEqual(results[0].usedDeprecatedRules, [
+					{
+						ruleId: "test/deprecated",
+						replacedBy: [],
+						info: deprecated,
+					},
+				]);
+			});
 		});
 
 		// working


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:** 22.14.0
- **npm version:** 10.9.2
- **Local ESLint version:** 10.2.1
- **Global ESLint version:** Not found
- **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
import { ESLint } from "eslint";

const eslint = new ESLint({
  overrideConfigFile: true,
  overrideConfig: {
    plugins: {
      test: {
        rules: {
          deprecated: {
            meta: { deprecated: { replacedBy: "replacement" } },
            create: () => ({}),
          },
        },
      },
    },
    rules: {
      "test/deprecated": "error",
    },
  },
});

const results = await eslint.lintFiles(["test.js"]);
results[0].usedDeprecatedRules;
```

**What did you expect to happen?**

ESLint should not crash. The malformed replacement metadata should be treated as no replacements.

**What actually happened? Please include the actual, raw output from ESLint.**

ESLint throws because it attempted to call `.map()` on a non-array `meta.deprecated.replacedBy` value.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

- Guarded `meta.deprecated.replacedBy` with `Array.isArray()`.
- Added a regression test confirming non-array replacement metadata returns `replacedBy: []` instead of crashing.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
