### PR TITLE
feat: report no-with violations at the with keyword

### DIFF
--- a/lib/rules/no-with.js
+++ b/lib/rules/no-with.js
@@ -28,9 +28,15 @@ module.exports = {
 	},
 
 	create(context) {
+		const sourceCode = context.sourceCode;
+
 		return {
 			WithStatement(node) {
-				context.report({ node, messageId: "unexpectedWith" });
+				context.report({
+					node,
+					loc: sourceCode.getFirstToken(node).loc,
+					messageId: "unexpectedWith",
+				});
 			},
 		};
 	},

--- a/tests/lib/rules/no-with.js
+++ b/tests/lib/rules/no-with.js
@@ -31,6 +31,10 @@ ruleTester.run("no-with", rule, {
 			errors: [
 				{
 					messageId: "unexpectedWith",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 5,
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

`no-with` disallows `with` statements. When the rule reports a violation, highlighting the entire `with` statement can be noisy, especially if the body spans multiple lines.

#### What changes did you make? (Give an overview)

Updated `no-with` so violations are reported on the `with` keyword instead of the full `with` statement.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
