### PR TITLE
feat: correct max-depth handling for else-if chains

### DIFF
--- a/lib/rules/max-depth.js
+++ b/lib/rules/max-depth.js
@@ -117,6 +117,18 @@ module.exports = {
 			functionStack[functionStack.length - 1]--;
 		}
 
+		/**
+		 * Checks whether a node is an else-if statement.
+		 * @param {ASTNode} node node to evaluate
+		 * @returns {boolean} Whether the node is an else-if statement
+		 */
+		function isElseIf(node) {
+			return (
+				node.parent.type === "IfStatement" &&
+				node.parent.alternate === node
+			);
+		}
+
 		//--------------------------------------------------------------------------
 		// Public API
 		//--------------------------------------------------------------------------
@@ -129,7 +141,7 @@ module.exports = {
 			StaticBlock: startFunction,
 
 			IfStatement(node) {
-				if (node.parent.type !== "IfStatement") {
+				if (!isElseIf(node)) {
 					pushBlock(node);
 				}
 			},
@@ -142,7 +154,11 @@ module.exports = {
 			ForInStatement: pushBlock,
 			ForOfStatement: pushBlock,
 
-			"IfStatement:exit": popBlock,
+			"IfStatement:exit"(node) {
+				if (!isElseIf(node)) {
+					popBlock();
+				}
+			},
 			"SwitchStatement:exit": popBlock,
 			"TryStatement:exit": popBlock,
 			"DoWhileStatement:exit": popBlock,

--- a/tests/lib/rules/max-depth.js
+++ b/tests/lib/rules/max-depth.js
@@ -105,6 +105,26 @@ ruleTester.run("max-depth", rule, {
 			],
 		},
 		{
+			code: "function foo() { if (a) {} else if (b) {} if (c) { if (d) {} } }",
+			options: [1],
+			errors: [
+				{
+					messageId: "tooDeeply",
+					data: { depth: 2, maxDepth: 1 },
+				},
+			],
+		},
+		{
+			code: "if (a) if (b) {}",
+			options: [1],
+			errors: [
+				{
+					messageId: "tooDeeply",
+					data: { depth: 2, maxDepth: 1 },
+				},
+			],
+		},
+		{
 			code: "function foo() { while (true) { if (true) {} } }",
 			options: [1],
 			errors: [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:** v24.16.0
- **npm version:** v11.13.0
- **Local ESLint version:** v10.4.1
- **Global ESLint version:** v10.4.1
- **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->

```js
{
    rules: {
        "max-depth": ["error", 1]
    }
}
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
function foo() {
    if (a) {} else if (b) {}

    if (c) {
        if (d) {}
    }
}
```

**What did you expect to happen?**

The rule should report the nested `if (d)` as depth 2 when `max-depth` is configured with a maximum of 1.

**What actually happened? Please include the actual, raw output from ESLint.**

The rule reported no errors.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed `max-depth` so `else if` chains do not unbalance the rule’s internal depth counter.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
