### PR TITLE
test: add unit tests for lib/shared/severity

### DIFF
--- a/tests/lib/shared/severity.js
+++ b/tests/lib/shared/severity.js
@@ -1,0 +1,72 @@
+/**
+ * @fileoverview Tests for severity util
+ * @author Kuldeep Kumar <https://github.com/Kuldeep2822k>
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const { assert } = require("chai");
+const {
+	normalizeSeverityToString,
+	normalizeSeverityToNumber,
+} = require("../../../lib/shared/severity");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("severity", () => {
+	describe("normalizeSeverityToString()", () => {
+		[
+			[2, "error"],
+			["2", "error"],
+			["error", "error"],
+			[1, "warn"],
+			["1", "warn"],
+			["warn", "warn"],
+			[0, "off"],
+			["0", "off"],
+			["off", "off"],
+		].forEach(([input, expected]) => {
+			it(`should return "${expected}" when passed ${JSON.stringify(input)}`, () => {
+				assert.strictEqual(normalizeSeverityToString(input), expected);
+			});
+		});
+
+		it("should throw an error when passed an invalid severity value", () => {
+			assert.throws(
+				() => normalizeSeverityToString("invalid"),
+				/Invalid severity value/u,
+			);
+		});
+	});
+
+	describe("normalizeSeverityToNumber()", () => {
+		[
+			[2, 2],
+			["2", 2],
+			["error", 2],
+			[1, 1],
+			["1", 1],
+			["warn", 1],
+			[0, 0],
+			["0", 0],
+			["off", 0],
+		].forEach(([input, expected]) => {
+			it(`should return ${expected} when passed ${JSON.stringify(input)}`, () => {
+				assert.strictEqual(normalizeSeverityToNumber(input), expected);
+			});
+		});
+
+		it("should throw an error when passed an invalid severity value", () => {
+			assert.throws(
+				() => normalizeSeverityToNumber("invalid"),
+				/Invalid severity value/u,
+			);
+		});
+	});
+});


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain: Add missing unit tests for `lib/shared/severity.js`

#### What changes did you make? (Give an overview)

Added a new test file `tests/lib/shared/severity.js` to provide dedicated unit test coverage for the two utility functions exported from `lib/shared/severity.js`:

- `normalizeSeverityToString()` — converts a severity value (`0/1/2`, `"0"/"1"/"2"`, `"off"/"warn"/"error"`) to its string form.
- `normalizeSeverityToNumber()` — converts the same set of inputs to its numeric form.

The test file covers:
- All 9 valid input variants for each function (numeric, string-numeric, and string-name forms).
- The error throw path for invalid input in both functions.

This follows the same structure and conventions as other test files in `tests/lib/shared/` (e.g., `naming.js`, `string-utils.js`).

#### Is there anything you'd like reviewers to focus on?


