### PR TITLE
test: add unit tests for ParserService

### DIFF
--- a/tests/lib/services/parser-service.js
+++ b/tests/lib/services/parser-service.js
@@ -1,0 +1,161 @@
+/**
+ * @fileoverview Unit tests for the ParserService class.
+ * @author Taejin Kim
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const { ParserService } = require("../../../lib/services/parser-service");
+const assert = require("node:assert");
+const sinon = require("sinon");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("ParserService", () => {
+	/** @type {ParserService} */
+	let parserService;
+
+	beforeEach(() => {
+		parserService = new ParserService();
+	});
+
+	describe("parseSync()", () => {
+		it("should return ok: true with sourceCode when parse succeeds", () => {
+			const fakeFile = { path: "test.js", body: "const x = 1;" };
+			const fakeAst = { type: "Program", body: [] };
+			const fakeSourceCode = { text: fakeFile.body, ast: fakeAst };
+			const fakeLanguage = {
+				parse: () => ({ ok: true, ast: fakeAst }),
+				createSourceCode: () => fakeSourceCode,
+			};
+
+			const result = parserService.parseSync(fakeFile, {
+				language: fakeLanguage,
+				languageOptions: {},
+			});
+
+			assert.strictEqual(result.ok, true);
+			assert.strictEqual(result.sourceCode, fakeSourceCode);
+		});
+
+		it("should call createSourceCode with the file, parse result, and languageOptions", () => {
+			const fakeFile = { path: "test.js", body: "const x = 1;" };
+			const fakeAst = { type: "Program", body: [] };
+			const fakeParseResult = { ok: true, ast: fakeAst };
+			const languageOptions = { ecmaVersion: 2022 };
+			const fakeLanguage = {
+				parse: () => fakeParseResult,
+				createSourceCode: sinon.spy((file, parseResult) => ({
+					text: file.body,
+					ast: parseResult.ast,
+				})),
+			};
+
+			parserService.parseSync(fakeFile, {
+				language: fakeLanguage,
+				languageOptions,
+			});
+
+			assert.ok(
+				fakeLanguage.createSourceCode.calledOnceWithExactly(
+					fakeFile,
+					fakeParseResult,
+					{ languageOptions },
+				),
+				"Expected createSourceCode to be called once with the file, parse result, and { languageOptions }",
+			);
+		});
+
+		it("should return ok: false with errors when parse fails", () => {
+			const fakeLanguage = {
+				parse: () => ({
+					ok: false,
+					errors: [
+						{ message: "Unexpected token", line: 1, column: 5 },
+					],
+				}),
+			};
+			const fakeFile = { path: "test.js", body: "const x =" };
+
+			const result = parserService.parseSync(fakeFile, {
+				language: fakeLanguage,
+				languageOptions: {},
+			});
+
+			assert.strictEqual(result.ok, false);
+			assert.ok(Array.isArray(result.errors));
+			assert.strictEqual(result.errors.length, 1);
+			assert.strictEqual(result.errors[0].ruleId, null);
+			assert.strictEqual(result.errors[0].fatal, true);
+			assert.strictEqual(result.errors[0].severity, 2);
+		});
+
+		it("should prefix error messages with 'Parsing error: '", () => {
+			const fakeLanguage = {
+				parse: () => ({
+					ok: false,
+					errors: [
+						{ message: "Unexpected token", line: 1, column: 5 },
+					],
+				}),
+			};
+			const fakeFile = { path: "test.js", body: "const x =" };
+
+			const result = parserService.parseSync(fakeFile, {
+				language: fakeLanguage,
+				languageOptions: {},
+			});
+
+			assert.strictEqual(
+				result.errors[0].message,
+				"Parsing error: Unexpected token",
+			);
+		});
+
+		it("should preserve line and column from parser errors", () => {
+			const fakeLanguage = {
+				parse: () => ({
+					ok: false,
+					errors: [
+						{ message: "Unexpected token", line: 5, column: 10 },
+					],
+				}),
+			};
+			const fakeFile = { path: "test.js", body: "" };
+
+			const result = parserService.parseSync(fakeFile, {
+				language: fakeLanguage,
+				languageOptions: {},
+			});
+
+			assert.strictEqual(result.errors[0].line, 5);
+			assert.strictEqual(result.errors[0].column, 10);
+		});
+
+		it("should throw when language.parse returns a promise", () => {
+			const fakeLanguage = {
+				parse: () =>
+					Promise.resolve({
+						ok: true,
+						ast: { type: "Program", body: [] },
+					}),
+			};
+			const fakeFile = { path: "test.js", body: "const x = 1;" };
+
+			assert.throws(
+				() =>
+					parserService.parseSync(fakeFile, {
+						language: fakeLanguage,
+						languageOptions: {},
+					}),
+				/Unsupported: Language parser returned a promise\./u,
+			);
+		});
+	});
+});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:  add unit tests for ParserService

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Add unit tests for `ParserService` (`lib/services/parser-service.js`)
The tests cover the following behaviors:
- Successful parsing returns `{ ok: true, sourceCode }`
- `createSourceCode` is called with the file, parse result, and `{ languageOptions }`
- Failed parsing returns `{ ok: false, errors }` with properly formatted error objects
  (`ruleId: null`, `fatal: true`, `severity: 2`)
- Error messages are prefixed with `"Parsing error: "`
- `line` and `column` from parser errors are preserved
- Throws when `language.parse` returns a Promise (async parsers are unsupported)

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
