### PR TITLE
fix: honor maximum option when set to zero

### DIFF
--- a/lib/rules/complexity.js
+++ b/lib/rules/complexity.js
@@ -78,7 +78,7 @@ module.exports = {
 				Object.hasOwn(option, "maximum") ||
 				Object.hasOwn(option, "max")
 			) {
-				threshold = option.maximum || option.max;
+				threshold = option.maximum ?? option.max;
 			}
 
 			if (Object.hasOwn(option, "variant")) {

--- a/lib/rules/max-depth.js
+++ b/lib/rules/max-depth.js
@@ -68,7 +68,7 @@ module.exports = {
 			typeof option === "object" &&
 			(Object.hasOwn(option, "maximum") || Object.hasOwn(option, "max"))
 		) {
-			maxDepth = option.maximum || option.max;
+			maxDepth = option.maximum ?? option.max;
 		}
 		if (typeof option === "number") {
 			maxDepth = option;

--- a/lib/rules/max-nested-callbacks.js
+++ b/lib/rules/max-nested-callbacks.js
@@ -71,7 +71,7 @@ module.exports = {
 			typeof option === "object" &&
 			(Object.hasOwn(option, "maximum") || Object.hasOwn(option, "max"))
 		) {
-			THRESHOLD = option.maximum || option.max;
+			THRESHOLD = option.maximum ?? option.max;
 		} else if (typeof option === "number") {
 			THRESHOLD = option;
 		}

--- a/lib/rules/max-params.js
+++ b/lib/rules/max-params.js
@@ -83,7 +83,7 @@ module.exports = {
 				Object.hasOwn(option, "maximum") ||
 				Object.hasOwn(option, "max")
 			) {
-				numParams = option.maximum || option.max;
+				numParams = option.maximum ?? option.max;
 			}
 
 			countThis = option.countThis;

--- a/lib/rules/max-statements.js
+++ b/lib/rules/max-statements.js
@@ -87,7 +87,7 @@ module.exports = {
 			typeof option === "object" &&
 			(Object.hasOwn(option, "maximum") || Object.hasOwn(option, "max"))
 		) {
-			maxStatements = option.maximum || option.max;
+			maxStatements = option.maximum ?? option.max;
 		} else if (typeof option === "number") {
 			maxStatements = option;
 		}

--- a/tests/lib/rules/complexity.js
+++ b/tests/lib/rules/complexity.js
@@ -863,6 +863,11 @@ ruleTester.run("complexity", rule, {
 			errors: [makeError("Function 'a'", 1, 0)],
 		},
 		{
+			code: "function a(x) {}",
+			options: [{ maximum: 0 }],
+			errors: [makeError("Function 'a'", 1, 0)],
+		},
+		{
 			code: "const obj = { b: (a) => a?.b?.c, c: function (a) { return a?.b?.c; } };",
 			options: [{ max: 2 }],
 			errors: [

--- a/tests/lib/rules/max-depth.js
+++ b/tests/lib/rules/max-depth.js
@@ -267,6 +267,20 @@ ruleTester.run("max-depth", rule, {
 				},
 			],
 		},
+		{
+			code: "function foo() { if (true) {} }",
+			options: [{ maximum: 0 }],
+			errors: [
+				{
+					messageId: "tooDeeply",
+					data: { depth: 1, maxDepth: 0 },
+					line: 1,
+					column: 18,
+					endLine: 1,
+					endColumn: 20,
+				},
+			],
+		},
 
 		{
 			code: "class C { static { if (1) { if (2) { if (3) {} } } } }",

--- a/tests/lib/rules/max-nested-callbacks.js
+++ b/tests/lib/rules/max-nested-callbacks.js
@@ -165,6 +165,20 @@ ruleTester.run("max-nested-callbacks", rule, {
 				},
 			],
 		},
+		{
+			code: "foo(function() {})",
+			options: [{ maximum: 0 }],
+			errors: [
+				{
+					messageId: "exceed",
+					data: { num: 1, max: 0 },
+					line: 1,
+					column: 5,
+					endLine: 1,
+					endColumn: 13,
+				},
+			],
+		},
 
 		// object property options
 		{

--- a/tests/lib/rules/max-params.js
+++ b/tests/lib/rules/max-params.js
@@ -125,6 +125,16 @@ ruleTester.run("max-params", rule, {
 				},
 			],
 		},
+		{
+			code: "function test(a) {}",
+			options: [{ maximum: 0 }],
+			errors: [
+				{
+					messageId: "exceed",
+					data: { name: "Function 'test'", count: 1, max: 0 },
+				},
+			],
+		},
 
 		// Error location should not cover the entire function; just the name.
 		{

--- a/tests/lib/rules/max-statements.js
+++ b/tests/lib/rules/max-statements.js
@@ -390,6 +390,20 @@ ruleTester.run("max-statements", rule, {
 			],
 		},
 		{
+			code: "function foo() { 1; }",
+			options: [{ maximum: 0 }],
+			errors: [
+				{
+					messageId: "exceed",
+					data: { name: "Function 'foo'", count: 1, max: 0 },
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 13,
+				},
+			],
+		},
+		{
 			code: "function foo() { foo_1; /* foo_ 2 */ class C { static { one; two; three; four; { five; six; seven; eight; } } } foo_3 }",
 			options: [2],
 			languageOptions: { ecmaVersion: 2022 },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:** v24.16.0
- **npm version:** v11.13.0
- **Local ESLint version:** v10.4.1
- **Global ESLint version:** v10.4.1
- **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->

```js
{
    rules: {
        complexity: ["error", { maximum: 0 }],
        "max-depth": ["error", { maximum: 0 }],
        "max-nested-callbacks": ["error", { maximum: 0 }],
        "max-params": ["error", { maximum: 0 }],
        "max-statements": ["error", { maximum: 0 }]
    }
}
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
function test(a) {
    if (a) {
        foo(function() {});
    }

    bar();
}
```

**What did you expect to happen?**

ESLint should treat `{ maximum: 0 }` the same as `{ max: 0 }` and report violations.

**What actually happened? Please include the actual, raw output from ESLint.**

The affected rules did not honor `maximum: 0` because the option value was resolved with `option.maximum || option.max`.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated `complexity`, `max-depth`, `max-nested-callbacks`, `max-params`, and `max-statements` to preserve `0` when resolving the `maximum` option.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
