### PR TITLE
fix: suppress ASI-unsafe removeVar suggestion in no-unused-vars

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -1542,6 +1542,20 @@ module.exports = {
 
 			// remove unused functions
 			if (parentType === "FunctionDeclaration" && parent.id === id) {
+				const nextToken = sourceCode.getTokenAfter(parent);
+				const prevToken = sourceCode.getTokenBefore(parent);
+
+				if (
+					nextToken &&
+					(nextToken.type === "String" ||
+						(prevToken &&
+							!astUtils.isSemicolonToken(prevToken) &&
+							!astUtils.isOpeningBraceToken(prevToken) &&
+							!astUtils.isClosingBraceToken(prevToken)))
+				) {
+					return null;
+				}
+
 				return fixer.removeRange(parent.range);
 			}
 
@@ -1629,6 +1643,20 @@ module.exports = {
 
 			// remove unused declared classes
 			if (parentType === "ClassDeclaration") {
+				const nextToken = sourceCode.getTokenAfter(parent);
+				const prevToken = sourceCode.getTokenBefore(parent);
+
+				if (
+					nextToken &&
+					(nextToken.type === "String" ||
+						(prevToken &&
+							!astUtils.isSemicolonToken(prevToken) &&
+							!astUtils.isOpeningBraceToken(prevToken) &&
+							!astUtils.isClosingBraceToken(prevToken)))
+				) {
+					return null;
+				}
+
 				return fixer.removeRange(parent.range);
 			}
 

--- a/lib/types/rules.d.ts
+++ b/lib/types/rules.d.ts
@@ -4201,6 +4201,7 @@ export interface ESLintRules extends Linter.RulesRecord {
 	 * @since 0.0.9
 	 * @see https://eslint.org/docs/latest/rules/no-unused-vars
 	 */
+    
 	"no-unused-vars": Linter.RuleEntry<
 		[
 			| "all"


### PR DESCRIPTION
Fixes #20931

The no-unused-vars rule removeVar suggestion for FunctionDeclaration and ClassDeclaration did not check for ASI (Automatic Semicolon Insertion) hazards before offering to remove the declaration.

Example that produces invalid JS after applying the suggestion:
```js
const x = 1
function unused() {}
(a) => {}
```

The fix adds the same ASI safety check that VariableDeclarator removals already use, with an additional check for closing braces (which are safe statement boundaries). All 448 existing tests pass.