### PR TITLE
fix: add parent to rule api node types

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -122,6 +122,10 @@ interface JSXIdentifier extends ESTree.BaseNode {
 	name: string;
 }
 
+type NodeWithParent<T extends ESTree.Node = ESTree.Node> = T &
+	Rule.NodeParentExtension;
+type JSXIdentifierWithParent = JSXIdentifier & Rule.NodeParentExtension;
+
 export namespace Scope {
 	interface ScopeManager {
 		scopes: Scope[];
@@ -152,7 +156,7 @@ export namespace Scope {
 		upper: Scope | null;
 		childScopes: Scope[];
 		variableScope: Scope;
-		block: ESTree.Node;
+		block: Rule.Node;
 		variables: Variable[];
 		set: Map<string, Variable>;
 		references: Reference[];
@@ -167,13 +171,13 @@ export namespace Scope {
 	interface Variable {
 		name: string;
 		scope: Scope;
-		identifiers: ESTree.Identifier[];
+		identifiers: NodeWithParent<ESTree.Identifier>[];
 		references: Reference[];
 		defs: Definition[];
 	}
 
 	interface Reference {
-		identifier: ESTree.Identifier | JSXIdentifier;
+		identifier: NodeWithParent<ESTree.Identifier> | JSXIdentifierWithParent;
 		from: Scope;
 		resolved: Variable | null;
 		writeExpr?: ESTree.Expression | null;
@@ -191,48 +195,58 @@ export namespace Scope {
 	}
 
 	type DefinitionType =
-		| { type: "CatchClause"; node: ESTree.CatchClause; parent: null }
+		| {
+				type: "CatchClause";
+				node: NodeWithParent<ESTree.CatchClause>;
+				parent: null;
+		  }
 		| {
 				type: "ClassName";
-				node: ESTree.ClassDeclaration | ESTree.ClassExpression;
+				node:
+					| NodeWithParent<ESTree.ClassDeclaration>
+					| NodeWithParent<ESTree.ClassExpression>;
 				parent: null;
 		  }
 		| {
 				type: "FunctionName";
-				node: ESTree.FunctionDeclaration | ESTree.FunctionExpression;
+				node:
+					| NodeWithParent<ESTree.FunctionDeclaration>
+					| NodeWithParent<ESTree.FunctionExpression>;
 				parent: null;
 		  }
 		| {
 				type: "ImplicitGlobalVariable";
 				node:
-					| ESTree.AssignmentExpression
-					| ESTree.ForInStatement
-					| ESTree.ForOfStatement;
+					| NodeWithParent<ESTree.AssignmentExpression>
+					| NodeWithParent<ESTree.ForInStatement>
+					| NodeWithParent<ESTree.ForOfStatement>;
 				parent: null;
 		  }
 		| {
 				type: "ImportBinding";
 				node:
-					| ESTree.ImportSpecifier
-					| ESTree.ImportDefaultSpecifier
-					| ESTree.ImportNamespaceSpecifier;
+					| NodeWithParent<ESTree.ImportSpecifier>
+					| NodeWithParent<ESTree.ImportDefaultSpecifier>
+					| NodeWithParent<ESTree.ImportNamespaceSpecifier>;
 				parent: ESTree.ImportDeclaration;
 		  }
 		| {
 				type: "Parameter";
 				node:
-					| ESTree.FunctionDeclaration
-					| ESTree.FunctionExpression
-					| ESTree.ArrowFunctionExpression;
+					| NodeWithParent<ESTree.FunctionDeclaration>
+					| NodeWithParent<ESTree.FunctionExpression>
+					| NodeWithParent<ESTree.ArrowFunctionExpression>;
 				parent: null;
 		  }
 		| {
 				type: "Variable";
-				node: ESTree.VariableDeclarator;
+				node: NodeWithParent<ESTree.VariableDeclarator>;
 				parent: ESTree.VariableDeclaration;
 		  };
 
-	type Definition = DefinitionType & { name: ESTree.Identifier };
+	type Definition = DefinitionType & {
+		name: NodeWithParent<ESTree.Identifier>;
+	};
 }
 
 // #region SourceCode
@@ -269,11 +283,11 @@ export class SourceCode implements TextSourceCode<{
 
 	getAllComments(): ESTree.Comment[];
 
-	getAncestors(node: ESTree.Node): ESTree.Node[];
+	getAncestors(node: ESTree.Node): Rule.Node[];
 
 	getDeclaredVariables(node: ESTree.Node): Scope.Variable[];
 
-	getNodeByRangeIndex(index: number): ESTree.Node | null;
+	getNodeByRangeIndex(index: number): Rule.Node | null;
 
 	getLocFromIndex(index: number): ESTree.Position;
 

--- a/tests/lib/types/types.test.mts
+++ b/tests/lib/types/types.test.mts
@@ -146,7 +146,10 @@ sourceCode.getLines();
 
 sourceCode.getAllComments();
 
-sourceCode.getNodeByRangeIndex(0);
+const nodeByRangeIndex = sourceCode.getNodeByRangeIndex(0);
+if (nodeByRangeIndex) {
+	nodeByRangeIndex.parent;
+}
 
 sourceCode.getNodeByRangeIndex(0);
 
@@ -460,6 +463,7 @@ sourceCode.markVariableAsUsed("foo", AST);
 sourceCode.getDeclaredVariables(AST); // $ExpectType Variable[]
 
 sourceCode.getAncestors(AST); // $ExpectType Node[]
+sourceCode.getAncestors(AST)[0].parent;
 
 // #endregion
 
@@ -484,16 +488,20 @@ const scope = scopeManager.scopes[0];
 scope.implicit;
 scope.implicit?.variables;
 scope.implicit?.set;
+scope.block.parent;
 
 const variable = scope.variables[0];
 
 variable.name = "foo";
 
 variable.identifiers[0].type = "Identifier";
+variable.identifiers[0].parent;
 
 variable.defs[0].name.type = "Identifier";
+variable.defs[0].name.parent;
 variable.defs[0].type;
 variable.defs[0].node;
+variable.defs[0].node.parent;
 variable.defs[0].parent;
 
 const reference = scope.references[0];
@@ -501,6 +509,7 @@ const reference = scope.references[0];
 reference.from = scope;
 reference.identifier.type = "Identifier";
 reference.identifier.type = "JSXIdentifier";
+reference.identifier.parent;
 reference.resolved = variable;
 reference.writeExpr = { type: "Identifier", name: "foo" };
 // @ts-expect-error


### PR DESCRIPTION
Fixes #20902.

This PR covers the first, narrower part of the issue: ESLint runtime adds parent links during traversal, but several rule API surfaces expose AST nodes without the existing parent extension in their TypeScript types.

Updated types:

- SourceCode#getAncestors()
- SourceCode#getNodeByRangeIndex()
- Scope#block
- Scope.Variable#identifiers
- Scope.Reference#identifier
- Scope.Definition#name and DefinitionType#node

This intentionally does not add the more precise node-to-parent visitor mapping discussed in the issue comments, so that part can be reviewed separately.

Verification:

- npm run test:types
- npm run test:types:5.3
- npm run test:types:5.x
- npm run test:types:7.x
- npm run fmt:check -- lib/types/index.d.ts tests/lib/types/types.test.mts
- git diff --check