### PR TITLE
docs: switch build to Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
             - uses: actions/checkout@v6
             - uses: actions/setup-node@v6
               with:
-                  node-version: "20" # Should be the same as the version used on Netlify to build the ESLint Playground
+                  node-version: "24" # Should be the same as the version used on Netlify to build the ESLint Playground
             - name: Install Packages
               run: npm install
             - name: Test

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -21,7 +21,7 @@ jobs:
             - uses: actions/checkout@v6
             - uses: actions/setup-node@v6
               with:
-                  node-version: "lts/*"
+                  node-version: "24" # Should be the same as the version used on Netlify to build the docs site
 
             - name: Install Docs Packages
               working-directory: docs

--- a/docs/package.json
+++ b/docs/package.json
@@ -57,7 +57,7 @@
         "tap-spot": "^1.1.2"
     },
     "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": ">=24"
     },
     "browserslist": [
         "defaults",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Updates the docs site to use Node.js 24.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

I've already updated configuration on Netlify to use Node.js 24.

This PR:

1. Updates `engines` in docs/package.json to require Node >= 24.
2. Updates browser test to use Node 24, as we'll use this version on eslint.org to build the Playground.
3. Updates docs-ci to pin Node 24 instead of LTS (which would become Node 26 at some point). Let me know if this change makes sense.

#### Is there anything you'd like reviewers to focus on?

PR for v9.x-dev branch update: https://github.com/eslint/eslint/pull/20894

PR for v8.x branch test: https://github.com/eslint/eslint/pull/20896

<!-- markdownlint-disable-file MD004 -->
