### PR TITLE
fix: detect globalThis.NaN in use-isnan rule

### DIFF
--- a/lib/rules/use-isnan.js
+++ b/lib/rules/use-isnan.js
@@ -30,7 +30,8 @@ function isNaNIdentifier(node) {
 
 	return (
 		astUtils.isSpecificId(nodeToCheck, "NaN") ||
-		astUtils.isSpecificMemberAccess(nodeToCheck, "Number", "NaN")
+		astUtils.isSpecificMemberAccess(nodeToCheck, "Number", "NaN") ||
+		astUtils.isSpecificMemberAccess(nodeToCheck, "globalThis", "NaN")
 	);
 }
 


### PR DESCRIPTION
## Problem

The `use-isnan` rule detects `NaN` and `Number.NaN` but misses `globalThis.NaN`. Since `globalThis` is the standardized way to access the global object in ES2020, `globalThis.NaN` is equivalent to bare `NaN`, and comparisons to it suffer from the same language pitfall.

```js
if (foo === globalThis.NaN) { }  // ❌ No error reported
if (foo === NaN) { }              // ✅ Error reported
```

## Root cause

The `isNaNIdentifier` helper in `lib/rules/use-isnan.js` only checks for bare `NaN` identifier and `Number.NaN` member access, but doesn't check for `globalThis.NaN`.

## Changes

Added `globalThis.NaN` detection to `isNaNIdentifier()` function — a single-line addition:

```diff
 return (
     astUtils.isSpecificId(nodeToCheck, "NaN") ||
-    astUtils.isSpecificMemberAccess(nodeToCheck, "Number", "NaN")
+    astUtils.isSpecificMemberAccess(nodeToCheck, "Number", "NaN") ||
+    astUtils.isSpecificMemberAccess(nodeToCheck, "globalThis", "NaN")
 );
```

Fixes #20854