### PR TITLE
test: add unit tests for SuppressionsService.applySuppressions()

### DIFF
--- a/tests/lib/services/suppressions-service.js
+++ b/tests/lib/services/suppressions-service.js
@@ -787,4 +787,254 @@ describe("SuppressionsService", () => {
 			);
 		});
 	});
+
+	describe("applySuppressions()", () => {
+		it("should suppress messages when violations count is less than or equal to suppressions count", () => {
+			const cwd = path.resolve("/project");
+			const suppressionsService = new SuppressionsService({
+				filePath: path.join(cwd, "eslint-suppressions.json"),
+				cwd,
+			});
+			const relPath = path.posix.join("src", "app.js");
+			const suppressions = {
+				[relPath]: { "no-console": { count: 2 } },
+			};
+			const results = [
+				createResult({
+					filePath: path.join(cwd, "src", "app.js"),
+					messages: [
+						createMessage("no-console"),
+						createMessage("no-console"),
+					],
+				}),
+			];
+
+			const { results: newResults, unused } =
+				suppressionsService.applySuppressions(results, suppressions);
+
+			assert.strictEqual(newResults[0].messages.length, 0);
+			assert.strictEqual(newResults[0].suppressedMessages.length, 2);
+			assert.strictEqual(
+				newResults[0].suppressedMessages[0].ruleId,
+				"no-console",
+			);
+			assert.deepStrictEqual(
+				newResults[0].suppressedMessages[0].suppressions,
+				[{ kind: "file", justification: "" }],
+			);
+			assert.strictEqual(newResults[0].errorCount, 0);
+			assert.deepStrictEqual(unused, {});
+		});
+
+		it("should not suppress messages when violations count exceeds suppressions count", () => {
+			const cwd = path.resolve("/project");
+			const suppressionsService = new SuppressionsService({
+				filePath: path.join(cwd, "eslint-suppressions.json"),
+				cwd,
+			});
+			const relPath = path.posix.join("src", "app.js");
+			const suppressions = {
+				[relPath]: { "no-console": { count: 1 } },
+			};
+			const results = [
+				createResult({
+					filePath: path.join(cwd, "src", "app.js"),
+					messages: [
+						createMessage("no-console"),
+						createMessage("no-console"),
+					],
+				}),
+			];
+
+			const { results: newResults, unused } =
+				suppressionsService.applySuppressions(results, suppressions);
+
+			assert.strictEqual(newResults[0].messages.length, 2);
+			assert.strictEqual(newResults[0].suppressedMessages.length, 0);
+			assert.strictEqual(newResults[0].errorCount, 2);
+			assert.deepStrictEqual(unused, {});
+		});
+
+		it("should return unused suppressions when violations count is less than suppressions count", () => {
+			const cwd = path.resolve("/project");
+			const suppressionsService = new SuppressionsService({
+				filePath: path.join(cwd, "eslint-suppressions.json"),
+				cwd,
+			});
+			const relPath = path.posix.join("src", "app.js");
+			const suppressions = {
+				[relPath]: { "no-console": { count: 3 } },
+			};
+			const results = [
+				createResult({
+					filePath: path.join(cwd, "src", "app.js"),
+					messages: [createMessage("no-console")],
+				}),
+			];
+
+			const { results: newResults, unused } =
+				suppressionsService.applySuppressions(results, suppressions);
+
+			assert.strictEqual(newResults[0].messages.length, 0);
+			assert.strictEqual(newResults[0].suppressedMessages.length, 1);
+			assert.deepStrictEqual(unused, {
+				[relPath]: { "no-console": { count: 2 } },
+			});
+		});
+
+		it("should return unused suppressions when there are no violations for a suppressed rule", () => {
+			const cwd = path.resolve("/project");
+			const suppressionsService = new SuppressionsService({
+				filePath: path.join(cwd, "eslint-suppressions.json"),
+				cwd,
+			});
+			const relPath = path.posix.join("src", "app.js");
+			const suppressions = {
+				[relPath]: {
+					"no-console": { count: 1 },
+					"no-unused-vars": { count: 1 },
+				},
+			};
+			const results = [
+				createResult({
+					filePath: path.join(cwd, "src", "app.js"),
+					messages: [createMessage("no-unused-vars")],
+				}),
+			];
+
+			const { results: newResults, unused } =
+				suppressionsService.applySuppressions(results, suppressions);
+
+			assert.strictEqual(newResults[0].messages.length, 0);
+			assert.strictEqual(newResults[0].suppressedMessages.length, 1);
+			assert.deepStrictEqual(unused, {
+				[relPath]: { "no-console": { count: 1 } },
+			});
+		});
+
+		it("should process multiple rules and return correct stats and unused counts", () => {
+			const cwd = path.resolve("/project");
+			const suppressionsService = new SuppressionsService({
+				filePath: path.join(cwd, "eslint-suppressions.json"),
+				cwd,
+			});
+			const relPath = path.posix.join("src", "app.js");
+			const suppressions = {
+				[relPath]: {
+					"no-console": { count: 2 },
+					"no-unused-vars": { count: 1 },
+				},
+			};
+			const results = [
+				createResult({
+					filePath: path.join(cwd, "src", "app.js"),
+					messages: [
+						createMessage("no-console"),
+						createMessage("no-unused-vars"),
+						createMessage("no-unused-vars"),
+					],
+				}),
+			];
+
+			const { results: newResults, unused } =
+				suppressionsService.applySuppressions(results, suppressions);
+
+			// no-unused-vars has 2 violations but only 1 suppression → not suppressed
+			assert.strictEqual(newResults[0].messages.length, 2);
+			// no-console has 1 violation and 2 suppressions → suppressed
+			assert.strictEqual(newResults[0].suppressedMessages.length, 1);
+			assert.strictEqual(newResults[0].errorCount, 2);
+			assert.deepStrictEqual(unused, {
+				[relPath]: { "no-console": { count: 1 } },
+			});
+		});
+
+		it("should return all suppressions as unused when the file has no violations", () => {
+			const cwd = path.resolve("/project");
+			const suppressionsService = new SuppressionsService({
+				filePath: path.join(cwd, "eslint-suppressions.json"),
+				cwd,
+			});
+			const relPath = path.posix.join("src", "app.js");
+			const suppressions = {
+				[relPath]: { "no-console": { count: 1 } },
+			};
+			const results = [
+				createResult({
+					filePath: path.join(cwd, "src", "app.js"),
+					messages: [],
+				}),
+			];
+
+			const { results: newResults, unused } =
+				suppressionsService.applySuppressions(results, suppressions);
+
+			assert.strictEqual(newResults[0].messages.length, 0);
+			assert.deepStrictEqual(unused, {
+				[relPath]: { "no-console": { count: 1 } },
+			});
+		});
+
+		it("should skip files that have no matching suppressions", () => {
+			const cwd = path.resolve("/project");
+			const suppressionsService = new SuppressionsService({
+				filePath: path.join(cwd, "eslint-suppressions.json"),
+				cwd,
+			});
+			const suppressions = {
+				"other/file.js": { "no-console": { count: 1 } },
+			};
+			const results = [
+				createResult({
+					filePath: path.join(cwd, "src", "app.js"),
+					messages: [createMessage("no-console")],
+				}),
+			];
+
+			const { results: newResults, unused } =
+				suppressionsService.applySuppressions(results, suppressions);
+
+			// Messages should remain untouched
+			assert.strictEqual(newResults[0].messages.length, 1);
+			assert.strictEqual(newResults[0].suppressedMessages.length, 0);
+			assert.strictEqual(newResults[0].errorCount, 1);
+			assert.deepStrictEqual(unused, {});
+		});
+
+		it("should not mutate the original results array", () => {
+			const cwd = path.resolve("/project");
+			const suppressionsService = new SuppressionsService({
+				filePath: path.join(cwd, "eslint-suppressions.json"),
+				cwd,
+			});
+			const relPath = path.posix.join("src", "app.js");
+			const suppressions = {
+				[relPath]: { "no-console": { count: 2 } },
+			};
+			const originalMessages = [
+				createMessage("no-console"),
+				createMessage("no-console"),
+			];
+			const results = [
+				createResult({
+					filePath: path.join(cwd, "src", "app.js"),
+					messages: originalMessages,
+				}),
+			];
+
+			suppressionsService.applySuppressions(results, suppressions);
+
+			// The original results array must remain unmodified
+			assert.strictEqual(
+				results[0].messages.length,
+				2,
+				"Expected original messages to remain unmodified",
+			);
+			assert.strictEqual(
+				results[0].suppressedMessages.length,
+				0,
+				"Expected original suppressedMessages to remain unmodified",
+			);
+		});
+	});
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:
Add unit tests for `SuppressionsService.applySuppressions()`.

#### What changes did you make? (Give an overview)

This is the **final follow-up** to #20734 (`load()`), #20765 (`suppress()`), #20797 (`prune()`), and #20802 (`save()`), completing the full unit test coverage of `SuppressionsService`.

This PR adds unit tests for the `applySuppressions()` method in `lib/services/suppressions-service.js`:

| Test Case | Code Path | What It Verifies |
|---|---|---|
| Suppress/report threshold | `violationsCount <= suppressionsCount` vs `>` | Messages are correctly suppressed or left as-is based on whether violations exceed the suppression count |
| Unused suppression tracking | `violationsCount < suppressionsCount` and unmatched rules | The `unused` return value correctly reflects the difference and fully unmatched suppressions |
| File not in suppressions | `!suppressions[relativeFilePath]` → `continue` | Messages are left untouched when the file has no matching suppressions |
| Non-mutation guarantee | `structuredClone(results)` | The original `results` array is not modified by the method |

Since `applySuppressions()` is a pure synchronous method, tests call it directly with crafted inputs without needing `sinon` stubs.

With this PR, all public methods of `SuppressionsService` now have dedicated test coverage:

| Method | PR |
|---|---|
| `load()` | #20734 |
| `suppress()` | #20765 |
| `prune()` | #20797 |
| `save()` | #20802 |
| `applySuppressions()` | This PR |

The remaining helper methods (`countViolationsByRule`, `suppressMessagesByRule`, `getRelativeFilePath`) are all exercised indirectly through the tests above.

#### Is there anything you'd like reviewers to focus on?

The tests cover all branches in the method, including the early `continue` for unmatched files, the suppress-vs-report threshold, and the `structuredClone` non-mutation guarantee.

<!-- markdownlint-disable-file MD004 -->
