### PR TITLE
ci: ensure auto-created PRs run CI

### DIFF
--- a/.github/workflows/ecosystem-updates.yml
+++ b/.github/workflows/ecosystem-updates.yml
@@ -23,5 +23,6 @@ jobs:
             - run: npm run test:ecosystem:update
             - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
               with:
+                  token: ${{ secrets.WORKFLOW_PUSH_BOT_TOKEN }}
                   commit-message: "chore: update ecosystem plugins"
                   title: "chore: update ecosystem plugins"


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR updates `.github/workflows/ecosystem-updates.yml` to ensure that auto-created pull requests trigger the CI workflows.

Currently, auto-generated PRs do not run CI, as shown below:

https://github.com/eslint/eslint/pull/20857

<img width="823" height="360" alt="image" src="https://github.com/user-attachments/assets/5533439f-2aae-4bcc-8eb9-63e809f1659c" />

This is the same issue that previously occurred in https://github.com/eslint/css/pull/330. The solution is to use the existing `secrets.WORKFLOW_PUSH_BOT_TOKEN` to ensure that CI is properly triggered.

#### Is there anything you'd like reviewers to focus on?

Ref: https://github.com/eslint/css/pull/330

<!-- markdownlint-disable-file MD004 -->
