### PR TITLE
test: add unit test for message-count

### DIFF
--- a/tests/lib/shared/message-counts.js
+++ b/tests/lib/shared/message-counts.js
@@ -1,0 +1,62 @@
+/**
+ * @fileoverview Tests for message-counts util.
+ * @author Kuldeep Kumar <https://github.com/Kuldeep2822k>
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const { assert } = require("chai");
+const { calculateStatsPerFile } = require("../../../lib/shared/message-counts");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("message-counts", () => {
+	describe("calculateStatsPerFile()", () => {
+		it("should return zero counts for an empty message list", () => {
+			assert.deepStrictEqual(calculateStatsPerFile([]), {
+				errorCount: 0,
+				fatalErrorCount: 0,
+				warningCount: 0,
+				fixableErrorCount: 0,
+				fixableWarningCount: 0,
+			});
+		});
+
+		it("should count errors, warnings, fatal errors, and fixable messages correctly", () => {
+			const messages = [
+				{ severity: 2 },
+				{ severity: 2, fix: { range: [0, 1], text: "x" } },
+				{ fatal: true },
+				{ fatal: true, fix: { range: [1, 2], text: "y" } },
+				{ severity: 1 },
+				{ severity: 1, fix: { range: [2, 3], text: "z" } },
+			];
+
+			assert.deepStrictEqual(calculateStatsPerFile(messages), {
+				errorCount: 4,
+				fatalErrorCount: 2,
+				warningCount: 2,
+				fixableErrorCount: 2,
+				fixableWarningCount: 1,
+			});
+		});
+
+		it("should treat fatal messages as errors even when severity is not 2", () => {
+			const messages = [{ fatal: true, severity: 1 }];
+
+			assert.deepStrictEqual(calculateStatsPerFile(messages), {
+				errorCount: 1,
+				fatalErrorCount: 1,
+				warningCount: 0,
+				fixableErrorCount: 0,
+				fixableWarningCount: 0,
+			});
+		});
+	});
+});


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix
[ ] New rule
[ ] Changes an existing rule
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Adds unit tests for `lib/shared/message-counts.js` which currently has no test coverage.

#### What changes did you make? (Give an overview)

Added `tests/lib/shared/message-counts.js` with tests for `calculateStatsPerFile()` covering:
- Empty message array
- Mixed severity, fatal, and fixable messages
- Edge case where `fatal: true` overrides a lower severity value

#### Is there anything you'd like reviewers to focus on?

Nothing specific — straightforward test addition.

