### PR TITLE
fix: add missing CodePath and CodePathSegment types

### DIFF
--- a/docs/src/extend/code-path-analysis.md
+++ b/docs/src/extend/code-path-analysis.md
@@ -43,6 +43,10 @@ This has references of both the initial segment and the final segments of a code
 - `upper` (`CodePath|null`) - The code path of the upper function/global scope.
 - `childCodePaths` (`CodePath[]`) - Code paths of functions this code path contains.
 
+`CodePath` has the following methods:
+
+- `traverseSegments(optionsOrCallback, callback)` - Traverses all reachable segments in this code path from the initial segment to the final segments. You can optionally pass an options object with `first` (`CodePathSegment`) and `last` (`CodePathSegment`) properties to limit the traversal. The callback receives a `CodePathSegment` and a controller object, and is called with `this` set to the current `CodePath`. The controller has a `skip()` method to skip the following segments in the current branch and a `break()` method to stop traversal.
+
 ### `CodePathSegment`
 
 `CodePathSegment` is a part of a code path.
@@ -54,6 +58,8 @@ Difference from doubly linked list is what there are forking and merging (the ne
 - `id` (`string`) - A unique string. Respective rules can use `id` to save additional information for each segment.
 - `nextSegments` (`CodePathSegment[]`) - The next segments. If forking, there are two or more. If final, there is nothing.
 - `prevSegments` (`CodePathSegment[]`) - The previous segments. If merging, there are two or more. If initial, there is nothing.
+- `allNextSegments` (`CodePathSegment[]`) - The next segments including both reachable and unreachable segments.
+- `allPrevSegments` (`CodePathSegment[]`) - The previous segments including both reachable and unreachable segments.
 - `reachable` (`boolean`) - A flag which shows whether or not it's reachable. This becomes `false` when preceded by `return`, `throw`, `break`, or `continue`.
 
 ## Events

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -723,6 +723,22 @@ export namespace Rule {
 		| "class-field-initializer"
 		| "class-static-block";
 
+	interface CodePathSegmentTraversalController {
+		skip(): void;
+		break(): void;
+	}
+
+	type CodePathSegmentTraversalCallback = (
+		this: CodePath,
+		segment: CodePathSegment,
+		controller: CodePathSegmentTraversalController,
+	) => void;
+
+	interface CodePathTraversalOptions {
+		first?: CodePathSegment | undefined;
+		last?: CodePathSegment | undefined;
+	}
+
 	interface CodePath {
 		id: string;
 		origin: CodePathOrigin;
@@ -732,12 +748,19 @@ export namespace Rule {
 		thrownSegments: CodePathSegment[];
 		upper: CodePath | null;
 		childCodePaths: CodePath[];
+		traverseSegments(callback: CodePathSegmentTraversalCallback): void;
+		traverseSegments(
+			options: CodePathTraversalOptions,
+			callback: CodePathSegmentTraversalCallback,
+		): void;
 	}
 
 	interface CodePathSegment {
 		id: string;
 		nextSegments: CodePathSegment[];
 		prevSegments: CodePathSegment[];
+		allNextSegments: CodePathSegment[];
+		allPrevSegments: CodePathSegment[];
 		reachable: boolean;
 	}
 

--- a/tests/lib/types/types.test.ts
+++ b/tests/lib/types/types.test.ts
@@ -806,6 +806,26 @@ rule = {
 		return {
 			onCodePathStart(codePath, node) {
 				const origin: Rule.CodePathOrigin = codePath.origin;
+				const traversalOptions: Rule.CodePathTraversalOptions = {
+					first: codePath.initialSegment,
+					last: codePath.finalSegments[0],
+				};
+
+				codePath.traverseSegments((segment, controller) => {
+					segment.allNextSegments satisfies Rule.CodePathSegment[];
+					segment.allPrevSegments satisfies Rule.CodePathSegment[];
+					controller.skip();
+					controller.break();
+				});
+
+				codePath.traverseSegments(
+					traversalOptions,
+					function (segment, controller) {
+						this satisfies Rule.CodePath;
+						segment.reachable satisfies boolean;
+						controller.skip();
+					},
+				);
 			},
 			onCodePathEnd(codePath, node) {
 				const origin: Rule.CodePathOrigin = codePath.origin;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version: v24.15.0**
- **npm version: v11.12.1**
- **Local ESLint version: v10.3.0**
- **Global ESLint version:**
- **Operating System:**

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->

```js

```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
onCodePathEnd(codePath) {
    codePath.traverseSegments((segment, controller) => {
      segment.allNextSegments;
      segment.allPrevSegments;
    });
},
```

**What did you expect to happen?**

I expected the TypeScript declarations to match the existing runtime code path analysis API, so that `CodePath#traverseSegments()` and `CodePathSegment#allNextSegments` / `allPrevSegments` could be used without type errors.

**What actually happened? Please include the actual, raw output from ESLint.**

TypeScript reported errors:

```
Property 'traverseSegments' does not exist on type 'CodePath'.
...
```

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

- Updated the `Rule.CodePath` and `Rule.CodePathSegment` types to include runtime members that were missing from the TypeScript declarations.
- Added type coverage for these members.
- Updated the code path analysis documentation to describe `traverseSegments()` and the `allNextSegments` / `allPrevSegments` properties.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
