### PR TITLE
docs: fix `display: none` of ad

### DIFF
--- a/docs/src/assets/scss/ads.scss
+++ b/docs/src/assets/scss/ads.scss
@@ -1,11 +1,9 @@
-.hero-ad {
+.docs-ad {
+	height: 290px;
+
 	@media all and (max-width: 800px) {
 		display: none;
 	}
-}
-
-.docs-ad {
-	height: 290px;
 }
 
 /*


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Added `display: none` to `.docs-ad` as there is a gap in the footer because of the ad div in mobile size.

Right now
<img width="458" height="499" alt="Screenshot 2026-05-21 205353" src="https://github.com/user-attachments/assets/744f557f-2461-42ca-bca5-962ac1ad171f" />

After this PR
<img width="447" height="428" alt="Screenshot 2026-05-21 205310" src="https://github.com/user-attachments/assets/933f8cd1-4f6e-445e-a8c9-2ac240e378dc" />


#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
