### PR TITLE
chore: add ignore-scripts=true to .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 package-lock = false
 install-links = false
+ignore-scripts = true

--- a/Makefile.js
+++ b/Makefile.js
@@ -657,6 +657,13 @@ target.mocha = () => {
 target.cypress = () => {
 	echo("Running unit tests on browsers");
 	target.webpack("production");
+
+	const installReturn = exec(`${getBinFile("cypress")} install`);
+
+	if (installReturn.code !== 0) {
+		exit(1);
+	}
+
 	const lastReturn = exec(`${getBinFile("cypress")} run --no-runner-ui`);
 
 	if (lastReturn.code !== 0) {


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
- [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
- [ ] Add autofix to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [x] Other, please explain:

Add `ignore-scripts = true` to `.npmrc` to skip lifecycle scripts during `npm install`.

#### What changes did you make? (Give an overview)

This prevents npm from running dependency lifecycle scripts (`preinstall`, `install`, `postinstall`, etc.) when contributors or CI install packages. ESLint itself does not define install scripts in `package.json`, so this change only affects third-party dependency scripts.

Dependency install scripts are a common supply-chain attack surface: a compromised package can run arbitrary code on `npm install` before anyone inspects it. Setting `ignore-scripts = true` in the project `.npmrc` reduces that risk for everyone who installs dependencies in this repo (local development and CI).

#### Is there anything you'd like reviewers to focus on?

Whether skipping dependency lifecycle scripts during install is acceptable for ESLint's development and CI workflows. In particular, whether any required setup currently relies on a dependency's install script that would no longer run with this setting.