### PR TITLE
feat: add checkRelationalComparisons to no-constant-binary-expression

### DIFF
--- a/docs/src/rules/no-constant-binary-expression.md
+++ b/docs/src/rules/no-constant-binary-expression.md
@@ -87,4 +87,38 @@ const arrIsEmpty = someArr.length === 0;
 
 ## Options
 
-This rule has no options.
+This rule has an object option:
+
+* `"checkRelationalComparisons": true` (default `false`) checks for relational comparisons (`<`, `<=`, `>`, `>=`) where both sides are literal values.
+
+### checkRelationalComparisons
+
+Examples of **incorrect** code for this rule with the `{ "checkRelationalComparisons": true }` option:
+
+::: incorrect
+
+```js
+/*eslint no-constant-binary-expression: ["error", { "checkRelationalComparisons": true } ]*/
+
+const value1 = 1 < 2;
+
+const value2 = "a" >= "b";
+
+const value3 = true > false;
+```
+
+:::
+
+Examples of **correct** code for this rule with the `{ "checkRelationalComparisons": true }` option:
+
+::: correct
+
+```js
+/*eslint no-constant-binary-expression: ["error", { "checkRelationalComparisons": true } ]*/
+
+const value1 = 1 < x;
+
+const value2 = a >= b;
+```
+
+:::

--- a/docs/src/rules/no-constant-binary-expression.md
+++ b/docs/src/rules/no-constant-binary-expression.md
@@ -33,7 +33,7 @@ const isEmpty = x === [];
 
 This rule identifies `==` and `===` comparisons which, based on the semantics of the JavaScript language, will always evaluate to `true` or `false`.
 
-It also identifies `||`, `&&` and `??` logical expressions which will either always or never short-circuit.
+It also identifies `||`, `&&` and `??` logical expressions which will either always or never short-circuit. Additionally, when configured with the `checkRelationalComparisons` option, it can identify constant relational comparisons (such as `<` or `>=`).
 
 Examples of **incorrect** code for this rule:
 
@@ -105,6 +105,8 @@ const value1 = 1 < 2;
 const value2 = "a" >= "b";
 
 const value3 = true > false;
+
+const hasStreak = profile.streak ?? 0 > 1;
 ```
 
 :::
@@ -119,6 +121,8 @@ Examples of **correct** code for this rule with the `{ "checkRelationalCompariso
 const value1 = 1 < x;
 
 const value2 = a >= b;
+
+const hasStreak = (profile.streak ?? 0) > 1;
 ```
 
 :::

--- a/lib/rules/no-constant-binary-expression.js
+++ b/lib/rules/no-constant-binary-expression.js
@@ -28,6 +28,8 @@ const NUMERIC_OR_STRING_BINARY_OPERATORS = new Set([
 	">>>",
 ]);
 
+const RELATIONAL_OPERATORS = new Set(["<", "<=", ">", ">="]);
+
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
@@ -485,6 +487,33 @@ function findBinaryExpressionConstantOperand(scope, a, b, operator) {
 	return null;
 }
 
+/**
+ * Checks if a node is a statically knowable literal.
+ * @param {Scope} scope The scope in which the node was found.
+ * @param {ASTNode} node The node to test.
+ * @returns {boolean} `true` if the node is a literal.
+ */
+function isStaticLiteral(scope, node) {
+	switch (node.type) {
+		case "Literal":
+			return true;
+		case "UnaryExpression":
+			return (
+				["-", "+", "~"].includes(node.operator) &&
+				node.argument.type === "Literal"
+			);
+		case "Identifier":
+			return (
+				node.name === "undefined" &&
+				isReferenceToGlobalVariable(scope, node)
+			);
+		case "TemplateLiteral":
+			return node.expressions.length === 0;
+		default:
+			return false;
+	}
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -499,7 +528,22 @@ module.exports = {
 			recommended: true,
 			url: "https://eslint.org/docs/latest/rules/no-constant-binary-expression",
 		},
-		schema: [],
+		defaultOptions: [
+			{
+				checkRelationalComparisons: false,
+			},
+		],
+		schema: [
+			{
+				type: "object",
+				properties: {
+					checkRelationalComparisons: {
+						type: "boolean",
+					},
+				},
+				additionalProperties: false,
+			},
+		],
 		messages: {
 			constantBinaryOperand:
 				"Unexpected constant binary expression. Compares constantly with the {{otherSide}}-hand side of the `{{operator}}`.",
@@ -509,11 +553,14 @@ module.exports = {
 				"Unexpected comparison to newly constructed object. These two values can never be equal.",
 			bothAlwaysNew:
 				"Unexpected comparison of two newly constructed objects. These two values can never be equal.",
+			constantRelationalComparison:
+				"Unexpected constant relational comparison. Both sides of the `{{operator}}` are literal values.",
 		},
 	},
 
 	create(context) {
 		const sourceCode = context.sourceCode;
+		const { checkRelationalComparisons } = context.options[0];
 
 		return {
 			LogicalExpression(node) {
@@ -585,6 +632,20 @@ module.exports = {
 						context.report({
 							node: left,
 							messageId: "bothAlwaysNew",
+						});
+					}
+				} else if (
+					checkRelationalComparisons &&
+					RELATIONAL_OPERATORS.has(operator)
+				) {
+					if (
+						isStaticLiteral(scope, left) &&
+						isStaticLiteral(scope, right)
+					) {
+						context.report({
+							node,
+							messageId: "constantRelationalComparison",
+							data: { operator },
 						});
 					}
 				}

--- a/lib/types/rules.d.ts
+++ b/lib/types/rules.d.ts
@@ -2228,7 +2228,16 @@ export interface ESLintRules extends Linter.RulesRecord {
 	 * @since 8.14.0
 	 * @see https://eslint.org/docs/latest/rules/no-constant-binary-expression
 	 */
-	"no-constant-binary-expression": Linter.RuleEntry<[]>;
+	"no-constant-binary-expression": Linter.RuleEntry<
+		[
+			Partial<{
+				/**
+				 * @default false
+				 */
+				checkRelationalComparisons: boolean;
+			}>,
+		]
+	>;
 
 	/**
 	 * Rule to disallow constant expressions in conditions.

--- a/tests/lib/rules/no-constant-binary-expression.js
+++ b/tests/lib/rules/no-constant-binary-expression.js
@@ -74,6 +74,51 @@ ruleTester.run("no-constant-binary-expression", rule, {
 		"foo ?? null ?? bar",
 		"a ?? (doSomething(), undefined) ?? b",
 		"a ?? (something = null) ?? b",
+		"5 < 10",
+		"5 <= 10",
+		"10 > 5",
+		"10 >= 5",
+		"'a' < 'b'",
+		"undefined >= 5",
+		"`` < ``",
+		"1n < 2n",
+		"null >= 5",
+		{
+			code: "5 < 10",
+			options: [{ checkRelationalComparisons: false }],
+		},
+		{
+			code: "x < 5",
+			options: [{ checkRelationalComparisons: true }],
+		},
+		{
+			code: "5 < x",
+			options: [{ checkRelationalComparisons: true }],
+		},
+		{
+			code: "x > y",
+			options: [{ checkRelationalComparisons: true }],
+		},
+		{
+			code: "x >= undefined",
+			options: [{ checkRelationalComparisons: true }],
+		},
+		{
+			code: "`${x}` < 5",
+			options: [{ checkRelationalComparisons: true }],
+		},
+		{
+			code: "5 > `${x}`",
+			options: [{ checkRelationalComparisons: true }],
+		},
+		{
+			code: "~x < 10",
+			options: [{ checkRelationalComparisons: true }],
+		},
+		{
+			code: "-x >= 5",
+			options: [{ checkRelationalComparisons: true }],
+		},
 	],
 	invalid: [
 		// Error messages
@@ -1950,6 +1995,176 @@ ruleTester.run("no-constant-binary-expression", rule, {
 		{
 			code: "window.abc ?? 'non-nullish' ?? anything",
 			errors: [{ messageId: "constantShortCircuit" }],
+		},
+		{
+			code: "5 < 10",
+			options: [{ checkRelationalComparisons: true }],
+			errors: [
+				{
+					messageId: "constantRelationalComparison",
+					data: { operator: "<" },
+				},
+			],
+		},
+		{
+			code: "5 <= 10",
+			options: [{ checkRelationalComparisons: true }],
+			errors: [
+				{
+					messageId: "constantRelationalComparison",
+					data: { operator: "<=" },
+				},
+			],
+		},
+		{
+			code: "10 > 5",
+			options: [{ checkRelationalComparisons: true }],
+			errors: [
+				{
+					messageId: "constantRelationalComparison",
+					data: { operator: ">" },
+				},
+			],
+		},
+		{
+			code: "10 >= 5",
+			options: [{ checkRelationalComparisons: true }],
+			errors: [
+				{
+					messageId: "constantRelationalComparison",
+					data: { operator: ">=" },
+				},
+			],
+		},
+		{
+			code: "'a' < 'b'",
+			options: [{ checkRelationalComparisons: true }],
+			errors: [
+				{
+					messageId: "constantRelationalComparison",
+					data: { operator: "<" },
+				},
+			],
+		},
+		{
+			code: "true >= false",
+			options: [{ checkRelationalComparisons: true }],
+			errors: [
+				{
+					messageId: "constantRelationalComparison",
+					data: { operator: ">=" },
+				},
+			],
+		},
+		{
+			code: "undefined < 5",
+			options: [{ checkRelationalComparisons: true }],
+			errors: [
+				{
+					messageId: "constantRelationalComparison",
+					data: { operator: "<" },
+				},
+			],
+		},
+		{
+			code: "5 > undefined",
+			options: [{ checkRelationalComparisons: true }],
+			errors: [
+				{
+					messageId: "constantRelationalComparison",
+					data: { operator: ">" },
+				},
+			],
+		},
+		{
+			code: "`` < ``",
+			options: [{ checkRelationalComparisons: true }],
+			errors: [
+				{
+					messageId: "constantRelationalComparison",
+					data: { operator: "<" },
+				},
+			],
+		},
+		{
+			code: "`` >= 5",
+			options: [{ checkRelationalComparisons: true }],
+			errors: [
+				{
+					messageId: "constantRelationalComparison",
+					data: { operator: ">=" },
+				},
+			],
+		},
+		{
+			code: "`foo` < `bar`",
+			options: [{ checkRelationalComparisons: true }],
+			errors: [
+				{
+					messageId: "constantRelationalComparison",
+					data: { operator: "<" },
+				},
+			],
+		},
+		{
+			code: "1n < 2n",
+			options: [{ checkRelationalComparisons: true }],
+			errors: [
+				{
+					messageId: "constantRelationalComparison",
+					data: { operator: "<" },
+				},
+			],
+		},
+		{
+			code: "null >= 5",
+			options: [{ checkRelationalComparisons: true }],
+			errors: [
+				{
+					messageId: "constantRelationalComparison",
+					data: { operator: ">=" },
+				},
+			],
+		},
+		{
+			code: "-5 < 10",
+			options: [{ checkRelationalComparisons: true }],
+			errors: [
+				{
+					messageId: "constantRelationalComparison",
+					data: { operator: "<" },
+				},
+			],
+		},
+		{
+			code: "10 >= +5",
+			options: [{ checkRelationalComparisons: true }],
+			errors: [
+				{
+					messageId: "constantRelationalComparison",
+					data: { operator: ">=" },
+				},
+			],
+		},
+		{
+			code: "~5 <= 10",
+			options: [{ checkRelationalComparisons: true }],
+			errors: [
+				{
+					messageId: "constantRelationalComparison",
+					data: { operator: "<=" },
+				},
+			],
+		},
+		{
+			code: "~1 > ~2",
+			options: [{ checkRelationalComparisons: true }],
+			errors: [
+				{
+					messageId: "constantRelationalComparison",
+					data: { operator: ">" },
+				},
+			],
 		},
 	],
 });

--- a/tests/lib/rules/no-constant-binary-expression.js
+++ b/tests/lib/rules/no-constant-binary-expression.js
@@ -119,6 +119,14 @@ ruleTester.run("no-constant-binary-expression", rule, {
 			code: "-x >= 5",
 			options: [{ checkRelationalComparisons: true }],
 		},
+		{
+			code: "x < /a/",
+			options: [{ checkRelationalComparisons: true }],
+		},
+		{
+			code: "/a/ >= x",
+			options: [{ checkRelationalComparisons: true }],
+		},
 	],
 	invalid: [
 		// Error messages
@@ -2163,6 +2171,26 @@ ruleTester.run("no-constant-binary-expression", rule, {
 				{
 					messageId: "constantRelationalComparison",
 					data: { operator: ">" },
+				},
+			],
+		},
+		{
+			code: "/a/ < /b/",
+			options: [{ checkRelationalComparisons: true }],
+			errors: [
+				{
+					messageId: "constantRelationalComparison",
+					data: { operator: "<" },
+				},
+			],
+		},
+		{
+			code: "/a/ >= /b/",
+			options: [{ checkRelationalComparisons: true }],
+			errors: [
+				{
+					messageId: "constantRelationalComparison",
+					data: { operator: ">=" },
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR adds the `checkRelationalComparisons` option (defaulting to `false`) to the `no-constant-binary-expression` rule.

When enabled, the rule identifies and flags relational operators (`<`, `<=`, `>`, `>=`) where both the left and right operands are statically knowable literal values.

Fixes #20573

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
