### PR TITLE
fix: make max-params `max` and `maximum` options mutually exclusive

### DIFF
--- a/lib/rules/max-params.js
+++ b/lib/rules/max-params.js
@@ -59,7 +59,10 @@ module.exports = {
 							},
 						},
 						additionalProperties: false,
-						not: { required: ["countVoidThis", "countThis"] },
+						allOf: [
+							{ not: { required: ["countVoidThis", "countThis"] } },
+							{ not: { required: ["max", "maximum"] } },
+						],
 					},
 				],
 			},
@@ -79,11 +82,10 @@ module.exports = {
 		let countThis = "except-void";
 
 		if (typeof option === "object") {
-			if (
-				Object.hasOwn(option, "maximum") ||
-				Object.hasOwn(option, "max")
-			) {
-				numParams = option.maximum || option.max;
+			if (Object.hasOwn(option, "maximum")) {
+				numParams = option.maximum;
+			} else if (Object.hasOwn(option, "max")) {
+				numParams = option.max;
 			}
 
 			countThis = option.countThis;


### PR DESCRIPTION
## Description

This PR fixes #20322 by making the `max` and `maximum` options in the `max-params` rule mutually exclusive at the schema level, and fixing the runtime code to handle `maximum: 0` correctly.

## Changes

1. **Schema validation**: Added `allOf` with `not: { required: ["max", "maximum"] }` constraint, so specifying both options now produces a configuration validation error instead of silently letting one win.

2. **Runtime fix**: Changed `option.maximum || option.max` to explicit `if/else if` checks. The `||` operator incorrectly handled `maximum: 0` (falsy) — it would fall through to `option.max` (undefined), making `numParams` undefined and breaking the rule.

3. **Bonus**: Also used `allOf` to combine the existing `countVoidThis`/`countThis` mutual exclusion constraint with the new one, keeping the schema clean.

## Verification

- `{ max: 5 }` → works as before
- `{ maximum: 5 }` → now correctly uses 5 (previously worked only via `||` fallback)
- `{ maximum: 0 }` → now correctly sets 0 (previously fell through to `undefined`)
- `{ max: 2, maximum: 3 }` → schema validation error (previously `maximum` silently won)

Closes #20322