### PR TITLE
feat: correct stack tracking in max-nested-callbacks

### DIFF
--- a/lib/rules/max-nested-callbacks.js
+++ b/lib/rules/max-nested-callbacks.js
@@ -109,11 +109,14 @@ module.exports = {
 
 		/**
 		 * Pops the call stack.
+		 * @param {ASTNode} node The node to check.
 		 * @returns {void}
 		 * @private
 		 */
-		function popStack() {
-			callbackStack.pop();
+		function popStack(node) {
+			if (callbackStack.at(-1) === node) {
+				callbackStack.pop();
+			}
 		}
 
 		//--------------------------------------------------------------------------

--- a/tests/lib/rules/max-nested-callbacks.js
+++ b/tests/lib/rules/max-nested-callbacks.js
@@ -81,6 +81,34 @@ ruleTester.run("max-nested-callbacks", rule, {
 			],
 		},
 		{
+			code: "foo(function() { const helper = function() {}; bar(function() { baz(function() {}); }); });",
+			options: [2],
+			errors: [
+				{
+					messageId: "exceed",
+					data: { num: 3, max: 2 },
+					line: 1,
+					column: 69,
+					endLine: 1,
+					endColumn: 77,
+				},
+			],
+		},
+		{
+			code: "foo(function() { const helper = () => {}; bar(function() { baz(function() {}); }); });",
+			options: [2],
+			errors: [
+				{
+					messageId: "exceed",
+					data: { num: 3, max: 2 },
+					line: 1,
+					column: 64,
+					endLine: 1,
+					endColumn: 72,
+				},
+			],
+		},
+		{
 			code: "foo(function() { bar(thing, (data) => { baz(function() {}); }); });",
 			options: [2],
 			languageOptions: { ecmaVersion: 6 },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**

`max-nested-callbacks`

**What change do you want to make (place an "X" next to just one item)?**

[x] Generate more warnings
[ ] Generate fewer warnings
[ ] Implement autofix
[ ] Implement suggestions

**How will the change be implemented (place an "X" next to just one item)?**

[ ] A new option
[x] A new default behavior
[ ] Other

**Please provide some example code that this change will affect:**

```js
/*eslint max-nested-callbacks: ["error", 2]*/

foo(function() {
    const helper = function() {};
    bar(function() {
        baz(function() {});
    });
});
```

**What does the rule currently do for this code?**

The rule does not report an error because exiting the non-callback `helper` function incorrectly pops the callback stack.

**What will the rule do after it's changed?**

The rule preserves the callback stack when exiting non-callback functions, so it reports the third nested callback.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated `max-nested-callbacks` so the callback stack is only popped when the exiting function is the callback currently at the top of the stack.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
