### PR TITLE
fix: handle ASI hazards in no-unused-vars removeVar suggestion

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -1062,35 +1062,26 @@ module.exports = {
 
 				const node = sourceCode.getNodeByRangeIndex(token.range[0]);
 
-				if (!node) {
-					return false;
-				}
+				switch (node.type) {
+					case "BlockStatement":
+						/*
+						 * Safe only if the block belongs to a statement construct,
+						 * not an expression (FunctionExpression, ArrowFunctionExpression)
+						 */
+						return (
+							node.parent.type !== "FunctionExpression" &&
+							node.parent.type !== "ArrowFunctionExpression"
+						);
 
-				if (node.type === "BlockStatement") {
-					/*
-					 * Safe only if the block belongs to a statement construct,
-					 * not an expression (FunctionExpression, ArrowFunctionExpression)
-					 */
-					return (
-						node.parent &&
-						node.parent.type !== "FunctionExpression" &&
-						node.parent.type !== "ArrowFunctionExpression"
-					);
-				}
+					case "ClassBody":
+						return node.parent.type === "ClassDeclaration";
 
-				// ClassBody from a ClassDeclaration (not ClassExpression)
-				if (node.type === "ClassBody") {
-					return (
-						node.parent && node.parent.type === "ClassDeclaration"
-					);
-				}
+					case "SwitchStatement":
+						return true;
 
-				// SwitchStatement closing brace
-				if (node.type === "SwitchStatement") {
-					return true;
+					default:
+						return false;
 				}
-
-				return false;
 			}
 
 			/**
@@ -1648,8 +1639,11 @@ module.exports = {
 				}
 			}
 
-			// remove unused functions
-			if (parentType === "FunctionDeclaration" && parent.id === id) {
+			// remove unused functions and classes
+			if (
+				(parentType === "FunctionDeclaration" && parent.id === id) ||
+				parentType === "ClassDeclaration"
+			) {
 				const nextToken = sourceCode.getTokenAfter(parent);
 				const prevToken = sourceCode.getTokenBefore(parent);
 
@@ -1743,21 +1737,6 @@ module.exports = {
 			// skip error in catch(error) variable
 			if (parentType === "CatchClause") {
 				return null;
-			}
-
-			// remove unused declared classes
-			if (parentType === "ClassDeclaration") {
-				const nextToken = sourceCode.getTokenAfter(parent);
-				const prevToken = sourceCode.getTokenBefore(parent);
-
-				if (
-					nextToken &&
-					isDeclarationNotSafeToRemove(nextToken, prevToken)
-				) {
-					return null;
-				}
-
-				return fixer.removeRange(parent.range);
 			}
 
 			// remove unused variable that is in a sequence [a,b] fixes to [a]

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -1043,6 +1043,57 @@ module.exports = {
 			}
 
 			/**
+			 * Check whether a closing brace token belongs to a block-level
+			 * construct (safe for ASI) rather than an expression (unsafe).
+			 *
+			 * Block-level `}` (e.g., if/for/while/function declaration body)
+			 * always triggers ASI, so it's safe to have adjacent tokens.
+			 *
+			 * Expression-level `}` (e.g., object literal, function expression,
+			 * arrow function body) does NOT trigger ASI, so adjacent tokens
+			 * could merge and change the parse.
+			 * @param {Token} token The token to check
+			 * @returns {boolean} true if the token is `}` from a block construct
+			 */
+			function isClosingBraceOfBlock(token) {
+				if (!astUtils.isClosingBraceToken(token)) {
+					return false;
+				}
+
+				const node = sourceCode.getNodeByRangeIndex(token.range[0]);
+
+				if (!node) {
+					return false;
+				}
+
+				if (node.type === "BlockStatement") {
+					/*
+					 * Safe only if the block belongs to a statement construct,
+					 * not an expression (FunctionExpression, ArrowFunctionExpression)
+					 */
+					return (
+						node.parent &&
+						node.parent.type !== "FunctionExpression" &&
+						node.parent.type !== "ArrowFunctionExpression"
+					);
+				}
+
+				// ClassBody from a ClassDeclaration (not ClassExpression)
+				if (node.type === "ClassBody") {
+					return (
+						node.parent && node.parent.type === "ClassDeclaration"
+					);
+				}
+
+				// SwitchStatement closing brace
+				if (node.type === "SwitchStatement") {
+					return true;
+				}
+
+				return false;
+			}
+
+			/**
 			 * Check whether declaration is safe to remove or not
 			 * @param {ASTNode} nextToken next token of unused variable
 			 * @param {ASTNode} prevToken previous token of unused variable
@@ -1053,7 +1104,8 @@ module.exports = {
 					nextToken.type === "String" ||
 					(prevToken &&
 						!astUtils.isSemicolonToken(prevToken) &&
-						!astUtils.isOpeningBraceToken(prevToken))
+						!astUtils.isOpeningBraceToken(prevToken) &&
+						!isClosingBraceOfBlock(prevToken))
 				);
 			}
 
@@ -1137,6 +1189,36 @@ module.exports = {
 					 * fix 'let bar = "hello", { a } = foo;' to 'let bar = "hello";' if 'a' is unused, same for arrays.
 					 */
 					if (getTokenBeforeValue(parentNode) === ",") {
+						// If this is the last declarator, removing it may create an ASI hazard
+						if (
+							parentNode === parentNode.parent.declarations.at(-1)
+						) {
+							const lastTokenOfDecl = sourceCode.getLastToken(
+								parentNode.parent,
+							);
+
+							// If the declaration has a trailing semicolon, the removal is safe
+							if (!astUtils.isSemicolonToken(lastTokenOfDecl)) {
+								const nextToken = sourceCode.getTokenAfter(
+									parentNode.parent,
+								);
+								const commaToken =
+									sourceCode.getTokenBefore(parentNode);
+								const lastRemainingToken =
+									sourceCode.getTokenBefore(commaToken);
+
+								if (
+									nextToken &&
+									isDeclarationNotSafeToRemove(
+										nextToken,
+										lastRemainingToken,
+									)
+								) {
+									return null;
+								}
+							}
+						}
+
 						return fixer.removeRange([
 							getPreviousTokenStart(parentNode),
 							parentNode.range[1],
@@ -1364,6 +1446,32 @@ module.exports = {
 
 				// remove unused declared variable with multiple declaration except first one like 'var a = b, c = d;'
 				if (tokenBefore.value === ",") {
+					// If this is the last declarator, removing it may create an ASI hazard
+					if (parent === parent.parent.declarations.at(-1)) {
+						const lastTokenOfDecl = sourceCode.getLastToken(
+							parent.parent,
+						);
+
+						// If the declaration has a trailing semicolon, the removal is safe
+						if (!astUtils.isSemicolonToken(lastTokenOfDecl)) {
+							const nextToken = sourceCode.getTokenAfter(
+								parent.parent,
+							);
+							const lastRemainingToken =
+								sourceCode.getTokenBefore(tokenBefore);
+
+							if (
+								nextToken &&
+								isDeclarationNotSafeToRemove(
+									nextToken,
+									lastRemainingToken,
+								)
+							) {
+								return null;
+							}
+						}
+					}
+
 					return fixer.removeRange([
 						tokenBefore.range[0],
 						parent.range[1],
@@ -1542,6 +1650,16 @@ module.exports = {
 
 			// remove unused functions
 			if (parentType === "FunctionDeclaration" && parent.id === id) {
+				const nextToken = sourceCode.getTokenAfter(parent);
+				const prevToken = sourceCode.getTokenBefore(parent);
+
+				if (
+					nextToken &&
+					isDeclarationNotSafeToRemove(nextToken, prevToken)
+				) {
+					return null;
+				}
+
 				return fixer.removeRange(parent.range);
 			}
 
@@ -1629,6 +1747,16 @@ module.exports = {
 
 			// remove unused declared classes
 			if (parentType === "ClassDeclaration") {
+				const nextToken = sourceCode.getTokenAfter(parent);
+				const prevToken = sourceCode.getTokenBefore(parent);
+
+				if (
+					nextToken &&
+					isDeclarationNotSafeToRemove(nextToken, prevToken)
+				) {
+					return null;
+				}
+
 				return fixer.removeRange(parent.range);
 			}
 

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -1196,7 +1196,7 @@ module.exports = {
 								const commaToken =
 									sourceCode.getTokenBefore(parentNode);
 								const lastRemainingToken =
-									sourceCode.getTokenBefore(commaToken);
+								const lastRemainingToken = sourceCode.getTokenBefore(parentNode, { skip: 1 });
 
 								if (
 									nextToken &&

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -1193,10 +1193,10 @@ module.exports = {
 								const nextToken = sourceCode.getTokenAfter(
 									parentNode.parent,
 								);
-								const commaToken =
-									sourceCode.getTokenBefore(parentNode);
 								const lastRemainingToken =
-								const lastRemainingToken = sourceCode.getTokenBefore(parentNode, { skip: 1 });
+									sourceCode.getTokenBefore(parentNode, {
+										skip: 1,
+									});
 
 								if (
 									nextToken &&
@@ -1449,7 +1449,7 @@ module.exports = {
 								parent.parent,
 							);
 							const lastRemainingToken =
-								sourceCode.getTokenBefore(tokenBefore);
+								sourceCode.getTokenBefore(parent, { skip: 1 });
 
 							if (
 								nextToken &&

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -4896,5 +4896,116 @@ try {
 				]),
 			],
 		},
+
+		// Safe removal: FunctionDeclaration is the last statement
+		{
+			code: "function unused() {}",
+			errors: [
+				definedError("unused", [
+					{
+						output: "",
+						messageId: "removeVar",
+						data: { varName: "unused" },
+					},
+				]),
+			],
+		},
+
+		// Safe removal: ClassDeclaration is the last statement
+		{
+			code: "class Unused {}",
+			languageOptions: { ecmaVersion: 2022 },
+			errors: [
+				definedError("Unused", [
+					{
+						output: "",
+						messageId: "removeVar",
+						data: { varName: "Unused" },
+					},
+				]),
+			],
+		},
+
+		// Safe removal: FunctionDeclaration with comment before
+		{
+			code: "/* comment */\nfunction unused() {}\n(a) => {}",
+			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+			errors: [
+				definedError("unused", [
+					{
+						output: "/* comment */\n\n(a) => {}",
+						messageId: "removeVar",
+						data: { varName: "unused" },
+					},
+				]),
+				definedError("a", [
+					{
+						output: "/* comment */\nfunction unused() {}\n() => {}",
+						messageId: "removeVar",
+						data: { varName: "a" },
+					},
+				]),
+			],
+		},
+
+		// Safe removal: FunctionDeclaration with comment after
+		{
+			code: "const x = 1;\nfunction unused() {}\n/* comment */\n(a) => {}",
+			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+			errors: [
+				assignedError("x", [
+					{
+						output: "\nfunction unused() {}\n/* comment */\n(a) => {}",
+						messageId: "removeVar",
+						data: { varName: "x" },
+					},
+				]),
+				definedError("unused", [
+					{
+						output: "const x = 1;\n\n/* comment */\n(a) => {}",
+						messageId: "removeVar",
+						data: { varName: "unused" },
+					},
+				]),
+				definedError("a", [
+					{
+						output: "const x = 1;\nfunction unused() {}\n/* comment */\n() => {}",
+						messageId: "removeVar",
+						data: { varName: "a" },
+					},
+				]),
+			],
+		},
+
+		// ASI hazard: removing last variable declarator without semicolon
+		{
+			code: "const x = 1,\n      y = () => {}\n() => {};",
+			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+			errors: [
+				assignedError("x", [
+					{
+						output: "const \n      y = () => {}\n() => {};",
+						messageId: "removeVar",
+						data: { varName: "x" },
+					},
+				]),
+				assignedError("y"),
+			],
+		},
+
+		// Safe removal: last variable declarator with semicolon
+		{
+			code: "var a = 1, b = 2; console.log(a)",
+			options: ["all"],
+			errors: [
+				assignedError("b", [
+					{
+						output: "var a = 1; console.log(a)",
+						messageId: "removeVar",
+						data: { varName: "b" },
+					},
+				]),
+			],
+		},
 	],
 });

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -4789,5 +4789,112 @@ try {
 				]),
 			],
 		},
+
+		// ASI hazard: FunctionDeclaration removal followed by (
+		{
+			code: "const x = 1\nfunction unused() {}\n(console.log)()",
+			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+			errors: [
+				assignedError("x", [
+					{
+						output: "\nfunction unused() {}\n(console.log)()",
+						messageId: "removeVar",
+						data: { varName: "x" },
+					},
+				]),
+				definedError("unused"),
+			],
+		},
+
+		// ASI hazard: FunctionDeclaration removal followed by /
+		{
+			code: "const x = 1\nfunction unused() {}\n/regex/.test('a')",
+			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+			errors: [
+				assignedError("x", [
+					{
+						output: "\nfunction unused() {}\n/regex/.test('a')",
+						messageId: "removeVar",
+						data: { varName: "x" },
+					},
+				]),
+				definedError("unused"),
+			],
+		},
+
+		// ASI hazard: ClassDeclaration removal followed by (
+		{
+			code: "const x = 1\nclass Unused {}\n(console.log)()",
+			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+			errors: [
+				assignedError("x", [
+					{
+						output: "\nclass Unused {}\n(console.log)()",
+						messageId: "removeVar",
+						data: { varName: "x" },
+					},
+				]),
+				definedError("Unused"),
+			],
+		},
+
+		// ASI hazard: multi-declaration last declarator removal followed by (
+		{
+			code: "const x = 1,\n      y = () => {}\n(console.log)()",
+			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+			errors: [
+				assignedError("x", [
+					{
+						output: "const \n      y = () => {}\n(console.log)()",
+						messageId: "removeVar",
+						data: { varName: "x" },
+					},
+				]),
+				assignedError("y"),
+			],
+		},
+
+		// Safe removal: FunctionDeclaration after semicolon
+		{
+			code: "var x = 1;\nfunction unused() {}\nvar z = 3",
+			errors: [
+				assignedError("x", [
+					{
+						output: "\nfunction unused() {}\nvar z = 3",
+						messageId: "removeVar",
+						data: { varName: "x" },
+					},
+				]),
+				definedError("unused", [
+					{
+						output: "var x = 1;\n\nvar z = 3",
+						messageId: "removeVar",
+						data: { varName: "unused" },
+					},
+				]),
+				assignedError("z", [
+					{
+						output: "var x = 1;\nfunction unused() {}\n",
+						messageId: "removeVar",
+						data: { varName: "z" },
+					},
+				]),
+			],
+		},
+
+		// Safe removal: ClassDeclaration inside block
+		{
+			code: "{ class Unused {} }",
+			languageOptions: { ecmaVersion: 2022 },
+			errors: [
+				definedError("Unused", [
+					{
+						output: "{  }",
+						messageId: "removeVar",
+						data: { varName: "Unused" },
+					},
+				]),
+			],
+		},
 	],
 });

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -5012,6 +5012,15 @@ try {
 			],
 		},
 
+		// ASI hazard abort: missing semicolon before function declaration (not strictly required but aborts to be safe)
+		{
+			code: "const before = true\nfunction unused() {}\nif (before) {}",
+			languageOptions: { ecmaVersion: 2022 },
+			errors: [
+				definedError("unused"),
+			],
+		},
+
 		// Safe removal: FunctionDeclaration with comment before
 		{
 			code: "/* comment */\nfunction unused() {}\n(a) => {}",

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -4837,27 +4837,21 @@ try {
 		{
 			code: "export const f = () => {}\nfunction unused() {}\n(console.log)()",
 			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
-			errors: [
-				definedError("unused"),
-			],
+			errors: [definedError("unused")],
 		},
 
 		// ASI hazard: Unsafe removal of function after FunctionExpression
 		{
 			code: "export const f = function() {}\nfunction unused() {}\n(console.log)()",
 			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
-			errors: [
-				definedError("unused"),
-			],
+			errors: [definedError("unused")],
 		},
 
 		// ASI hazard: Unsafe removal of function after ObjectExpression
 		{
 			code: "export const obj = { a: 1 }\nfunction unused() {}\n(console.log)()",
 			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
-			errors: [
-				definedError("unused"),
-			],
+			errors: [definedError("unused")],
 		},
 
 		// ASI hazard: FunctionDeclaration removal followed by (
@@ -5016,9 +5010,7 @@ try {
 		{
 			code: "const before = true\nfunction unused() {}\nif (before) {}",
 			languageOptions: { ecmaVersion: 2022 },
-			errors: [
-				definedError("unused"),
-			],
+			errors: [definedError("unused")],
 		},
 
 		// Safe removal: FunctionDeclaration with comment before

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -4833,13 +4833,6 @@ try {
 			],
 		},
 
-		// ASI hazard: Unsafe removal of function after ArrowFunctionExpression
-		{
-			code: "export const f = () => {}\nfunction unused() {}\n(console.log)()",
-			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
-			errors: [definedError("unused")],
-		},
-
 		// ASI hazard: Unsafe removal of function after FunctionExpression
 		{
 			code: "export const f = function() {}\nfunction unused() {}\n(console.log)()",

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -4970,12 +4970,12 @@ try {
 
 		// Safe removal: ClassDeclaration inside block
 		{
-			code: "{ class Unused {} }",
+			code: "{ console.log(); class Unused {} }",
 			languageOptions: { ecmaVersion: 2022 },
 			errors: [
 				definedError("Unused", [
 					{
-						output: "{  }",
+						output: "{ console.log();  }",
 						messageId: "removeVar",
 						data: { varName: "Unused" },
 					},
@@ -4985,11 +4985,11 @@ try {
 
 		// Safe removal: FunctionDeclaration is the last statement
 		{
-			code: "function unused() {}",
+			code: "console.log();\nfunction unused() {}",
 			errors: [
 				definedError("unused", [
 					{
-						output: "",
+						output: "console.log();\n",
 						messageId: "removeVar",
 						data: { varName: "unused" },
 					},
@@ -4999,12 +4999,12 @@ try {
 
 		// Safe removal: ClassDeclaration is the last statement
 		{
-			code: "class Unused {}",
+			code: "console.log();\nclass Unused {}",
 			languageOptions: { ecmaVersion: 2022 },
 			errors: [
 				definedError("Unused", [
 					{
-						output: "",
+						output: "console.log();\n",
 						messageId: "removeVar",
 						data: { varName: "Unused" },
 					},

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -4790,6 +4790,76 @@ try {
 			],
 		},
 
+		// ASI hazard: Safe removal of function after BlockStatement
+		{
+			code: "if (true) {}\nfunction unused() {}\n(console.log)()",
+			errors: [
+				definedError("unused", [
+					{
+						output: "if (true) {}\n\n(console.log)()",
+						messageId: "removeVar",
+						data: { varName: "unused" },
+					},
+				]),
+			],
+		},
+
+		// ASI hazard: Safe removal of function after ClassBody
+		{
+			code: "export class A {}\nfunction unused() {}\n(console.log)()",
+			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+			errors: [
+				definedError("unused", [
+					{
+						output: "export class A {}\n\n(console.log)()",
+						messageId: "removeVar",
+						data: { varName: "unused" },
+					},
+				]),
+			],
+		},
+
+		// ASI hazard: Safe removal of function after SwitchStatement
+		{
+			code: "switch (1) {}\nfunction unused() {}\n(console.log)()",
+			errors: [
+				definedError("unused", [
+					{
+						output: "switch (1) {}\n\n(console.log)()",
+						messageId: "removeVar",
+						data: { varName: "unused" },
+					},
+				]),
+			],
+		},
+
+		// ASI hazard: Unsafe removal of function after ArrowFunctionExpression
+		{
+			code: "export const f = () => {}\nfunction unused() {}\n(console.log)()",
+			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+			errors: [
+				definedError("unused"),
+			],
+		},
+
+		// ASI hazard: Unsafe removal of function after FunctionExpression
+		{
+			code: "export const f = function() {}\nfunction unused() {}\n(console.log)()",
+			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+			errors: [
+				definedError("unused"),
+			],
+		},
+
+		// ASI hazard: Unsafe removal of function after ObjectExpression
+		{
+			code: "export const obj = { a: 1 }\nfunction unused() {}\n(console.log)()",
+			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+			errors: [
+				definedError("unused"),
+			],
+		},
+
 		// ASI hazard: FunctionDeclaration removal followed by (
 		{
 			code: "const x = 1\nfunction unused() {}\n(console.log)()",
@@ -4841,6 +4911,22 @@ try {
 		// ASI hazard: multi-declaration last declarator removal followed by (
 		{
 			code: "const x = 1,\n      y = () => {}\n(console.log)()",
+			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+			errors: [
+				assignedError("x", [
+					{
+						output: "const \n      y = () => {}\n(console.log)()",
+						messageId: "removeVar",
+						data: { varName: "x" },
+					},
+				]),
+				assignedError("y"),
+			],
+		},
+
+		// ASI hazard: multi-declaration last declarator removal followed by ( with destructuring
+		{
+			code: "const { x } = obj,\n      y = () => {}\n(console.log)()",
 			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
 			errors: [
 				assignedError("x", [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:


Fixes #20931
<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Extended `isDeclarationNotSafeToRemove()` to cover `FunctionDeclaration`, `ClassDeclaration`, and multi-declaration last-declarator removal paths — all of which previously bypassed the ASI safety check.

Also added `isClosingBraceOfBlock()` helper to distinguish block-level `}` (safe for ASI) from expression-level `}` (unsafe), using `sourceCode.getNodeByRangeIndex()`.

#### Is there anything you'd like reviewers to focus on?
The `isClosingBraceOfBlock()` logic — it treats `BlockStatement` as safe only when its parent is not `FunctionExpression`/`ArrowFunctionExpression`, and `ClassBody` only when parent is `ClassDeclaration
<!-- markdownlint-disable-file MD004 -->



