### PR TITLE
fix: skip invalid async comment autofix in prefer-arrow-callback

### DIFF
--- a/lib/rules/prefer-arrow-callback.js
+++ b/lib/rules/prefer-arrow-callback.js
@@ -386,13 +386,26 @@ module.exports = {
 							const tokenBeforeBody = sourceCode.getTokenBefore(
 								node.body,
 							);
-
-							if (
+							const hasCommentsBetweenFunctionAndParams =
 								sourceCode.commentsExistBetween(
 									functionToken,
 									leftParenToken,
+								);
+
+							if (
+								node.async &&
+								hasCommentsBetweenFunctionAndParams &&
+								astUtils.LINEBREAK_MATCHER.test(
+									sourceCode.text.slice(
+										functionToken.range[1],
+										leftParenToken.range[0],
+									),
 								)
 							) {
+								return;
+							}
+
+							if (hasCommentsBetweenFunctionAndParams) {
 								// Remove only extra tokens to keep comments.
 								yield fixer.remove(functionToken);
 								if (node.id) {

--- a/tests/lib/rules/prefer-arrow-callback.js
+++ b/tests/lib/rules/prefer-arrow-callback.js
@@ -176,6 +176,18 @@ ruleTester.run("prefer-arrow-callback", rule, {
 			errors,
 		},
 		{
+			code: `qux(async function /* Lorem ipsum
+dolor sit amet. */ (foo) { return foo; })`,
+			output: null,
+			errors,
+		},
+		{
+			code: `qux(async function // Lorem ipsum
+(foo) { return foo; })`,
+			output: null,
+			errors,
+		},
+		{
 			code: "qux(async function (foo = 1, bar = 2, baz = 3) { return this; }.bind(this))",
 			output: "qux(async (foo = 1, bar = 2, baz = 3) => { return this; })",
 			errors,


### PR DESCRIPTION
Fixes #20913.

The `prefer-arrow-callback` fixer preserves comments between the `function` keyword and the parameter list. For async functions, preserving a multiline comment or line comment in that position can leave a line break after `async`, producing invalid output.

This change skips autofix for async function expressions when there is a comment and a line break between `function` and the parameter list. Same-line comment cases remain fixable.

Validation:
- `npx mocha tests/lib/rules/prefer-arrow-callback.js`
- `npx prettier --check lib/rules/prefer-arrow-callback.js tests/lib/rules/prefer-arrow-callback.js`
- `npx eslint lib/rules/prefer-arrow-callback.js tests/lib/rules/prefer-arrow-callback.js`