### PR TITLE
ci: declare contents:read on update-readme workflow

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -4,6 +4,9 @@ on:
     schedule:
         - cron: "0 8 * * *" # Every day at 1am PDT
 
+permissions:
+    contents: read
+
 jobs:
     build:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on the `update-readme` workflow. The workflow runs a script to regenerate the README; no GitHub API writes from the workflow itself.

Reopen of #20872 which auto-closed when a recovery force-push made the previous PR HEAD unreachable. Same scope, same intent, fresh branch.

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML 4-space indent matches existing repo style.