### PR TITLE
test: disable warning for `vm.constants.USE_MAIN_CONTEXT_DEFAULT_LOADER`

### DIFF
--- a/tests/lib/config/config-loader.js
+++ b/tests/lib/config/config-loader.js
@@ -88,6 +88,16 @@ describe("ConfigLoader", () => {
 
 				requireWithoutCache.cache = void 0;
 
+				// Do not warn about usage of experimental `vm.constants.USE_MAIN_CONTEXT_DEFAULT_LOADER`.
+				const emitStub = sinon.stub(process, "emit");
+				emitStub
+					.withArgs(
+						"warning",
+						sinon.match({ name: "ExperimentalWarning" }),
+					)
+					.returns();
+				emitStub.callThrough();
+
 				const compiledWrapper = vm.runInThisContext(
 					Module.wrap(configLoaderSource),
 					{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [X] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:
Fix test output
<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Currently, the output of the npm `test` script is broken because of an experimental warning that occurs in a unit test:

```text
> eslint@10.3.0 test
> node Makefile.js test

Validating rules
Running unit tests

  [....................................](node:13399) ExperimentalWarning: vm.USE_MAIN_CONTEXT_DEFAULT_LOADER is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]

  38129 passing (32s)
  11 pending


=============================== Coverage summary ===============================
Statements   : 99.26% ( 98126/98852 )
Branches     : 98.32% ( 16548/16830 )
Functions    : 99.46% ( 3512/3531 )
Lines        : 99.26% ( 98126/98852 )
================================================================================
Fuzzing rules [==============================] 100%, 0.9s elapsed, eta 0.0s, errors so far: 0
Validating licenses
```

The same warning also occurs in CI, although it's not visually disruptive. See for example https://github.com/eslint/eslint/actions/runs/25459450974/job/74697563703#step:5:10.

The purpose of this PR is to remove the warning from the test output:

```text
> eslint@10.3.0 test
> node Makefile.js test

Validating rules
Running unit tests

  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]

  38129 passing (33s)
  11 pending


=============================== Coverage summary ===============================
Statements   : 99.26% ( 98126/98852 )
Branches     : 98.32% ( 16550/16832 )
Functions    : 99.46% ( 3512/3531 )
Lines        : 99.26% ( 98126/98852 )
================================================================================
Fuzzing rules [==============================] 100%, 1.0s elapsed, eta 0.0s, errors so far: 0
Validating licenses
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated a unit test to suppress the experimental warning.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
