### PR TITLE
fix: report initializer callbacks in no-use-before-define

### DIFF
--- a/docs/src/rules/no-use-before-define.md
+++ b/docs/src/rules/no-use-before-define.md
@@ -131,6 +131,7 @@ export { foo };
         "classes": true,
         "variables": true,
         "allowNamedExports": false,
+        "allowDeferredReferences": true,
         "enums": true,
         "typedefs": true,
         "ignoreTypeReferences": true
@@ -159,6 +160,10 @@ export { foo };
   If this flag is set to `true`, the rule always allows references in `export {};` declarations.
   These references are safe even if the variables are declared later in the code.
   Default is `false`.
+* `allowDeferredReferences` (`boolean`) -
+  If this flag is set to `true`, the rule allows references in function expressions in variable initializers when the function might be called later.
+  If this is `false`, the rule also reports these references when the function expression is immediately invoked or is passed to a call or constructor during initialization.
+  Default is `true`.
 
 This rule additionally supports TypeScript type syntax. The following options enable checking for the references to `type`, `interface` and `enum` declarations:
 
@@ -173,7 +178,7 @@ This rule additionally supports TypeScript type syntax. The following options en
   Default is `true`.
 
 This rule accepts `"nofunc"` string as an option.
-`"nofunc"` is the same as `{ "functions": false, "classes": true, "variables": true, "allowNamedExports": false, "enums": true, "typedefs": true, "ignoreTypeReferences": true }`.
+`"nofunc"` is the same as `{ "functions": false, "classes": true, "variables": true, "allowNamedExports": false, "allowDeferredReferences": true, "enums": true, "typedefs": true, "ignoreTypeReferences": true }`.
 
 ### functions
 
@@ -362,6 +367,62 @@ export function foo() {
     return d;
 }
 const d = 1;
+```
+
+:::
+
+### allowDeferredReferences
+
+Examples of **incorrect** code for the `{ "allowDeferredReferences": false }` option:
+
+::: incorrect
+
+```js
+/*eslint no-use-before-define: ["error", { "allowDeferredReferences": false }]*/
+
+const a = test(value => a);
+
+const b = (() => b)();
+
+const c = new Test(() => c);
+
+const d = array.map(value => d.length);
+```
+
+:::
+
+Examples of **correct** code for the `{ "allowDeferredReferences": false }` option:
+
+::: correct
+
+```js
+/*eslint no-use-before-define: ["error", { "allowDeferredReferences": false }]*/
+
+const a = () => a;
+
+const b = function() {
+    return b;
+};
+
+const c = [() => c];
+
+const d = {
+    getD() {
+        return d;
+    }
+};
+```
+
+:::
+
+Examples of **correct** code for the `{ "allowDeferredReferences": true }` option:
+
+::: correct
+
+```js
+/*eslint no-use-before-define: ["error", { "allowDeferredReferences": true }]*/
+
+const a = test(value => a);
 ```
 
 :::

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -19,6 +19,8 @@
 const SENTINEL_TYPE =
 	/^(?:(?:Function|Class)(?:Declaration|Expression)|ArrowFunctionExpression|CatchClause|ImportDeclaration|ExportNamedDeclaration)$/u;
 const FOR_IN_OF_TYPE = /^For(?:In|Of)Statement$/u;
+const FUNCTION_TYPE =
+	/^(?:Function(?:Declaration|Expression)|ArrowFunctionExpression)$/u;
 
 /**
  * Parses a given value as options.
@@ -37,6 +39,7 @@ function parseOptions(options) {
 		classes: true,
 		variables: true,
 		allowNamedExports: false,
+		allowDeferredReferences: true,
 		enums: true,
 		typedefs: true,
 		ignoreTypeReferences: true,
@@ -51,6 +54,30 @@ function parseOptions(options) {
  */
 function isInRange(node, location) {
 	return node && node.range[0] <= location && location <= node.range[1];
+}
+
+/**
+ * Checks whether or not a given node is inside of the range of another node.
+ * @param {ASTNode} outerNode The node to check against.
+ * @param {ASTNode} innerNode The node to check.
+ * @returns {boolean} `true` if innerNode is inside of outerNode.
+ */
+function containsNode(outerNode, innerNode) {
+	return (
+		outerNode &&
+		innerNode &&
+		outerNode.range[0] <= innerNode.range[0] &&
+		innerNode.range[1] <= outerNode.range[1]
+	);
+}
+
+/**
+ * Checks whether or not a given node is a function node.
+ * @param {ASTNode} node A node to check.
+ * @returns {boolean} `true` if the node is a function node.
+ */
+function isFunctionNode(node) {
+	return node && FUNCTION_TYPE.test(node.type);
 }
 
 /**
@@ -146,6 +173,104 @@ function isFromSeparateExecutionContext(reference) {
 }
 
 /**
+ * Gets the variable initializer that contains a given reference.
+ * @param {Reference} reference A reference to check.
+ * @returns {ASTNode|null} The variable initializer, or null if there isn't one.
+ */
+function getVariableInitializer(reference) {
+	const definition = reference.resolved.defs[0];
+
+	if (
+		definition.type !== "Variable" ||
+		definition.node.type !== "VariableDeclarator" ||
+		!definition.node.init ||
+		!containsNode(definition.node.init, reference.identifier)
+	) {
+		return null;
+	}
+
+	return definition.node.init;
+}
+
+/**
+ * Gets the function that contains a given node.
+ * @param {ASTNode} node A node to check.
+ * @returns {ASTNode|null} The containing function, or null if there isn't one.
+ */
+function getContainingFunction(node) {
+	let currentNode = node.parent;
+
+	while (currentNode) {
+		if (isFunctionNode(currentNode)) {
+			return currentNode;
+		}
+
+		currentNode = currentNode.parent;
+	}
+
+	return null;
+}
+
+/**
+ * Checks whether a node is within a call or constructor argument.
+ * @param {ASTNode} expression A `CallExpression` or `NewExpression` node.
+ * @param {ASTNode} node A node to check.
+ * @returns {boolean} `true` if the node is within an argument.
+ */
+function isInArgumentList(expression, node) {
+	return expression.arguments.some(argument => containsNode(argument, node));
+}
+
+/**
+ * Checks whether a reference in a separate execution context can be evaluated
+ * while its own variable initializer is being evaluated.
+ * @param {Reference} reference A reference to check.
+ * @returns {boolean} `true` if the reference can be evaluated during initialization.
+ */
+function isPossiblyEvaluatedDuringInitialization(reference) {
+	const initializer = getVariableInitializer(reference);
+
+	if (!initializer) {
+		return false;
+	}
+
+	const containingFunction = getContainingFunction(reference.identifier);
+
+	if (!containsNode(initializer, containingFunction)) {
+		return false;
+	}
+
+	let node = containingFunction;
+
+	while (node && node !== initializer) {
+		const parent = node.parent;
+
+		if (!parent) {
+			return false;
+		}
+
+		if (parent !== initializer && isFunctionNode(parent)) {
+			return false;
+		}
+
+		if (
+			parent.type === "CallExpression" ||
+			parent.type === "NewExpression"
+		) {
+			return parent.callee === node || isInArgumentList(parent, node);
+		}
+
+		if (parent.type === "TaggedTemplateExpression") {
+			return true;
+		}
+
+		node = parent;
+	}
+
+	return false;
+}
+
+/**
  * Checks whether or not a given reference is evaluated during the initialization of its variable.
  *
  * This returns `true` in the following cases:
@@ -162,10 +287,18 @@ function isFromSeparateExecutionContext(reference) {
  *     class C extends (class { static foo = C; }) {}
  *     class C { [C]; }
  * @param {Reference} reference A reference to check.
+ * @param {Object} options The rule options.
  * @returns {boolean} `true` if the reference is evaluated during the initialization.
  */
-function isEvaluatedDuringInitialization(reference) {
+function isEvaluatedDuringInitialization(reference, options) {
 	if (isFromSeparateExecutionContext(reference)) {
+		if (
+			!options.allowDeferredReferences &&
+			isPossiblyEvaluatedDuringInitialization(reference)
+		) {
+			return true;
+		}
+
 		/*
 		 * Even if the reference appears in the initializer, it isn't evaluated during the initialization.
 		 * For example, `const x = () => x;` is valid.
@@ -299,6 +432,7 @@ module.exports = {
 							classes: { type: "boolean" },
 							variables: { type: "boolean" },
 							allowNamedExports: { type: "boolean" },
+							allowDeferredReferences: { type: "boolean" },
 							enums: { type: "boolean" },
 							typedefs: { type: "boolean" },
 							ignoreTypeReferences: { type: "boolean" },
@@ -315,6 +449,7 @@ module.exports = {
 				functions: true,
 				variables: true,
 				allowNamedExports: false,
+				allowDeferredReferences: true,
 				enums: true,
 				typedefs: true,
 				ignoreTypeReferences: true,
@@ -373,7 +508,9 @@ module.exports = {
 				((!options.variables && definitionType === "Variable") ||
 					(!options.classes && definitionType === "ClassName")) &&
 				// don't skip checking the reference if it's in the same execution context, because of TDZ
-				isFromSeparateExecutionContext(reference)
+				isFromSeparateExecutionContext(reference) &&
+				(options.allowDeferredReferences ||
+					!isPossiblyEvaluatedDuringInitialization(reference))
 			) {
 				return false;
 			}
@@ -429,7 +566,7 @@ module.exports = {
 				if (
 					reference.identifier.range[1] <
 						definitionIdentifier.range[1] ||
-					(isEvaluatedDuringInitialization(reference) &&
+					(isEvaluatedDuringInitialization(reference, options) &&
 						reference.identifier.parent.type !== "TSTypeReference")
 				) {
 					context.report({

--- a/lib/types/rules.d.ts
+++ b/lib/types/rules.d.ts
@@ -4270,6 +4270,10 @@ export interface ESLintRules extends Linter.RulesRecord {
 					/**
 					 * @default true
 					 */
+					allowDeferredReferences: boolean;
+					/**
+					 * @default true
+					 */
 					enums: boolean;
 					/**
 					 * @default true

--- a/tests/lib/rules/no-use-before-define.js
+++ b/tests/lib/rules/no-use-before-define.js
@@ -453,6 +453,35 @@ ruleTester.run("no-use-before-define", rule, {
 				parserOptions: { ecmaFeatures: { jsx: true } },
 			},
 		},
+		{
+			code: "const a = test(t => a);",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "const a = () => a;",
+			options: [{ allowDeferredReferences: false }],
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "const a = function() { return a; };",
+			options: [{ allowDeferredReferences: false }],
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "const a = [() => a];",
+			options: [{ allowDeferredReferences: false }],
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "const a = { getA() { return a; } };",
+			options: [{ allowDeferredReferences: false }],
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "const a = test(() => () => a);",
+			options: [{ allowDeferredReferences: false }],
+			languageOptions: { ecmaVersion: 6 },
+		},
 	],
 	invalid: [
 		{
@@ -1711,6 +1740,94 @@ ruleTester.run("no-use-before-define", rule, {
 					column: 2,
 					endLine: 1,
 					endColumn: 5,
+				},
+			],
+		},
+		{
+			code: "const a = test(t => a);",
+			options: [{ allowDeferredReferences: false }],
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "usedBeforeDefined",
+					data: { name: "a" },
+				},
+			],
+		},
+		{
+			code: "const a = test(t => a);",
+			options: [{ allowDeferredReferences: false, variables: false }],
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "usedBeforeDefined",
+					data: { name: "a" },
+				},
+			],
+		},
+		{
+			code: "const a = test(arr, function(t) { return a; });",
+			options: [{ allowDeferredReferences: false }],
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "usedBeforeDefined",
+					data: { name: "a" },
+				},
+			],
+		},
+		{
+			code: "const a = (() => a)();",
+			options: [{ allowDeferredReferences: false }],
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "usedBeforeDefined",
+					data: { name: "a" },
+				},
+			],
+		},
+		{
+			code: "const a = new Test(() => a);",
+			options: [{ allowDeferredReferences: false }],
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "usedBeforeDefined",
+					data: { name: "a" },
+				},
+			],
+		},
+		{
+			code: "const a = test({ getA: () => a });",
+			options: [{ allowDeferredReferences: false }],
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "usedBeforeDefined",
+					data: { name: "a" },
+				},
+			],
+		},
+		{
+			code: "const a = array.map(x => a.length);",
+			options: [{ allowDeferredReferences: false }],
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "usedBeforeDefined",
+					data: { name: "a" },
+				},
+			],
+		},
+		{
+			code: "const a = tag`${() => a}`;",
+			options: [{ allowDeferredReferences: false }],
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "usedBeforeDefined",
+					data: { name: "a" },
 				},
 			],
 		},
@@ -3242,6 +3359,24 @@ type StringOrNumber = string | number;
 	alert(a?.b);
 	var a = { b: 5 };
 		  `,
+			errors: [
+				{
+					data: { name: "a" },
+					messageId: "usedBeforeDefined",
+				},
+			],
+		},
+		{
+			code: `
+	function testFunction<T, U>(array: T[], fn: (elem: T) => U): U[] {
+	  return array.map(fn);
+	}
+
+	const arr = [1, 2];
+	const a = testFunction(arr, value => a);
+		  `,
+			options: [{ allowDeferredReferences: false }],
+			languageOptions: { parserOptions },
 			errors: [
 				{
 					data: { name: "a" },


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### Why is this change needed?

Fixes #20014.

`no-use-before-define` currently treats all references inside a function expression in a variable initializer as deferred. That is correct for cases such as `const value = () => value`, because the function body cannot run until after the initializer completes.

The same assumption is too optimistic when the function expression is part of an initializer call, constructor call, tag call, or IIFE. In those cases, the initializer can run the function before the variable binding has been initialized, which creates the TDZ failure described in the issue.

Reporting these cases by default would change existing rule behavior, so this keeps the current default and adds `allowDeferredReferences`. Users can set it to `false` when they want the rule to treat initializer callbacks pessimistically.

The check is intentionally limited to places where initializer evaluation can immediately hand off or call the function expression. Direct function assignments, arrays or objects stored as values, and nested returned functions remain allowed because those references are still deferred by construction.

#### What would you like reviewers to focus on?

Please focus on whether the option boundary is narrow enough: it catches callbacks/IIFEs that can run during initialization while preserving the existing optimistic default and avoiding definitely deferred patterns.
