### PR TITLE
fix: treat LogicalExpression as a group in no-unmodified-loop-condition

### DIFF
--- a/lib/rules/no-unmodified-loop-condition.js
+++ b/lib/rules/no-unmodified-loop-condition.js
@@ -26,14 +26,15 @@ const Traverser = require("../shared/traverser"),
 const SENTINEL_PATTERN =
 	/(?:(?:Call|Class|Function|Member|New|Yield)Expression|Statement|Declaration)$/u;
 const LOOP_PATTERN = /^(?:DoWhile|For|While)Statement$/u; // for-in/of statements don't have `test` property.
-const GROUP_PATTERN = /^(?:BinaryExpression|ConditionalExpression)$/u;
+const GROUP_PATTERN =
+	/^(?:BinaryExpression|ConditionalExpression|LogicalExpression)$/u;
 const SKIP_PATTERN = /^(?:ArrowFunction|Class|Function)Expression$/u;
 const DYNAMIC_PATTERN = /^(?:Call|Member|New|TaggedTemplate|Yield)Expression$/u;
 
 /**
  * @typedef {Object} LoopConditionInfo
  * @property {Reference} reference - The reference.
- * @property {ASTNode} group - BinaryExpression or ConditionalExpression nodes
+ * @property {ASTNode} group - BinaryExpression, ConditionalExpression, or LogicalExpression nodes
  *      that the reference is belonging to.
  * @property {Function} isInLoop - The predicate which checks a given reference
  *      is in this loop.
@@ -253,7 +254,7 @@ module.exports = {
 		/**
 		 * Checks whether or not a given group node has any dynamic elements.
 		 * @param {ASTNode} root A node to check.
-		 *      This node is one of BinaryExpression or ConditionalExpression.
+		 *      This node is one of BinaryExpression, ConditionalExpression, or LogicalExpression.
 		 * @returns {boolean} `true` if the node is dynamic.
 		 */
 		function hasDynamicExpressions(root) {

--- a/tests/lib/rules/no-unmodified-loop-condition.js
+++ b/tests/lib/rules/no-unmodified-loop-condition.js
@@ -51,6 +51,12 @@ ruleTester.run("no-unmodified-loop-condition", rule, {
 		"var foo = 0, bar = 1, baz = 2; while (foo ? bar : baz) { foo += 1; }",
 		"var foo = 0, bar = 0; while (foo && bar) { ++foo; ++bar; }",
 		"var foo = 0, bar = 0; while (foo || bar) { ++foo; ++bar; }",
+		"var obj = {}, filter = false; while (obj && !filter) { obj = Object.getPrototypeOf(obj); }",
+		"var foo = 0, bar = 0; while (foo && bar) { ++foo; }",
+		"var foo = 0, bar = 0; while (foo && bar) { ++bar; } foo = 1;",
+		"var foo = 0, bar = 0; while (foo && bar) { ++foo; } foo = 1;",
+		"var a, b, c; while (a < c && b < c) { ++a; } foo = 1;",
+		"var foo = 0, bar = 0; while (foo || bar) { ++bar; }",
 		"var foo = 0; do { ++foo; } while (foo);",
 		"var foo = 0; do { } while (foo++);",
 		"for (var foo = 0; foo; ++foo) { }",
@@ -98,31 +104,6 @@ ruleTester.run("no-unmodified-loop-condition", rule, {
 					messageId: "loopConditionNotModified",
 					data: { name: "bar" },
 				},
-			],
-		},
-		{
-			code: "var foo = 0, bar = 0; while (foo && bar) { ++bar; } foo = 1;",
-			errors: [
-				{
-					messageId: "loopConditionNotModified",
-					data: { name: "foo" },
-				},
-			],
-		},
-		{
-			code: "var foo = 0, bar = 0; while (foo && bar) { ++foo; } foo = 1;",
-			errors: [
-				{
-					messageId: "loopConditionNotModified",
-					data: { name: "bar" },
-				},
-			],
-		},
-		{
-			code: "var a, b, c; while (a < c && b < c) { ++a; } foo = 1;",
-			errors: [
-				{ messageId: "loopConditionNotModified", data: { name: "b" } },
-				{ messageId: "loopConditionNotModified", data: { name: "c" } },
 			],
 		},
 		{


### PR DESCRIPTION
## Summary

- Adds `LogicalExpression` to `GROUP_PATTERN` in `no-unmodified-loop-condition` so that `&&` and `||` expressions are treated the same as `BinaryExpression` and `ConditionalExpression` — modifying any variable that participates in the logical expression counts as a modification for the group.
- Updates three test cases that were previously in `invalid` but are now correctly `valid` (modifying one operand of `&&` is sufficient because the loop can exit when that operand becomes falsy).
- Adds new `valid` test cases explicitly covering the reported pattern (`while (obj && !filter) { obj = ... }`).

## Why

`GROUP_PATTERN` previously only matched `BinaryExpression` and `ConditionalExpression`. Variables on either side of `&&` or `||` had no shared group, so both were checked independently. When one operand was a constant guard (e.g. `!filter`) and the other was modified inside the loop (e.g. `obj = Object.getPrototypeOf(obj)`), the constant operand was reported as "not modified in this loop" — a false positive.

For `&&`, if either operand becomes falsy the loop exits, so modifying any operand is semantically equivalent to what `BinaryExpression` already does. The fix makes `LogicalExpression` consistent with that semantics.

## Test plan

- `node_modules/.bin/mocha tests/lib/rules/no-unmodified-loop-condition.js` — all 40 tests pass

Closes #20844

🤖 Generated with [Claude Code](https://claude.com/claude-code)