### PR TITLE
fix: prefer-arrow-callback invalid autofix with newline after `async`

### DIFF
--- a/lib/rules/prefer-arrow-callback.js
+++ b/lib/rules/prefer-arrow-callback.js
@@ -333,7 +333,6 @@ module.exports = {
 							);
 
 							if (node.async) {
-								
 								if (
 									functionToken.loc.end.line <
 									leftParenToken.loc.start.line

--- a/lib/rules/prefer-arrow-callback.js
+++ b/lib/rules/prefer-arrow-callback.js
@@ -333,13 +333,10 @@ module.exports = {
 							);
 
 							if (node.async) {
-								const textBetween = sourceCode.text.slice(
-									functionToken.range[1],
-									leftParenToken.range[0],
-								);
-
+								
 								if (
-									astUtils.LINEBREAK_MATCHER.test(textBetween)
+									functionToken.loc.end.line <
+									leftParenToken.loc.start.line
 								) {
 									return;
 								}

--- a/lib/rules/prefer-arrow-callback.js
+++ b/lib/rules/prefer-arrow-callback.js
@@ -323,6 +323,28 @@ module.exports = {
 								return;
 							}
 
+							const functionToken = sourceCode.getFirstToken(
+								node,
+								node.async ? 1 : 0,
+							);
+							const leftParenToken = sourceCode.getTokenAfter(
+								functionToken,
+								astUtils.isOpeningParenToken,
+							);
+
+							if (node.async) {
+								const textBetween = sourceCode.text.slice(
+									functionToken.range[1],
+									leftParenToken.range[0],
+								);
+
+								if (
+									astUtils.LINEBREAK_MATCHER.test(textBetween)
+								) {
+									return;
+								}
+							}
+
 							// Remove `.bind(this)` if exists.
 							if (callbackInfo.isLexicalThis) {
 								const memberNode = node.parent;
@@ -375,14 +397,6 @@ module.exports = {
 							}
 
 							// Convert the function expression to an arrow function.
-							const functionToken = sourceCode.getFirstToken(
-								node,
-								node.async ? 1 : 0,
-							);
-							const leftParenToken = sourceCode.getTokenAfter(
-								functionToken,
-								astUtils.isOpeningParenToken,
-							);
 							const tokenBeforeBody = sourceCode.getTokenBefore(
 								node.body,
 							);

--- a/tests/lib/rules/prefer-arrow-callback.js
+++ b/tests/lib/rules/prefer-arrow-callback.js
@@ -181,6 +181,26 @@ ruleTester.run("prefer-arrow-callback", rule, {
 			errors,
 		},
 		{
+			code: "foo(async function /*\n*/ () { return 1; });",
+			output: null,
+			errors,
+		},
+		{
+			code: "foo(async function // c\n () { return 1; });",
+			output: null,
+			errors,
+		},
+		{
+			code: "foo(async function\n () { return 1; });",
+			output: null,
+			errors,
+		},
+		{
+			code: "foo(async function /* c */ () { return 1; });",
+			output: "foo(async  /* c */ () => { return 1; });",
+			errors,
+		},
+		{
 			code: "foo((bar || function() {}).bind(this))",
 			output: null,
 			errors,


### PR DESCRIPTION
<!--
Thank you for contributing!

ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did *not* use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
The following template is intentionally not a markdown checkbox list for the reasons
explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #20913.

<!--
Please ensure your pull request is ready:

- Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
- Include tests for this change
- Update documentation for this change (if appropriate)
-->

<!--
The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

`prefer-arrow-callback` could produce unparseable JavaScript when autofixing an `async function` callback if a line terminator (plain whitespace, a line comment, or a multi-line block comment) sat between the `function` keyword and the opening parenthesis of the parameter list. The post-fix source placed those characters between `async` and the arrow head's `(`, which violates the ECMA-262 AsyncArrowFunction `[no LineTerminator here]` restriction.

The fix adds a guard at the top of the existing fixer. For async callbacks, if `astUtils.LINEBREAK_MATCHER` finds a line terminator in the source slice between the `function` keyword and the parameter list's `(`, the generator returns early without yielding any fixes. The rule still reports the violation; only the unsafe autofix is skipped. Behaviour for non-async callbacks and for async callbacks without an intervening line terminator is unchanged.

This matches the direction @mdjermanovic outlined in
https://github.com/eslint/eslint/issues/20913#issuecomment-4536976164.

Tests added to `tests/lib/rules/prefer-arrow-callback.js`:

- Block comment containing `\n` between `function` and `(` -> `output: null`
- Line comment between `function` and `(` -> `output: null`
- Plain whitespace newline between `function` and `(` -> `output: null`
- Control case: single-line block comment between `function` and `(` with no
  newline -> still autofixes as before, proving the guard is not over-broad

#### Is there anything you'd like reviewers to focus on?

- The fixer is a generator method, so the guard uses a bare `return;` rather than `return null;` to satisfy `consistent-return`. An empty-yielding generator produces the same observable behaviour as a `null`-returning fixer (no fix applied), and the `output: null` test assertions confirm this.
- Using `astUtils.LINEBREAK_MATCHER` on the raw source slice catches all line-terminator forms (LF, CRLF, LS, PS) and naturally covers both comment-internal newlines and bare-whitespace newlines without needing to enumerate comment node types.
- The guard is scoped to `node.async` only -- the spec's `[no LineTerminator here]` restriction is specific to AsyncArrowFunction, so non-async callbacks need no such guard.

<!-- markdownlint-disable-file MD004 -->
