### PR TITLE
chore: add OSS-Fuzz harnesses under tools/oss-fuzz

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -122,6 +122,14 @@ module.exports = defineConfig([
 		},
 	},
 	{
+		name: "eslint/oss-fuzz",
+		files: ["tools/oss-fuzz/*.js"],
+		rules: {
+			// Jazzer.js is installed on demand by OSS-Fuzz / contributors.
+			"n/no-extraneous-require": "off",
+		},
+	},
+	{
 		name: "eslint/rules",
 		files: ["lib/rules/*.js", "tools/internal-rules/*.js"],
 		ignores: ["**/index.js"],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -127,6 +127,7 @@ module.exports = defineConfig([
 		rules: {
 			// Jazzer.js is installed on demand by OSS-Fuzz / contributors.
 			"n/no-extraneous-require": "off",
+			"n/no-missing-require": "off",
 		},
 	},
 	{

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -23,6 +23,8 @@
         "tests/pnpm/**",
         // Run from Makefile.js
         "tools/generate-formatter-examples.js",
+        // Fuzz targets run by Jazzer.js on OSS-Fuzz; @jazzer.js/core is installed on demand
+        "tools/oss-fuzz/**",
       ],
       "ignoreDependencies": [
         // Underlying code coverage engine used in unit tests

--- a/tools/oss-fuzz/README.md
+++ b/tools/oss-fuzz/README.md
@@ -1,0 +1,59 @@
+# OSS-Fuzz harnesses
+
+Coverage-guided fuzz targets that drive ESLint's public API through
+[Jazzer.js](https://github.com/CodeIntelligenceTesting/jazzer.js). Used by
+[OSS-Fuzz](https://google.github.io/oss-fuzz/) to fuzz the `master` branch
+continuously and complementary to the property-based fuzzer in
+`tools/eslint-fuzzer.js`.
+
+## Targets
+
+| File                     | Surface                                                                                                                |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| `fuzz_linter.js`         | `Linter.verify` across varied ECMA versions, source types, parser feature flags, and a randomised subset of core rules |
+| `fuzz_verify_and_fix.js` | `Linter.verifyAndFix`, restricted to fixable rules to exercise the autofix loop and overlapping-fix path               |
+| `fuzz_source_code.js`    | Post-parse `SourceCode` helpers: tokens, comments, `getLocFromIndex`, `getScope`, `getAncestors`                       |
+
+Each target consumes the fuzzer's byte stream via Jazzer.js's
+`FuzzedDataProvider` to derive its config and source-code inputs, then calls
+into the linter and lets uncaught exceptions surface as fuzzer findings.
+Errors that come from the fuzzer-generated configuration (rather than the
+source code under test) are filtered out so they don't drown out real bugs.
+
+## Running locally
+
+From the repository root:
+
+```bash
+# Install Jazzer.js (pinned for parity with the OSS-Fuzz base image).
+npm install --no-save @jazzer.js/core@2.1.0
+
+# Run any of the three targets. -runs limits the iteration count.
+npx jazzer tools/oss-fuzz/fuzz_linter -- -runs=10000
+npx jazzer tools/oss-fuzz/fuzz_verify_and_fix -- -runs=10000
+npx jazzer tools/oss-fuzz/fuzz_source_code -- -runs=10000
+```
+
+Use `--sync` if you want synchronous mode (matches how OSS-Fuzz invokes the
+targets), and pass a corpus directory after the target name to seed and
+persist inputs:
+
+```bash
+mkdir -p corpus/fuzz_linter
+npx jazzer tools/oss-fuzz/fuzz_linter corpus/fuzz_linter --sync -- -runs=100000
+```
+
+## Why Jazzer.js 2.1.0
+
+The prebuilt native fuzzer binary in Jazzer.js 4.x requires GLIBC 2.32, which
+is newer than what the OSS-Fuzz base-runner image (Ubuntu 20.04) provides.
+Pinning to 2.1.0 keeps local runs and the OSS-Fuzz build using the same
+version.
+
+## Reporting
+
+Crashes and uncaught exceptions found by the OSS-Fuzz infrastructure are
+disclosed privately to the project's primary contact under a 90-day embargo
+before going public. The OSS-Fuzz project configuration lives at
+[`projects/eslint`](https://github.com/google/oss-fuzz/tree/master/projects/eslint)
+in the OSS-Fuzz repository.

--- a/tools/oss-fuzz/fuzz_linter.js
+++ b/tools/oss-fuzz/fuzz_linter.js
@@ -1,0 +1,151 @@
+/**
+ * @fileoverview Coverage-guided fuzz target for `Linter.verify`.
+ * @author Dexter K.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const { FuzzedDataProvider } = require("@jazzer.js/core");
+const { Linter } = require("../../lib/linter");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+const linter = new Linter();
+
+const ECMA_VERSIONS = [3, 5, 2015, 2018, 2020, 2022, 2024, "latest"];
+const SOURCE_TYPES = ["script", "module", "commonjs"];
+
+/*
+ * A representative cross-section of rules covering parser-touching rules,
+ * scope analysis, AST shape, and rules with non-trivial state (control-flow,
+ * autofix, suggestions). Enabling all rules at once dilutes coverage signal,
+ * so the fuzzer picks a small subset on each iteration.
+ */
+const RULE_POOL = [
+	"no-cond-assign",
+	"no-constant-condition",
+	"no-dupe-args",
+	"no-dupe-keys",
+	"no-empty",
+	"no-extra-boolean-cast",
+	"no-irregular-whitespace",
+	"no-redeclare",
+	"no-undef",
+	"no-unreachable",
+	"no-unused-vars",
+	"no-use-before-define",
+	"complexity",
+	"max-depth",
+	"max-nested-callbacks",
+	"max-params",
+	"prefer-const",
+	"semi",
+	"quotes",
+	"eqeqeq",
+	"curly",
+	"no-var",
+	"no-multi-spaces",
+	"no-trailing-spaces",
+];
+
+/**
+ * Pick a small random subset of rules to enable.
+ * @param {FuzzedDataProvider} provider The fuzzer-provided data source.
+ * @returns {Object} A `rules` object suitable for the linter config.
+ */
+function pickRules(provider) {
+	const rules = {};
+	const count = provider.consumeIntegralInRange(0, 8);
+
+	for (let i = 0; i < count; i++) {
+		const idx = provider.consumeIntegralInRange(0, RULE_POOL.length - 1);
+
+		rules[RULE_POOL[idx]] = "error";
+	}
+	return rules;
+}
+
+/**
+ * Filter out errors caused by the fuzzer-generated configuration rather than
+ * the source code under test, so they don't drown out real bugs.
+ * @param {Error} e The error thrown by the linter.
+ * @returns {boolean} `true` when the error is a known config-shape rejection.
+ */
+function isExpectedConfigurationError(e) {
+	if (!e || typeof e.message !== "string") {
+		return false;
+	}
+	const msg = e.message;
+
+	return (
+		msg.includes('Key "languageOptions":') ||
+		msg.includes('Key "linterOptions":') ||
+		msg.includes('Key "rules":') ||
+		msg.includes("ecmaVersion must be") ||
+		msg.includes("sourceType must be")
+	);
+}
+
+//------------------------------------------------------------------------------
+// Public API
+//------------------------------------------------------------------------------
+
+/**
+ * Fuzz entry point invoked by Jazzer.js for each input.
+ * @param {Buffer} data The fuzzer-provided input bytes.
+ * @returns {void}
+ * @throws {Error} Any unexpected error from `Linter.verify`.
+ */
+module.exports.fuzz = function (data) {
+	const provider = new FuzzedDataProvider(data);
+
+	const ecmaVersion =
+		ECMA_VERSIONS[
+			provider.consumeIntegralInRange(0, ECMA_VERSIONS.length - 1)
+		];
+	const sourceType =
+		SOURCE_TYPES[
+			provider.consumeIntegralInRange(0, SOURCE_TYPES.length - 1)
+		];
+	const allowInlineConfig = provider.consumeBoolean();
+	const reportUnusedDisableDirectives = provider.consumeBoolean();
+
+	const config = {
+		languageOptions: {
+			ecmaVersion,
+			sourceType,
+			parserOptions: {
+				ecmaFeatures: {
+					jsx: provider.consumeBoolean(),
+					globalReturn: provider.consumeBoolean(),
+				},
+			},
+		},
+		linterOptions: {
+			reportUnusedDisableDirectives,
+		},
+		rules: pickRules(provider),
+	};
+
+	const code = provider.consumeRemainingAsString();
+
+	try {
+		linter.verify(code, config, { allowInlineConfig });
+	} catch (e) {
+		/*
+		 * ESLint surfaces parser errors as lint messages, so any thrown error
+		 * here is unexpected and worth reporting unless it's a known config
+		 * rejection from the fuzzer-generated options.
+		 */
+		if (isExpectedConfigurationError(e)) {
+			return;
+		}
+		throw e;
+	}
+};

--- a/tools/oss-fuzz/fuzz_source_code.js
+++ b/tools/oss-fuzz/fuzz_source_code.js
@@ -1,0 +1,117 @@
+/**
+ * @fileoverview Coverage-guided fuzz target for post-parse `SourceCode` helpers.
+ * @author Dexter K.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const { FuzzedDataProvider } = require("@jazzer.js/core");
+const { Linter } = require("../../lib/linter");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+const linter = new Linter();
+
+/**
+ * Filter out errors caused by the fuzzer-generated configuration.
+ * @param {Error} e The error thrown by the linter.
+ * @returns {boolean} `true` when the error is a known config-shape rejection.
+ */
+function isExpectedConfigurationError(e) {
+	if (!e || typeof e.message !== "string") {
+		return false;
+	}
+	const msg = e.message;
+
+	return (
+		msg.includes('Key "languageOptions":') ||
+		msg.includes("ecmaVersion must be") ||
+		msg.includes("sourceType must be")
+	);
+}
+
+//------------------------------------------------------------------------------
+// Public API
+//------------------------------------------------------------------------------
+
+/**
+ * Fuzz entry point invoked by Jazzer.js for each input.
+ *
+ * `Linter.verify` parses the source and stashes the resulting `SourceCode` on
+ * the linter; this target then exercises the read-only inspection helpers that
+ * rules rely on. Bugs in token/comment indexing or location lookups tend to
+ * surface here rather than in `verify` itself.
+ * @param {Buffer} data The fuzzer-provided input bytes.
+ * @returns {void}
+ * @throws {Error} Any unexpected error from the linter or `SourceCode` helpers.
+ */
+module.exports.fuzz = function (data) {
+	const provider = new FuzzedDataProvider(data);
+
+	const ecmaVersion = provider.consumeIntegralInRange(2015, 2024);
+	const sourceType = provider.consumeBoolean() ? "module" : "script";
+
+	const config = {
+		languageOptions: {
+			ecmaVersion,
+			sourceType,
+		},
+	};
+
+	const code = provider.consumeRemainingAsString();
+
+	try {
+		linter.verify(code, config);
+	} catch (e) {
+		if (isExpectedConfigurationError(e)) {
+			return;
+		}
+		throw e;
+	}
+
+	const sourceCode = linter.getSourceCode();
+
+	if (!sourceCode || !sourceCode.ast) {
+		/*
+		 * Parsing failed - the parser error is surfaced as a lint message and
+		 * no SourceCode is produced. Nothing more to fuzz on this input.
+		 */
+		return;
+	}
+
+	// Token APIs.
+	const tokens = sourceCode.ast.tokens || [];
+
+	if (tokens.length > 0) {
+		const t = tokens[0];
+
+		sourceCode.getTokenByRangeStart(t.range[0]);
+		sourceCode.getTokenBefore(t);
+		sourceCode.getTokenAfter(t);
+		sourceCode.getFirstToken(sourceCode.ast);
+		sourceCode.getLastToken(sourceCode.ast);
+	}
+
+	// Comment APIs.
+	sourceCode.getAllComments();
+
+	// Text/location APIs.
+	const text = sourceCode.getText();
+
+	sourceCode.getLines();
+	if (text.length > 0) {
+		const offset = provider.consumeIntegralInRange(0, text.length - 1);
+
+		sourceCode.getLocFromIndex(offset);
+	}
+
+	// Scope and ancestor APIs (driven through the AST root).
+	sourceCode.getScope(sourceCode.ast);
+	sourceCode.getAncestors(sourceCode.ast);
+};

--- a/tools/oss-fuzz/fuzz_verify_and_fix.js
+++ b/tools/oss-fuzz/fuzz_verify_and_fix.js
@@ -1,0 +1,137 @@
+/**
+ * @fileoverview Coverage-guided fuzz target for `Linter.verifyAndFix`.
+ * @author Dexter K.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const { FuzzedDataProvider } = require("@jazzer.js/core");
+const { Linter } = require("../../lib/linter");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+const linter = new Linter();
+
+/*
+ * Rules with autofixers. The verifyAndFix path runs the fixer in a loop until
+ * convergence, so it stresses fixer composition and the overlapping-range
+ * path that pure verify() doesn't reach.
+ */
+const FIXABLE_RULE_POOL = [
+	"semi",
+	"quotes",
+	"no-extra-semi",
+	"no-extra-boolean-cast",
+	"no-trailing-spaces",
+	"no-multi-spaces",
+	"prefer-const",
+	"no-var",
+	"eqeqeq",
+	"curly",
+	"dot-notation",
+	"object-shorthand",
+	"prefer-arrow-callback",
+	"prefer-template",
+	"arrow-parens",
+	"arrow-spacing",
+	"comma-dangle",
+	"comma-spacing",
+	"indent",
+	"key-spacing",
+	"keyword-spacing",
+	"no-extra-parens",
+	"no-useless-rename",
+	"no-useless-return",
+	"yoda",
+];
+
+const ECMA_VERSIONS = [5, 2015, 2018, 2020, 2022, 2024, "latest"];
+const SOURCE_TYPES = ["script", "module", "commonjs"];
+
+/**
+ * Pick a small random subset of fixable rules.
+ * @param {FuzzedDataProvider} provider The fuzzer-provided data source.
+ * @returns {Object} A `rules` object suitable for the linter config.
+ */
+function pickRules(provider) {
+	const rules = {};
+	const count = provider.consumeIntegralInRange(1, 6);
+
+	for (let i = 0; i < count; i++) {
+		const idx = provider.consumeIntegralInRange(
+			0,
+			FIXABLE_RULE_POOL.length - 1,
+		);
+
+		rules[FIXABLE_RULE_POOL[idx]] = "error";
+	}
+	return rules;
+}
+
+/**
+ * Filter out errors caused by the fuzzer-generated configuration.
+ * @param {Error} e The error thrown by the linter.
+ * @returns {boolean} `true` when the error is a known config-shape rejection.
+ */
+function isExpectedConfigurationError(e) {
+	if (!e || typeof e.message !== "string") {
+		return false;
+	}
+	const msg = e.message;
+
+	return (
+		msg.includes('Key "languageOptions":') ||
+		msg.includes('Key "rules":') ||
+		msg.includes("ecmaVersion must be") ||
+		msg.includes("sourceType must be")
+	);
+}
+
+//------------------------------------------------------------------------------
+// Public API
+//------------------------------------------------------------------------------
+
+/**
+ * Fuzz entry point invoked by Jazzer.js for each input.
+ * @param {Buffer} data The fuzzer-provided input bytes.
+ * @returns {void}
+ * @throws {Error} Any unexpected error from `Linter.verifyAndFix`.
+ */
+module.exports.fuzz = function (data) {
+	const provider = new FuzzedDataProvider(data);
+
+	const ecmaVersion =
+		ECMA_VERSIONS[
+			provider.consumeIntegralInRange(0, ECMA_VERSIONS.length - 1)
+		];
+	const sourceType =
+		SOURCE_TYPES[
+			provider.consumeIntegralInRange(0, SOURCE_TYPES.length - 1)
+		];
+	const fix = provider.consumeBoolean();
+
+	const config = {
+		languageOptions: {
+			ecmaVersion,
+			sourceType,
+		},
+		rules: pickRules(provider),
+	};
+
+	const code = provider.consumeRemainingAsString();
+
+	try {
+		linter.verifyAndFix(code, config, { fix });
+	} catch (e) {
+		if (isExpectedConfigurationError(e)) {
+			return;
+		}
+		throw e;
+	}
+};


### PR DESCRIPTION


## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [X] (If the above is not checked) I have reviewed the AI-generated content before submitting.


## What is the purpose of this pull request?

Adds three coverage-guided fuzz targets that drive ESLint's public API
through [Jazzer.js](https://github.com/CodeIntelligenceTesting/jazzer.js),
intended to be run continuously by [OSS-Fuzz](https://google.github.io/oss-fuzz/)
against `master`. Complementary to the existing property-based fuzzer in
`tools/eslint-fuzzer.js` rather than a replacement.

Refs #20839 (Change Request: OSS-Fuzz integration).
Companion OSS-Fuzz integration PR: google/oss-fuzz#15458.

## What changes did you make? (Give an overview)

Three fuzz targets under a new `tools/oss-fuzz/` directory:

| Target | Surface |
| --- | --- |
| `fuzz_linter.js` | `Linter.verify` across varied ECMA versions, source types, parser feature flags, and a randomised subset of core rules |
| `fuzz_verify_and_fix.js` | `Linter.verifyAndFix` restricted to fixable rules to exercise the autofix loop and overlapping-fix path |
| `fuzz_source_code.js` | Post-parse `SourceCode` helpers: tokens, comments, `getLocFromIndex`, `getScope`, `getAncestors` |

Each target consumes the fuzzer's byte stream via Jazzer.js's
`FuzzedDataProvider` to derive its config and source, then calls into the
linter and lets uncaught exceptions surface as fuzzer findings. Errors that
come from the fuzzer-generated configuration (rather than the source under
test) are filtered out so they don't drown out real bugs.

Also includes:

- `tools/oss-fuzz/README.md` documenting how to run the targets locally.
- An `eslint.config.js` override for `tools/oss-fuzz/*.js` that disables
  `n/no-extraneous-require` for `@jazzer.js/core` (it is installed on
  demand rather than pinned as a devDependency, since 2.x is needed for
  the OSS-Fuzz Ubuntu 20.04 base image and 4.x for newer environments).

## Is there anything you'd like reviewers to focus on?

- The choice of harness location (`tools/oss-fuzz/`) and naming, vs.
  `tests/fuzz/` or co-locating with `tools/eslint-fuzzer.js`.
- The set of rules in `RULE_POOL` / `FIXABLE_RULE_POOL` — these were picked
  to cover parser-touching, scope-analysis, AST-shape, and stateful rules
  without enabling so many that coverage signal is diluted. Happy to
  expand or trim based on maintainer preference.
- Whether `@jazzer.js/core` should instead be added as a `devDependency`.
  The README currently uses `npm install --no-save @jazzer.js/core@2.1.0`
  to avoid pinning a version that's deprecated upstream but required by
  the OSS-Fuzz base image.

## How to verify locally

From the repo root:

```bash
npm install
npm install --no-save @jazzer.js/core@2.1.0

npx jazzer tools/oss-fuzz/fuzz_linter --sync -- -runs=20000
npx jazzer tools/oss-fuzz/fuzz_verify_and_fix --sync -- -runs=20000
npx jazzer tools/oss-fuzz/fuzz_source_code --sync -- -runs=20000
