### PR TITLE
feat: remove is-glob dependency, use minimatch for glob detection

### DIFF
--- a/lib/eslint/eslint-helpers.js
+++ b/lib/eslint/eslint-helpers.js
@@ -13,7 +13,6 @@ const path = require("node:path");
 const fs = require("node:fs");
 const { isMainThread, threadId } = require("node:worker_threads");
 const fsp = fs.promises;
-const isGlob = require("is-glob");
 const hash = require("../cli-engine/hash");
 const minimatch = require("minimatch");
 const globParent = require("glob-parent");
@@ -31,6 +30,7 @@ const { SuppressionsService } = require("../services/suppressions-service.js");
 
 const Minimatch = minimatch.Minimatch;
 const MINIMATCH_OPTIONS = { dot: true };
+const MINIMATCH_GLOB_OPTIONS = { ...MINIMATCH_OPTIONS, magicalBraces: true };
 const hrtimeBigint = process.hrtime.bigint;
 
 //-----------------------------------------------------------------------------
@@ -191,7 +191,10 @@ function normalizeToPosix(pattern) {
  * @returns {boolean} `true` if the string is a glob pattern.
  */
 function isGlobPattern(pattern) {
-	return isGlob(path.sep === "\\" ? normalizeToPosix(pattern) : pattern);
+	const patternToUse =
+		path.sep === "\\" ? normalizeToPosix(pattern) : pattern;
+
+	return new Minimatch(patternToUse, MINIMATCH_GLOB_OPTIONS).hasMagic();
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -151,7 +151,6 @@
     "glob-parent": "^6.0.2",
     "ignore": "^5.2.0",
     "imurmurhash": "^0.1.4",
-    "is-glob": "^4.0.0",
     "json-stable-stringify-without-jsonify": "^1.0.1",
     "minimatch": "^10.2.4",
     "natural-compare": "^1.4.0",

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -2948,6 +2948,27 @@ describe("ESLint", () => {
 			assert.strictEqual(results[2].suppressedMessages.length, 0);
 		});
 
+		it("should resolve brace expansion globs when 'globInputPaths' option is true", async () => {
+			eslint = new ESLint({
+				ignore: false,
+				cwd: getFixturePath(".."),
+				overrideConfig: { files: ["**/*.js", "**/*.js2"] },
+				overrideConfigFile: getFixturePath("eslint.config.js"),
+			});
+			const results = await eslint.lintFiles([
+				"fixtures/files/{foo.js,foo.js2}",
+			]);
+
+			assert.deepStrictEqual(
+				results.map(({ filePath }) => path.basename(filePath)),
+				["foo.js", "foo.js2"],
+			);
+			assert.strictEqual(results[0].messages.length, 0);
+			assert.strictEqual(results[1].messages.length, 0);
+			assert.strictEqual(results[0].suppressedMessages.length, 0);
+			assert.strictEqual(results[1].suppressedMessages.length, 0);
+		});
+
 		// only works on a Windows machine
 		if (os.platform() === "win32") {
 			it("should resolve globs with Windows slashes when 'globInputPaths' option is true", async () => {


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
- [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
- [ ] Add autofix to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [x] Other, please explain:

Dependency removal — replace `is-glob` (unmaintained, ~170 lines, brings in `is-extglob` as a sub-dependency) with the already-present `minimatch` dependency, which is the source of truth for all glob matching in ESLint. Fixes #20871.

#### What changes did you make? (Give an overview)

- **`lib/eslint/eslint-helpers.js`**: Removed `require("is-glob")`. Added a `MINIMATCH_GLOB_OPTIONS` constant (`{ dot: true, magicalBraces: true }`) and rewrote `isGlobPattern()` to use `new Minimatch(pattern, MINIMATCH_GLOB_OPTIONS).hasMagic()`. Using `magicalBraces: true` ensures `{foo,bar}`-style patterns are detected as glob magic, consistent with how `minimatch` expands them downstream.
- **`package.json`**: Removed `"is-glob": "^4.0.0"` from dependencies. After this change `is-glob` remains only as a transitive dependency of `glob-parent`.
- **`tests/lib/eslint/eslint.js`**: Added a test covering brace expansion glob patterns (`fixtures/files/{foo.js,foo.js2}`), which exercises the `magicalBraces: true` behavior and was not previously covered.

#### Is there anything you'd like reviewers to focus on?

**Pattern compatibility testing: `is-glob` vs `minimatch.hasMagic()`**

To validate this replacement, I tested 45 real-world glob patterns against both `is-glob@4.0.3` and `new Minimatch(pattern, { dot: true, magicalBraces: true }).hasMagic()`. Patterns were drawn from `eslint` script entries in `package.json` files across popular repositories (React, Vue, Express, Lodash, Axios, Prettier, Babel) plus ESLint's own test fixtures.

**41/45 patterns agree exactly.** All common real-world patterns match. The 4 differences:

<details>
<summary>Full results table (click to expand)</summary>

```
Pattern                                       is-glob    minimatch  Match?
---------------------------------------------------------------------------
src                                           false      false      ✓
lib                                           false      false      ✓
test                                          false      false      ✓
lib/cli.js                                    false      false      ✓
*.js                                          true       true       ✓
**/*.js                                       true       true       ✓
src/**                                        true       true       ✓
test/**/*.js                                  true       true       ✓
{src,test}/**/*.js                            true       true       ✓
{src,test}/**/*.{ts,tsx}                      true       true       ✓
{lib,test}/**/*.js                            true       true       ✓
{src,mock,library}/**/*.{vue,js}              true       true       ✓
foo.{js,ts}                                   true       true       ✓
fixtures/files/{foo.js,foo.js2}               true       true       ✓
src/**/*.{js,jsx,ts,tsx}                      true       true       ✓
**/*.{ts,tsx,json,yml}                        true       true       ✓
src/[abc].js                                  true       true       ✓
!src/**/*.js                                  true       true       ✓
+(foo).js                                     true       true       ✓
*(foo).js                                     true       true       ✓
?(foo).js                                     true       true       ✓
@(src|lib)/**                                 true       true       ✓
.                                             false      false      ✓
.a.js                                         false      false      ✓
a*.js                                         true       true       ✓
no-config-file/*.js                           true       true       ✓
**/{js,jsx}                                   true       true       ✓
(and 14 more matching pairs)

foo?.js                                       false      true       ✗ MISMATCH
src/?.js                                      false      true       ✗ MISMATCH
!foo.js                                       true       false      ✗ MISMATCH
!(foo).js                                     true       false      ✗ MISMATCH
```

</details>

**`foo?.js` / `src/?.js` — behavior improvement**

`is-glob` deliberately skips `?`. `minimatch` correctly treats `?` as a glob wildcard in all positions. `foo?.js` matches `fooa.js`, `foo1.js`, etc. — it is a valid glob and should be treated as one.

**`!foo.js` / `!(foo).js` — question for reviewers**

Both stem from the same root cause: `is-glob` triggers on any leading `!` (`^!` in its regex), while `minimatch.hasMagic()` returns `false` because the inner pattern (`foo.js`) has no wildcard characters.

Tracing the old behavior through `globSearch`: `globParent("!foo.js")` returns `.`, and `new Minimatch("!foo.js")` with `negate: true` matches **every file in the working directory except `foo.js`**. Passing `!foo.js` alone to `lintFiles()` would silently lint the entire project. The new behavior throws `NoFilesFoundError`, which seems more correct.

Note: `!src/**/*.js` (negation **with** wildcards) is **unaffected** — `hasMagic()` already returns `true` for those and they continue to route through the glob engine as before.

**If passing a bare negation like `!foo.js` (no wildcards) to `lintFiles()` is an intentionally supported use case**, adding `|| matcher.negate` to `isGlobPattern()` would restore the old routing behavior. There are no existing tests or docs covering this pattern, so the current implementation treats the behavior change as a fix rather than a regression — but happy to adjust if the team considers it supported.