### PR TITLE
fix: escape code path DOT labels in debug output

### DIFF
--- a/lib/linter/code-path-analysis/debug-helpers.js
+++ b/lib/linter/code-path-analysis/debug-helpers.js
@@ -45,6 +45,15 @@ function nodeToString(node, label) {
 	}
 }
 
+/**
+ * Escape text for use in a DOT label.
+ * @param {string} value The value to escape.
+ * @returns {string} The escaped value.
+ */
+function escapeDotLabelText(value) {
+	return value.replace(/\\/gu, String.raw`\\`).replace(/"/gu, String.raw`\"`);
+}
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -147,7 +156,9 @@ module.exports = {
 					}
 
 					if (segment.internal.nodes.length > 0) {
-						text += segment.internal.nodes.join("\\n");
+						text += segment.internal.nodes
+							.map(escapeDotLabelText)
+							.join("\\n");
 					} else {
 						text += "????";
 					}

--- a/tests/lib/linter/code-path-analysis/debug-helpers.js
+++ b/tests/lib/linter/code-path-analysis/debug-helpers.js
@@ -1,0 +1,65 @@
+/**
+ * @fileoverview Tests for debug helpers.
+ * @author Pixel998
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const assert = require("node:assert");
+const proxyquire = require("proxyquire").noCallThru();
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("debug-helpers", () => {
+	describe("dumpDot()", () => {
+		it("should escape DOT label text", () => {
+			let debugCall;
+
+			/**
+			 * Capture debug calls.
+			 * @param {...any} args The arguments passed to debug.
+			 * @returns {void}
+			 */
+			function debugLog(...args) {
+				debugCall = args;
+			}
+
+			debugLog.enabled = true;
+
+			const debugHelpers = proxyquire(
+				"../../../../lib/linter/code-path-analysis/debug-helpers",
+				{
+					debug: () => debugLog,
+				},
+			);
+			const segment = {
+				id: "s1_1",
+				reachable: true,
+				internal: {
+					nodes: ['Literal (")', "Literal (\\)"],
+				},
+				allNextSegments: [],
+			};
+			const codePath = {
+				initialSegment: segment,
+				returnedSegments: [segment],
+				thrownSegments: [],
+			};
+			const expectedLabel = [
+				's1_1[label="Literal (\\")',
+				'Literal (\\\\)"];',
+			].join("\\n");
+
+			debugHelpers.dumpDot(codePath);
+
+			assert.strictEqual(debugCall[0], "DOT");
+			assert.ok(debugCall[1].includes(expectedLabel));
+		});
+	});
+});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What did you do? Please include the actual source code causing the issue.**

I used code path DOT debug output with code containing a string literal with a double quote, for example:

```js
const value = '"';
```

**What did you expect to happen?**

The generated code path DOT output should be syntactically valid.

**What actually happened? Please include the actual, raw output from ESLint.**

Node labels in the generated DOT output contain unescaped double quote, producing invalid DOT labels.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

- Added an `escapeDotLabelText` helper that escapes `\` and `"` in DOT label text.

#### Related Issues

https://github.com/eslint/code-explorer/pull/415

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
