### PR TITLE
fix: callback detection logic for IIFEs in max-nested-callbacks

### DIFF
--- a/lib/rules/max-nested-callbacks.js
+++ b/lib/rules/max-nested-callbacks.js
@@ -91,11 +91,7 @@ module.exports = {
 		function checkFunction(node) {
 			const parent = node.parent;
 
-			if (
-				 (parent.type !== "CallExpression" ||
-					parent.type === "NewExpression") &&
-				parent.callee !== node
-			) {
+			if (parent.type !== "CallExpression" || parent.callee === node) {
 				return;
 			}
 

--- a/lib/rules/max-nested-callbacks.js
+++ b/lib/rules/max-nested-callbacks.js
@@ -91,7 +91,11 @@ module.exports = {
 		function checkFunction(node) {
 			const parent = node.parent;
 
-			if (parent.type !== "CallExpression") {
+			if (
+				 (parent.type !== "CallExpression" ||
+					parent.type === "NewExpression") &&
+				parent.callee !== node
+			) {
 				return;
 			}
 

--- a/tests/lib/rules/max-nested-callbacks.js
+++ b/tests/lib/rules/max-nested-callbacks.js
@@ -64,6 +64,16 @@ ruleTester.run("max-nested-callbacks", rule, {
 			code: "foo(function() { bar(thing, function(data) {}); });",
 			options: [{ max: 3 }],
 		},
+
+		// callback detection
+		{
+			code: "(() => {})();",
+			options: [{ max: 0 }],
+		},
+		{
+			code: "(function() {})();",
+			options: [{ max: 0 }],
+		},
 	],
 	invalid: [
 		{
@@ -242,6 +252,106 @@ ruleTester.run("max-nested-callbacks", rule, {
 					column: 50,
 					endLine: 1,
 					endColumn: 58,
+				},
+			],
+		},
+
+		// callback detection
+		{
+			code: "fn('before', () => 'counted', 'after');",
+			options: [{ max: 0 }],
+			errors: [
+				{
+					messageId: "exceed",
+					data: { num: 1, max: 0 },
+					line: 1,
+					column: 17,
+					endLine: 1,
+					endColumn: 19,
+				},
+			],
+		},
+		{
+			code: "object.method(() => 'counted');",
+			options: [{ max: 0 }],
+			errors: [
+				{
+					messageId: "exceed",
+					data: { num: 1, max: 0 },
+					line: 1,
+					column: 18,
+					endLine: 1,
+					endColumn: 20,
+				},
+			],
+		},
+		{
+			code: "(() => {})(() => 'counted');",
+			options: [{ max: 0 }],
+			errors: [
+				{
+					messageId: "exceed",
+					data: { num: 1, max: 0 },
+					line: 1,
+					column: 15,
+					endLine: 1,
+					endColumn: 17,
+				},
+			],
+		},
+		{
+			code: "new Promise(() => {});",
+			options: [{ max: 0 }],
+			errors: [
+				{
+					messageId: "exceed",
+					data: { num: 1, max: 0 },
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 18,
+				},
+			],
+		},
+		{
+			code: "fn(() => { new Promise(() => {}); });",
+			options: [{ max: 1 }],
+			errors: [
+				{
+					messageId: "exceed",
+					data: { num: 2, max: 1 },
+					line: 1,
+					column: 27,
+					endLine: 1,
+					endColumn: 29,
+				},
+			],
+		},
+		{
+			code: "new Promise(() => { fn(() => {}); });",
+			options: [{ max: 1 }],
+			errors: [
+				{
+					messageId: "exceed",
+					data: { num: 2, max: 1 },
+					line: 1,
+					column: 27,
+					endLine: 1,
+					endColumn: 29,
+				},
+			],
+		},
+		{
+			code: "new Promise(() => { new Promise(() => {}); });",
+			options: [{ max: 1 }],
+			errors: [
+				{
+					messageId: "exceed",
+					data: { num: 2, max: 1 },
+					line: 1,
+					column: 36,
+					endLine: 1,
+					endColumn: 38,
 				},
 			],
 		},

--- a/tests/lib/rules/max-nested-callbacks.js
+++ b/tests/lib/rules/max-nested-callbacks.js
@@ -77,7 +77,7 @@ ruleTester.run("max-nested-callbacks", rule, {
 		{
 			code: "new Promise(() => {});",
 			options: [{ max: 0 }],
-		}
+		},
 	],
 	invalid: [
 		{

--- a/tests/lib/rules/max-nested-callbacks.js
+++ b/tests/lib/rules/max-nested-callbacks.js
@@ -74,6 +74,10 @@ ruleTester.run("max-nested-callbacks", rule, {
 			code: "(function() {})();",
 			options: [{ max: 0 }],
 		},
+		{
+			code: "new Promise(() => {});",
+			options: [{ max: 0 }],
+		}
 	],
 	invalid: [
 		{
@@ -296,62 +300,6 @@ ruleTester.run("max-nested-callbacks", rule, {
 					column: 15,
 					endLine: 1,
 					endColumn: 17,
-				},
-			],
-		},
-		{
-			code: "new Promise(() => {});",
-			options: [{ max: 0 }],
-			errors: [
-				{
-					messageId: "exceed",
-					data: { num: 1, max: 0 },
-					line: 1,
-					column: 16,
-					endLine: 1,
-					endColumn: 18,
-				},
-			],
-		},
-		{
-			code: "fn(() => { new Promise(() => {}); });",
-			options: [{ max: 1 }],
-			errors: [
-				{
-					messageId: "exceed",
-					data: { num: 2, max: 1 },
-					line: 1,
-					column: 27,
-					endLine: 1,
-					endColumn: 29,
-				},
-			],
-		},
-		{
-			code: "new Promise(() => { fn(() => {}); });",
-			options: [{ max: 1 }],
-			errors: [
-				{
-					messageId: "exceed",
-					data: { num: 2, max: 1 },
-					line: 1,
-					column: 27,
-					endLine: 1,
-					endColumn: 29,
-				},
-			],
-		},
-		{
-			code: "new Promise(() => { new Promise(() => {}); });",
-			options: [{ max: 1 }],
-			errors: [
-				{
-					messageId: "exceed",
-					data: { num: 2, max: 1 },
-					line: 1,
-					column: 36,
-					endLine: 1,
-					endColumn: 38,
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**
- `max-nested-callbacks`

**What change do you want to make (place an "X" next to just one item)?**

[x] Generate more warnings
[ ] Generate fewer warnings
[ ] Implement autofix
[ ] Implement suggestions

**How will the change be implemented (place an "X" next to just one item)?**

[ ] A new option
[x] A new default behavior
[ ] Other

**Please provide some example code that this change will affect:**

```js
new Promise(() => {});
(() => {})();
```

**What does the rule currently do for this code?**
Ignores the callback passed to the [constructor](https://eslint.org/play/#eyJ0ZXh0IjoibmV3IFByb21pc2UoKCkgPT4ge30pOyIsIm9wdGlvbnMiOnsicnVsZXMiOnsibWF4LW5lc3RlZC1jYWxsYmFja3MiOlsiZXJyb3IiLHsibWF4IjowfV19LCJsYW5ndWFnZU9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hRmVhdHVyZXMiOnt9fX19fQ==) and counts an [IIFE](https://eslint.org/play/#eyJ0ZXh0IjoiKCgpID0+IHt9KSgpIiwib3B0aW9ucyI6eyJydWxlcyI6eyJtYXgtbmVzdGVkLWNhbGxiYWNrcyI6WyJlcnJvciIseyJtYXgiOjB9XX0sImxhbmd1YWdlT3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFGZWF0dXJlcyI6e319fX19).

**What will the rule do after it's changed?**
Count the callback to the constructor and ignore IIFEs.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Improve the callback detection of `max-nested-callbacks`:
- Does not count IIFEs as a callback (`(() => {})()`)
- Counts functions passed to a constructor call as a callback (`new Promise(() => {})`)

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
