### PR TITLE
fix: detect unmodified variables in ternaries in no-unmodified-loop-c…

### DIFF
--- a/docs/src/rules/no-unmodified-loop-condition.md
+++ b/docs/src/rules/no-unmodified-loop-condition.md
@@ -25,7 +25,7 @@ while (node) {
 This rule finds references which are inside of loop conditions, then checks the
 variables of those references are modified in the loop.
 
-If a reference is inside of a binary expression, this rule checks the result of
+If a reference is inside of a binary expression or a ternary expression, this rule checks the result of
 the expression instead (it's OK if any of the operands is modified).
 If a reference is inside of a dynamic expression (e.g. `CallExpression`,
 `YieldExpression`, ...), this rule ignores it.
@@ -84,10 +84,11 @@ while (node !== root) {
     node = node.parent;
 }
 
-// OK, "node" is modified.
-while (node ? true : false) {
-    doSomething(node);
-    node = node.parent;
+// OK, all three variables are modified in this loop.
+while (node ? A : B) {
+    node = node.next;
+    A = getA();
+    B = getB();
 }
 
 // A property might be a getter which has side effect...

--- a/docs/src/rules/no-unmodified-loop-condition.md
+++ b/docs/src/rules/no-unmodified-loop-condition.md
@@ -25,8 +25,8 @@ while (node) {
 This rule finds references which are inside of loop conditions, then checks the
 variables of those references are modified in the loop.
 
-If a reference is inside of a binary expression or a ternary expression, this rule checks the result of
-the expression instead.
+If a reference is inside of a binary expression, this rule checks the result of
+the expression instead (it's OK if any of the operands is modified).
 If a reference is inside of a dynamic expression (e.g. `CallExpression`,
 `YieldExpression`, ...), this rule ignores it.
 
@@ -50,6 +50,13 @@ for (let j = 0; j < 5;) {
 
 while (node !== root) {
     doSomething(node);
+}
+
+let done = false;
+// "done" is not modified.
+while (node ? !done : false) {
+    doSomething(node);
+    node = node.parent;
 }
 ```
 
@@ -77,8 +84,8 @@ while (node !== root) {
     node = node.parent;
 }
 
-// OK, the result of this ternary expression is changed in this loop.
-while (node ? A : B) {
+// OK, "node" is modified.
+while (node ? true : false) {
     doSomething(node);
     node = node.parent;
 }

--- a/lib/rules/no-unmodified-loop-condition.js
+++ b/lib/rules/no-unmodified-loop-condition.js
@@ -26,7 +26,6 @@ const Traverser = require("../shared/traverser"),
 const SENTINEL_PATTERN =
 	/(?:(?:Call|Class|Function|Member|New|Yield)Expression|Statement|Declaration)$/u;
 const LOOP_PATTERN = /^(?:DoWhile|For|While)Statement$/u; // for-in/of statements don't have `test` property.
-const GROUP_PATTERN = /^BinaryExpression$/u;
 const SKIP_PATTERN = /^(?:ArrowFunction|Class|Function)Expression$/u;
 const DYNAMIC_PATTERN = /^(?:Call|Member|New|TaggedTemplate|Yield)Expression$/u;
 
@@ -308,7 +307,7 @@ module.exports = {
 				 * If it's inside of a group, OK if either operand is modified.
 				 * So stores the group this reference belongs to.
 				 */
-				if (GROUP_PATTERN.test(node.type)) {
+				if (node.type === "BinaryExpression") {
 					// If this expression is dynamic, no need to check.
 					if (hasDynamicExpressions(node)) {
 						break;

--- a/lib/rules/no-unmodified-loop-condition.js
+++ b/lib/rules/no-unmodified-loop-condition.js
@@ -26,14 +26,14 @@ const Traverser = require("../shared/traverser"),
 const SENTINEL_PATTERN =
 	/(?:(?:Call|Class|Function|Member|New|Yield)Expression|Statement|Declaration)$/u;
 const LOOP_PATTERN = /^(?:DoWhile|For|While)Statement$/u; // for-in/of statements don't have `test` property.
-const GROUP_PATTERN = /^(?:BinaryExpression|ConditionalExpression)$/u;
+const GROUP_PATTERN = /^BinaryExpression$/u;
 const SKIP_PATTERN = /^(?:ArrowFunction|Class|Function)Expression$/u;
 const DYNAMIC_PATTERN = /^(?:Call|Member|New|TaggedTemplate|Yield)Expression$/u;
 
 /**
  * @typedef {Object} LoopConditionInfo
  * @property {Reference} reference - The reference.
- * @property {ASTNode} group - BinaryExpression or ConditionalExpression nodes
+ * @property {ASTNode} group - BinaryExpression node
  *      that the reference is belonging to.
  * @property {Function} isInLoop - The predicate which checks a given reference
  *      is in this loop.
@@ -253,7 +253,7 @@ module.exports = {
 		/**
 		 * Checks whether or not a given group node has any dynamic elements.
 		 * @param {ASTNode} root A node to check.
-		 *      This node is one of BinaryExpression or ConditionalExpression.
+		 *      This node is a BinaryExpression.
 		 * @returns {boolean} `true` if the node is dynamic.
 		 */
 		function hasDynamicExpressions(root) {

--- a/tests/lib/rules/no-unmodified-loop-condition.js
+++ b/tests/lib/rules/no-unmodified-loop-condition.js
@@ -48,6 +48,7 @@ ruleTester.run("no-unmodified-loop-condition", rule, {
 		"var foo = 0; while (foo.ok) { }",
 		"var foo = 0; while (foo) { update(); } function update() { ++foo; }",
 		"var foo = 0, bar = 9; while (foo < bar) { foo += 1; }",
+		"var foo = 0, bar = 1, baz = 2; while (foo ? bar : baz) { foo += 1; bar += 1; baz += 1; }",
 		"var foo = 0, bar = 0; while (foo && bar) { ++foo; ++bar; }",
 		"var foo = 0, bar = 0; while (foo || bar) { ++foo; ++bar; }",
 		"var foo = 0; do { ++foo; } while (foo);",

--- a/tests/lib/rules/no-unmodified-loop-condition.js
+++ b/tests/lib/rules/no-unmodified-loop-condition.js
@@ -48,7 +48,6 @@ ruleTester.run("no-unmodified-loop-condition", rule, {
 		"var foo = 0; while (foo.ok) { }",
 		"var foo = 0; while (foo) { update(); } function update() { ++foo; }",
 		"var foo = 0, bar = 9; while (foo < bar) { foo += 1; }",
-		"var foo = 0, bar = 1, baz = 2; while (foo ? bar : baz) { foo += 1; }",
 		"var foo = 0, bar = 0; while (foo && bar) { ++foo; ++bar; }",
 		"var foo = 0, bar = 0; while (foo || bar) { ++foo; ++bar; }",
 		"var foo = 0; do { ++foo; } while (foo);",
@@ -131,6 +130,29 @@ ruleTester.run("no-unmodified-loop-condition", rule, {
 				{
 					messageId: "loopConditionNotModified",
 					data: { name: "foo" },
+				},
+			],
+		},
+		{
+			code: "var foo = 0, bar = 1, baz = 2; while (foo ? bar : baz) { foo += 1; }",
+			errors: [
+				{
+					messageId: "loopConditionNotModified",
+					data: { name: "bar" },
+				},
+				{
+					messageId: "loopConditionNotModified",
+					data: { name: "baz" },
+				},
+			],
+		},
+		{
+			code: "let chunk = nextOrNull(); let done = false; while (chunk ? !done : false) { chunk = nextOrNull(); }",
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "loopConditionNotModified",
+					data: { name: "done" },
 				},
 			],
 		},


### PR DESCRIPTION

<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes a `ConditionalExpression` false negative in the `no-unmodified-loop-condition` rule identified in [#20844](https://github.com/eslint/eslint/issues/20844).

#### What changes did you make? (Give an overview)

`ConditionalExpression` was included in `GROUP_PATTERN` alongside `BinaryExpression`. This caused the rule to treat all references within a ternary (`foo ? bar : baz`) as a single group — if **any** variable in the group was modified, **none** were reported.

This is correct for `BinaryExpression` (e.g. `i < n` — modifying `i` makes the whole expression dynamic), but incorrect for `ConditionalExpression`. In `foo ? bar : baz`, modifying `foo` (the test) does not make `bar` or `baz` dynamic — they are still constant values evaluated independently.

**Changes:**

1. **`lib/rules/no-unmodified-loop-condition.js`** — Removed `ConditionalExpression` from `GROUP_PATTERN` so each ternary operand is checked independently. Updated two JSDoc comments that referenced the old grouping.

2. **`tests/lib/rules/no-unmodified-loop-condition.js`** — Moved the existing valid ternary case to invalid (it now correctly reports `bar` and `baz`). Added a test for the exact reproduction case from the issue (`chunk ? !done : false`).

3. **`docs/src/rules/no-unmodified-loop-condition.md`** — Updated the rule description to reflect that only binary expressions are grouped. Added `chunk ? !done : false` as an incorrect example. Updated the correct ternary example's comment for clarity.

#### Is there anything you'd like reviewers to focus on?

1. Whether the documentation wording accurately describes the new behavior — specifically the updated sentence about binary expressions on line 28–29.

2. The valid test suite currently has no ternary coverage since the old valid case was moved to invalid. Would it be worth adding a valid counterpart like:
   ```js
   "var foo = 0; while (foo ? 1 : 0) { foo += 1; }"
   ```
   This would guard against future false-positive regressions on ternaries, confirming that a modified variable in a ternary's test position still passes correctly. It's also consistent with the existing docs example (`while (node ? true : false)`).

<!-- markdownlint-disable-file MD004 -->
