### PR TITLE
docs: document ESLint migration codemods in v9 and v10 guides

### DIFF
--- a/docs/src/use/migrate-to-10.0.0.md
+++ b/docs/src/use/migrate-to-10.0.0.md
@@ -11,7 +11,7 @@ eleventyNavigation:
 
 ESLint v10.0.0 is a major release of ESLint, and as such, has several breaking changes that you need to be aware of. This guide is intended to walk you through the breaking changes.
 
-To help with this migration, ESLint provides migration codemods to automate many of the changes described in this guide. All official ESLint codemods are available in the [eslint/codemods](https://github.com/eslint/codemods) repository and through the [Codemod Registry](https://codemod.link/eslint).
+To help with this migration, ESLint provides migration codemods to automate many of the changes described in this guide. All official ESLint codemods are available in the [eslint/codemods](https://github.com/eslint/codemods) repository and through the [Codemod Registry](https://app.codemod.com/registry?q=scope%3Aeslint).
 
 ## Use migration codemods
 

--- a/docs/src/use/migrate-to-10.0.0.md
+++ b/docs/src/use/migrate-to-10.0.0.md
@@ -82,6 +82,7 @@ ESLint is officially dropping support for these versions of Node.js starting wit
 - Node.js v24 and above
 
 **Codemod:** The migration codemods do not cover this change.
+
 **To address:** Make sure you upgrade to at least Node.js v20.19.0 when using ESLint v10.0.0. One important thing to double check is the Node.js version supported by your editor when using ESLint via editor integrations. If you are unable to upgrade, we recommend continuing to use ESLint v9 until you are able to upgrade Node.js.
 
 **Related issue(s):** [#19969](https://github.com/eslint/eslint/issues/19969)

--- a/docs/src/use/migrate-to-10.0.0.md
+++ b/docs/src/use/migrate-to-10.0.0.md
@@ -24,7 +24,7 @@ The `@eslint/v9-to-v10` codemod upgrades ESLint projects from v9 to v10. It incl
 npx codemod @eslint/v9-to-v10
 ```
 
-Learn more in the [Codemod Registry](https://codemod.link/eslint).
+Learn more in the [Codemod Registry](https://app.codemod.com/registry?q=scope%3Aeslint).
 
 Codemods are a starting point. Review the changes and consult the breaking changes below for anything the codemods do not cover.
 

--- a/docs/src/use/migrate-to-10.0.0.md
+++ b/docs/src/use/migrate-to-10.0.0.md
@@ -95,7 +95,9 @@ Three new rules have been enabled in `eslint:recommended`:
 - [`no-useless-assignment`](../rules/no-useless-assignment)
 - [`preserve-caught-error`](../rules/preserve-caught-error)
 
-**To address:** The migration codemods do not cover this change. Fix errors or disable these rules.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** Fix errors or disable these rules.
 
 **Related issue(s):** [#19966](https://github.com/eslint/eslint/issues/19966)
 
@@ -103,9 +105,11 @@ Three new rules have been enabled in `eslint:recommended`:
 
 In ESLint v9, the alternate config lookup behavior could be enabled with the `v10_config_lookup_from_file` feature flag. This behavior made ESLint locate `eslint.config.*` by starting from the directory of each linted file and searching up towards the filesystem root. In ESLint v10.0.0, this behavior is now the default and the `v10_config_lookup_from_file` flag has been removed. Attempting to use this flag will now result in an error.
 
+**Codemod:** Use the [@eslint/v9-to-v10-config](#use-migration-codemods) codemod to remove legacy flags from your setup.
+
 **To address:**
 
-- Use the [@eslint/v9-to-v10-config](#use-migration-codemods) codemod to remove legacy flags from your setup, or remove them manually:
+- Remove legacy flags manually:
     - CLI: remove `--flag v10_config_lookup_from_file`.
     - Environment: remove `v10_config_lookup_from_file` from `ESLINT_FLAGS`.
     - API: remove `"v10_config_lookup_from_file"` from the `flags` array passed to `new ESLint()` or `new Linter()`.
@@ -119,10 +123,12 @@ ESLint v9 introduced a [new default configuration format](./configure/configurat
 
 Starting with ESLint v10.0.0, the old configuration format is no longer supported.
 
+**Codemod:** Use the [@eslint/v9-to-v10](#use-migration-codemods) codemod to automate much of this migration. Use the [@eslint/v9-to-v10-linter-api](#use-migration-codemods) codemod to update deprecated `FlatESLint` and `LegacyESLint` usage.
+
 **To address:**
 
-- Use the [@eslint/v9-to-v10](#use-migration-codemods) codemod to automate much of this migration, or follow the instructions in the [configuration migration guide](./configure/migration-guide).
-- Be aware that the deprecated APIs `FlatESLint` and `LegacyESLint` have been removed. Use the [@eslint/v9-to-v10-linter-api](#use-migration-codemods) codemod or always use `ESLint` instead.
+- Or follow the instructions in the [configuration migration guide](./configure/migration-guide).
+- Be aware that the deprecated APIs `FlatESLint` and `LegacyESLint` have been removed. Always use `ESLint` instead.
 - The `configType` option of the `Linter` class can no longer be set to `"eslintrc"`. Remove the option to use the new configuration format.
 
 **Related issue(s):** [#13481](https://github.com/eslint/eslint/issues/13481)
@@ -143,7 +149,9 @@ export function createCard(name) {
 
 Prior to v10.0.0, ESLint did not recognize that `<Card>` is a reference to the imported `Card`, which could result in false positives such as reporting `Card` as "defined but never used" ([`no-unused-vars`](../rules/no-unused-vars)) or false negatives such as failing to report `Card` as undefined ([`no-undef`](../rules/no-undef)) if the import is removed. Starting with v10.0.0, `<Card>` is treated as a normal reference to the variable in scope. This brings JSX handling in line with developer expectations and improves the linting experience for modern JavaScript applications using JSX.
 
-**To address:** The migration codemods do not cover this change.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:**
 
 - For users:
     - New linting reports may appear in files with JSX. Update your code accordingly or adjust rule configurations if needed.
@@ -162,7 +170,9 @@ error: /* eslint-env */ comments are no longer supported at file.js:1:1:
     | ^
 ```
 
-**To address:** The migration codemods do not cover this change. Remove any `eslint-env` comments from your code. If you are still using the old configuration system and need help migrating, check the [migration guide](./configure/migration-guide#eslint-env-configuration-comments).
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** Remove any `eslint-env` comments from your code. If you are still using the old configuration system and need help migrating, check the [migration guide](./configure/migration-guide#eslint-env-configuration-comments).
 
 **Related issue(s):** [#13481](https://github.com/eslint/eslint/issues/13481)
 
@@ -170,7 +180,9 @@ error: /* eslint-env */ comments are no longer supported at file.js:1:1:
 
 ESLint is officially dropping support for versions of `jiti` that are less than v2.2.0.
 
-**To address:** The migration codemods do not cover this change. If you've authored your config file in `TypeScript` and have `jiti` v2.1.2 or earlier installed, be sure to update it to at least `2.2.0` when using ESLint v10.0.0.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** If you've authored your config file in `TypeScript` and have `jiti` v2.1.2 or earlier installed, be sure to update it to at least `2.2.0` when using ESLint v10.0.0.
 
 **Related issue(s):** [#19765](https://github.com/eslint/eslint/issues/19765)
 
@@ -186,7 +198,9 @@ npx eslint "**/[[:upper:]]*.js"
 
 Here, `[[:upper:]]` is a POSIX character class that matches uppercase letters in different alphabets.
 
-**To address:** The migration codemods do not cover this change. If any of the glob patterns in your configuration, CLI arguments, or Node.js API calls look like containing a POSIX character class, verify that they match files as intended.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** If any of the glob patterns in your configuration, CLI arguments, or Node.js API calls look like containing a POSIX character class, verify that they match files as intended.
 
 **Related issue(s):** [eslint/rewrite#66](https://github.com/eslint/rewrite/issues/66)
 
@@ -202,7 +216,9 @@ Starting in ESLint v10.0.0, the built-in [`stylish`](./formatters#stylish) forma
 
 2. Second, `--color` and `--no-color` CLI flags now have higher precedence than environment variables when determining whether to use colorized output. This change ensures that explicit user preferences via CLI flags are prioritized. However, if neither flag is provided, environment variables will be considered as before.
 
-**To address:** The migration codemods do not cover this change.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:**
 
 - Review any environment configuration related to terminal colors (for example, CI defaults or shell profiles). If ESLint's output appears uncolored after upgrading to v10.0.0, check whether `NO_COLOR` or `NODE_DISABLE_COLORS` (or similar settings) are being set in your environment.
 - If you rely on mixed approaches (for example, using `--color` flag but also setting `NO_COLOR` environment variable), be aware that the CLI flags now take precedence and adjust your setup accordingly.
@@ -215,7 +231,9 @@ As of ESLint v10.0.0, string options `"always"` and `"as-needed"` of the [`radix
 
 The default behavior of this rule has not been changed.
 
-**To address:** The migration codemods do not cover this change.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:**
 
 - If you are using this rule without any options specified, there is no action required.
 - If you are using this rule with the `"always"` option explicitly specified, remove the option. The behavior of this rule will remain the same.
@@ -227,7 +245,9 @@ The default behavior of this rule has not been changed.
 
 In ESLint v10.0.0, the [`no-shadow-restricted-names`](../rules/no-shadow-restricted-names) rule now treats `globalThis` as a restricted name by default. Consequently, the `reportGlobalThis` option now defaults to `true` (previously `false`). As a result, declarations such as `const globalThis = "foo";` or `function globalThis() {}` will now be reported by default.
 
-**To address:** The migration codemods do not cover this change.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:**
 
 - Rename local identifiers named `globalThis` to avoid shadowing the global.
 - Or restore the previous behavior by configuring the rule explicitly:
@@ -252,7 +272,9 @@ For example, this configuration is now invalid due to the extra element `"foo"`:
 /*eslint func-names: ["error", "always", { "generators": "never" }, "foo"]*/
 ```
 
-**To address:** The migration codemods do not cover this change.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:**
 
 - Remove any extra array elements from your `func-names` configuration so that it contains only:
     - a base string option: `"always" | "as-needed" | "never"`, and
@@ -270,7 +292,9 @@ For example, this configuration is now invalid due to the duplicate `"u"` flag:
 /*eslint no-invalid-regexp: ["error", { "allowConstructorFlags": ["u", "y", "u"] }]*/
 ```
 
-**To address:** The migration codemods do not cover this change. Remove any duplicate flags from your `allowConstructorFlags` array configuration of `no-invalid-regexp` rule. Each flag should appear only once in the array.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** Remove any duplicate flags from your `allowConstructorFlags` array configuration of `no-invalid-regexp` rule. Each flag should appear only once in the array.
 
 **Related issue(s):** [#18755](https://github.com/eslint/eslint/issues/18755)
 
@@ -280,7 +304,9 @@ In ESLint v10.0.0, the `name` property has been restored to the ESLint core conf
 
 This change should not require any action for most users. However, if you are using `@eslint/js` v10.x with the `FlatCompat` utility from `@eslint/eslintrc`, you should upgrade `@eslint/eslintrc` to the latest version to ensure compatibility.
 
-**To address:** The migration codemods do not cover this change. Upgrade `@eslint/eslintrc` to the latest version if you are using `FlatCompat`.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** Upgrade `@eslint/eslintrc` to the latest version if you are using `FlatCompat`.
 
 **Related issue(s):** [#19864](https://github.com/eslint/eslint/issues/19864)
 
@@ -288,7 +314,9 @@ This change should not require any action for most users. However, if you are us
 
 In ESLint v10.0.0, the deprecated `type` property in errors of invalid test cases for rules has been removed. Using the `type` property in test cases now throws an error.
 
-**To address:** Use the [@eslint/v9-to-v10-ruletester](#use-migration-codemods) codemod to automate this change, or remove the `type` property from error objects in invalid test cases manually.
+**Codemod:** Use the [@eslint/v9-to-v10-ruletester](#use-migration-codemods) codemod to automate this change.
+
+**To address:** Remove the `type` property from error objects in invalid test cases manually.
 
 **Related issue(s):** [#19029](https://github.com/eslint/eslint/issues/19029)
 
@@ -308,7 +336,9 @@ In ESLint v9 and earlier, `Program.range` covers only `const x = 1;` (excludes s
 
 Starting with ESLint v10.0.0, `Program.range` covers the entire source text, including the leading and trailing comments/whitespace.
 
-**To address:** The migration codemods do not cover this change.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:**
 
 - For rule and plugin authors: If your code depends on the previous `Program.range` behavior, or on `SourceCode` methods that assume it (such as `sourceCode.getCommentsBefore(programNode)` to retrieve all leading comments), update your logic. If your code reports on the `Program` node, update your logic to report on the first statement within the `Program` node, i.e. `node.body[0] ?? node`, to ensure the directive `/* eslint-disable your-rule */` can still work.
 - For custom parsers: Set `Program.range` to cover the full source text (typically `[0, code.length]`).
@@ -328,7 +358,9 @@ Affected methods:
 - `replaceText(nodeOrToken, text)`
 - `replaceTextRange(range, text)`
 
-**To address:** The migration codemods do not cover this change. Ensure the `text` value you pass to fixer methods is a string.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** Ensure the `text` value you pass to fixer methods is a string.
 
 **Related issue(s):** [#18807](https://github.com/eslint/eslint/issues/18807)
 
@@ -340,7 +372,9 @@ The default `ScopeManager` implementation [`eslint-scope`](https://www.npmjs.com
 
 This change does not affect custom rules.
 
-**To address:** The migration codemods do not cover this change. If you maintain a custom parser that provides a custom `ScopeManager` implementation, update your custom `ScopeManager` implementation.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** If you maintain a custom parser that provides a custom `ScopeManager` implementation, update your custom `ScopeManager` implementation.
 
 **Related issue(s):** [eslint/js#665](https://github.com/eslint/js/issues/665)
 
@@ -357,7 +391,9 @@ In ESLint v9.x, we deprecated the following [methods](https://eslint.org/blog/20
 
 In ESLint v10.0.0, all of these members have been removed.
 
-**To address:** Use the [@eslint/v9-to-v10-custom-rules](#use-migration-codemods) codemod to automate this change, or in your custom rules, make the following changes:
+**Codemod:** Use the [@eslint/v9-to-v10-custom-rules](#use-migration-codemods) codemod to automate this change.
+
+**To address:** In your custom rules, make the following changes:
 
 | **Removed on `context`**        | **Replacement on `context`**                                         |
 | ------------------------------- | -------------------------------------------------------------------- |
@@ -396,7 +432,9 @@ The following deprecated `SourceCode` methods have been removed in ESLint v10.0.
 
 These methods have been deprecated for multiple major versions and were primarily used by deprecated formatting rules and internal ESLint utilities. Custom rules using these methods must be updated to use their modern replacements.
 
-**To address:** Use the [@eslint/v9-to-v10-custom-rules](#use-migration-codemods) codemod to automate this change, or in your custom rules, make the following changes:
+**Codemod:** Use the [@eslint/v9-to-v10-custom-rules](#use-migration-codemods) codemod to automate this change.
+
+**To address:** In your custom rules, make the following changes:
 
 | **Removed on `SourceCode`**                  | **Replacement**                                                |
 | -------------------------------------------- | -------------------------------------------------------------- |
@@ -433,7 +471,9 @@ const validTestCases = [
 ruleTester.run("rule-id", rule, { valid: validTestCases, invalid: [] });
 ```
 
-**To address:** Use the [@eslint/v9-to-v10-ruletester](#use-migration-codemods) codemod to automate this change, or remove any `errors`/`output` properties from valid test cases manually.
+**Codemod:** Use the [@eslint/v9-to-v10-ruletester](#use-migration-codemods) codemod to automate this change.
+
+**To address:** Remove any `errors`/`output` properties from valid test cases manually.
 
 **Related issue(s):** [#18960](https://github.com/eslint/eslint/issues/18960)
 
@@ -441,6 +481,8 @@ ruleTester.run("rule-id", rule, { valid: validTestCases, invalid: [] });
 
 In ESLint v10.0.0, the deprecated `nodeType` property on `LintMessage` objects has been removed. This affects consumers of the Node.js API (for example, custom formatters and editor/tool integrations) that previously relied on `message.nodeType`.
 
-**To address:** Use the [@eslint/v9-to-v10-linter-api](#use-migration-codemods) codemod to automate this change, or remove all usages of `message.nodeType` in your integrations and formatters manually.
+**Codemod:** Use the [@eslint/v9-to-v10-linter-api](#use-migration-codemods) codemod to automate this change.
+
+**To address:** Remove all usages of `message.nodeType` in your integrations and formatters manually.
 
 **Related issue(s):** [#19029](https://github.com/eslint/eslint/issues/19029)

--- a/docs/src/use/migrate-to-10.0.0.md
+++ b/docs/src/use/migrate-to-10.0.0.md
@@ -94,7 +94,6 @@ Three new rules have been enabled in `eslint:recommended`:
 - [`no-useless-assignment`](../rules/no-useless-assignment)
 - [`preserve-caught-error`](../rules/preserve-caught-error)
 
-**Codemod:** The migration codemods do not cover this change.
 
 **To address:** Fix errors or disable these rules.
 
@@ -148,7 +147,6 @@ export function createCard(name) {
 
 Prior to v10.0.0, ESLint did not recognize that `<Card>` is a reference to the imported `Card`, which could result in false positives such as reporting `Card` as "defined but never used" ([`no-unused-vars`](../rules/no-unused-vars)) or false negatives such as failing to report `Card` as undefined ([`no-undef`](../rules/no-undef)) if the import is removed. Starting with v10.0.0, `<Card>` is treated as a normal reference to the variable in scope. This brings JSX handling in line with developer expectations and improves the linting experience for modern JavaScript applications using JSX.
 
-**Codemod:** The migration codemods do not cover this change.
 
 **To address:**
 
@@ -169,7 +167,6 @@ error: /* eslint-env */ comments are no longer supported at file.js:1:1:
     | ^
 ```
 
-**Codemod:** The migration codemods do not cover this change.
 
 **To address:** Remove any `eslint-env` comments from your code. If you are still using the old configuration system and need help migrating, check the [migration guide](./configure/migration-guide#eslint-env-configuration-comments).
 
@@ -179,7 +176,6 @@ error: /* eslint-env */ comments are no longer supported at file.js:1:1:
 
 ESLint is officially dropping support for versions of `jiti` that are less than v2.2.0.
 
-**Codemod:** The migration codemods do not cover this change.
 
 **To address:** If you've authored your config file in `TypeScript` and have `jiti` v2.1.2 or earlier installed, be sure to update it to at least `2.2.0` when using ESLint v10.0.0.
 
@@ -197,7 +193,6 @@ npx eslint "**/[[:upper:]]*.js"
 
 Here, `[[:upper:]]` is a POSIX character class that matches uppercase letters in different alphabets.
 
-**Codemod:** The migration codemods do not cover this change.
 
 **To address:** If any of the glob patterns in your configuration, CLI arguments, or Node.js API calls look like containing a POSIX character class, verify that they match files as intended.
 
@@ -215,7 +210,6 @@ Starting in ESLint v10.0.0, the built-in [`stylish`](./formatters#stylish) forma
 
 2. Second, `--color` and `--no-color` CLI flags now have higher precedence than environment variables when determining whether to use colorized output. This change ensures that explicit user preferences via CLI flags are prioritized. However, if neither flag is provided, environment variables will be considered as before.
 
-**Codemod:** The migration codemods do not cover this change.
 
 **To address:**
 
@@ -230,7 +224,6 @@ As of ESLint v10.0.0, string options `"always"` and `"as-needed"` of the [`radix
 
 The default behavior of this rule has not been changed.
 
-**Codemod:** The migration codemods do not cover this change.
 
 **To address:**
 
@@ -244,7 +237,6 @@ The default behavior of this rule has not been changed.
 
 In ESLint v10.0.0, the [`no-shadow-restricted-names`](../rules/no-shadow-restricted-names) rule now treats `globalThis` as a restricted name by default. Consequently, the `reportGlobalThis` option now defaults to `true` (previously `false`). As a result, declarations such as `const globalThis = "foo";` or `function globalThis() {}` will now be reported by default.
 
-**Codemod:** The migration codemods do not cover this change.
 
 **To address:**
 
@@ -271,7 +263,6 @@ For example, this configuration is now invalid due to the extra element `"foo"`:
 /*eslint func-names: ["error", "always", { "generators": "never" }, "foo"]*/
 ```
 
-**Codemod:** The migration codemods do not cover this change.
 
 **To address:**
 
@@ -291,7 +282,6 @@ For example, this configuration is now invalid due to the duplicate `"u"` flag:
 /*eslint no-invalid-regexp: ["error", { "allowConstructorFlags": ["u", "y", "u"] }]*/
 ```
 
-**Codemod:** The migration codemods do not cover this change.
 
 **To address:** Remove any duplicate flags from your `allowConstructorFlags` array configuration of `no-invalid-regexp` rule. Each flag should appear only once in the array.
 
@@ -303,7 +293,6 @@ In ESLint v10.0.0, the `name` property has been restored to the ESLint core conf
 
 This change should not require any action for most users. However, if you are using `@eslint/js` v10.x with the `FlatCompat` utility from `@eslint/eslintrc`, you should upgrade `@eslint/eslintrc` to the latest version to ensure compatibility.
 
-**Codemod:** The migration codemods do not cover this change.
 
 **To address:** Upgrade `@eslint/eslintrc` to the latest version if you are using `FlatCompat`.
 
@@ -335,7 +324,7 @@ In ESLint v9 and earlier, `Program.range` covers only `const x = 1;` (excludes s
 
 Starting with ESLint v10.0.0, `Program.range` covers the entire source text, including the leading and trailing comments/whitespace.
 
-**Codemod:** The migration codemods do not cover this change.
+
 
 **To address:**
 
@@ -357,7 +346,7 @@ Affected methods:
 - `replaceText(nodeOrToken, text)`
 - `replaceTextRange(range, text)`
 
-**Codemod:** The migration codemods do not cover this change.
+
 
 **To address:** Ensure the `text` value you pass to fixer methods is a string.
 
@@ -371,7 +360,7 @@ The default `ScopeManager` implementation [`eslint-scope`](https://www.npmjs.com
 
 This change does not affect custom rules.
 
-**Codemod:** The migration codemods do not cover this change.
+
 
 **To address:** If you maintain a custom parser that provides a custom `ScopeManager` implementation, update your custom `ScopeManager` implementation.
 

--- a/docs/src/use/migrate-to-10.0.0.md
+++ b/docs/src/use/migrate-to-10.0.0.md
@@ -81,7 +81,6 @@ ESLint is officially dropping support for these versions of Node.js starting wit
 - Node.js v22.13.0 and above
 - Node.js v24 and above
 
-**Codemod:** The migration codemods do not cover this change.
 
 **To address:** Make sure you upgrade to at least Node.js v20.19.0 when using ESLint v10.0.0. One important thing to double check is the Node.js version supported by your editor when using ESLint via editor integrations. If you are unable to upgrade, we recommend continuing to use ESLint v9 until you are able to upgrade Node.js.
 

--- a/docs/src/use/migrate-to-10.0.0.md
+++ b/docs/src/use/migrate-to-10.0.0.md
@@ -81,7 +81,6 @@ ESLint is officially dropping support for these versions of Node.js starting wit
 - Node.js v22.13.0 and above
 - Node.js v24 and above
 
-
 **To address:** Make sure you upgrade to at least Node.js v20.19.0 when using ESLint v10.0.0. One important thing to double check is the Node.js version supported by your editor when using ESLint via editor integrations. If you are unable to upgrade, we recommend continuing to use ESLint v9 until you are able to upgrade Node.js.
 
 **Related issue(s):** [#19969](https://github.com/eslint/eslint/issues/19969)
@@ -93,7 +92,6 @@ Three new rules have been enabled in `eslint:recommended`:
 - [`no-unassigned-vars`](../rules/no-unassigned-vars)
 - [`no-useless-assignment`](../rules/no-useless-assignment)
 - [`preserve-caught-error`](../rules/preserve-caught-error)
-
 
 **To address:** Fix errors or disable these rules.
 
@@ -147,7 +145,6 @@ export function createCard(name) {
 
 Prior to v10.0.0, ESLint did not recognize that `<Card>` is a reference to the imported `Card`, which could result in false positives such as reporting `Card` as "defined but never used" ([`no-unused-vars`](../rules/no-unused-vars)) or false negatives such as failing to report `Card` as undefined ([`no-undef`](../rules/no-undef)) if the import is removed. Starting with v10.0.0, `<Card>` is treated as a normal reference to the variable in scope. This brings JSX handling in line with developer expectations and improves the linting experience for modern JavaScript applications using JSX.
 
-
 **To address:**
 
 - For users:
@@ -167,7 +164,6 @@ error: /* eslint-env */ comments are no longer supported at file.js:1:1:
     | ^
 ```
 
-
 **To address:** Remove any `eslint-env` comments from your code. If you are still using the old configuration system and need help migrating, check the [migration guide](./configure/migration-guide#eslint-env-configuration-comments).
 
 **Related issue(s):** [#13481](https://github.com/eslint/eslint/issues/13481)
@@ -175,7 +171,6 @@ error: /* eslint-env */ comments are no longer supported at file.js:1:1:
 ## <a name="drop-old-jiti"></a> Jiti < v2.2.0 are no longer supported
 
 ESLint is officially dropping support for versions of `jiti` that are less than v2.2.0.
-
 
 **To address:** If you've authored your config file in `TypeScript` and have `jiti` v2.1.2 or earlier installed, be sure to update it to at least `2.2.0` when using ESLint v10.0.0.
 
@@ -193,7 +188,6 @@ npx eslint "**/[[:upper:]]*.js"
 
 Here, `[[:upper:]]` is a POSIX character class that matches uppercase letters in different alphabets.
 
-
 **To address:** If any of the glob patterns in your configuration, CLI arguments, or Node.js API calls look like containing a POSIX character class, verify that they match files as intended.
 
 **Related issue(s):** [eslint/rewrite#66](https://github.com/eslint/rewrite/issues/66)
@@ -210,7 +204,6 @@ Starting in ESLint v10.0.0, the built-in [`stylish`](./formatters#stylish) forma
 
 2. Second, `--color` and `--no-color` CLI flags now have higher precedence than environment variables when determining whether to use colorized output. This change ensures that explicit user preferences via CLI flags are prioritized. However, if neither flag is provided, environment variables will be considered as before.
 
-
 **To address:**
 
 - Review any environment configuration related to terminal colors (for example, CI defaults or shell profiles). If ESLint's output appears uncolored after upgrading to v10.0.0, check whether `NO_COLOR` or `NODE_DISABLE_COLORS` (or similar settings) are being set in your environment.
@@ -224,7 +217,6 @@ As of ESLint v10.0.0, string options `"always"` and `"as-needed"` of the [`radix
 
 The default behavior of this rule has not been changed.
 
-
 **To address:**
 
 - If you are using this rule without any options specified, there is no action required.
@@ -236,7 +228,6 @@ The default behavior of this rule has not been changed.
 ## <a name="no-shadow-restricted-names"></a> `no-shadow-restricted-names` now reports `globalThis` by default
 
 In ESLint v10.0.0, the [`no-shadow-restricted-names`](../rules/no-shadow-restricted-names) rule now treats `globalThis` as a restricted name by default. Consequently, the `reportGlobalThis` option now defaults to `true` (previously `false`). As a result, declarations such as `const globalThis = "foo";` or `function globalThis() {}` will now be reported by default.
-
 
 **To address:**
 
@@ -263,7 +254,6 @@ For example, this configuration is now invalid due to the extra element `"foo"`:
 /*eslint func-names: ["error", "always", { "generators": "never" }, "foo"]*/
 ```
 
-
 **To address:**
 
 - Remove any extra array elements from your `func-names` configuration so that it contains only:
@@ -282,7 +272,6 @@ For example, this configuration is now invalid due to the duplicate `"u"` flag:
 /*eslint no-invalid-regexp: ["error", { "allowConstructorFlags": ["u", "y", "u"] }]*/
 ```
 
-
 **To address:** Remove any duplicate flags from your `allowConstructorFlags` array configuration of `no-invalid-regexp` rule. Each flag should appear only once in the array.
 
 **Related issue(s):** [#18755](https://github.com/eslint/eslint/issues/18755)
@@ -292,7 +281,6 @@ For example, this configuration is now invalid due to the duplicate `"u"` flag:
 In ESLint v10.0.0, the `name` property has been restored to the ESLint core configs exported from `@eslint/js`. This property was previously removed due to incompatibility with the legacy eslintrc configuration system. Now that eslintrc is no longer supported, the `name` property has been added back.
 
 This change should not require any action for most users. However, if you are using `@eslint/js` v10.x with the `FlatCompat` utility from `@eslint/eslintrc`, you should upgrade `@eslint/eslintrc` to the latest version to ensure compatibility.
-
 
 **To address:** Upgrade `@eslint/eslintrc` to the latest version if you are using `FlatCompat`.
 
@@ -324,8 +312,6 @@ In ESLint v9 and earlier, `Program.range` covers only `const x = 1;` (excludes s
 
 Starting with ESLint v10.0.0, `Program.range` covers the entire source text, including the leading and trailing comments/whitespace.
 
-
-
 **To address:**
 
 - For rule and plugin authors: If your code depends on the previous `Program.range` behavior, or on `SourceCode` methods that assume it (such as `sourceCode.getCommentsBefore(programNode)` to retrieve all leading comments), update your logic. If your code reports on the `Program` node, update your logic to report on the first statement within the `Program` node, i.e. `node.body[0] ?? node`, to ensure the directive `/* eslint-disable your-rule */` can still work.
@@ -346,8 +332,6 @@ Affected methods:
 - `replaceText(nodeOrToken, text)`
 - `replaceTextRange(range, text)`
 
-
-
 **To address:** Ensure the `text` value you pass to fixer methods is a string.
 
 **Related issue(s):** [#18807](https://github.com/eslint/eslint/issues/18807)
@@ -359,8 +343,6 @@ In ESLint v10.0.0, custom `ScopeManager` implementations must automatically reso
 The default `ScopeManager` implementation [`eslint-scope`](https://www.npmjs.com/package/eslint-scope) has already been updated.
 
 This change does not affect custom rules.
-
-
 
 **To address:** If you maintain a custom parser that provides a custom `ScopeManager` implementation, update your custom `ScopeManager` implementation.
 

--- a/docs/src/use/migrate-to-10.0.0.md
+++ b/docs/src/use/migrate-to-10.0.0.md
@@ -32,7 +32,6 @@ The lists below are ordered roughly by the number of users each change is expect
 
 ## Table of Contents
 
-- [Use migration codemods](#use-migration-codemods)
 
 ### Breaking changes for users
 
@@ -83,7 +82,8 @@ ESLint is officially dropping support for these versions of Node.js starting wit
 - Node.js v22.13.0 and above
 - Node.js v24 and above
 
-**To address:** The migration codemods do not cover this change. Make sure you upgrade to at least Node.js v20.19.0 when using ESLint v10.0.0. One important thing to double check is the Node.js version supported by your editor when using ESLint via editor integrations. If you are unable to upgrade, we recommend continuing to use ESLint v9 until you are able to upgrade Node.js.
+**Codemod:** The migration codemods do not cover this change. 
+**To address:** Make sure you upgrade to at least Node.js v20.19.0 when using ESLint v10.0.0. One important thing to double check is the Node.js version supported by your editor when using ESLint via editor integrations. If you are unable to upgrade, we recommend continuing to use ESLint v9 until you are able to upgrade Node.js.
 
 **Related issue(s):** [#19969](https://github.com/eslint/eslint/issues/19969)
 

--- a/docs/src/use/migrate-to-10.0.0.md
+++ b/docs/src/use/migrate-to-10.0.0.md
@@ -32,7 +32,6 @@ The lists below are ordered roughly by the number of users each change is expect
 
 ## Table of Contents
 
-
 ### Breaking changes for users
 
 - [Node.js < v20.19, v21, v23 are no longer supported](#drop-old-node)
@@ -82,7 +81,7 @@ ESLint is officially dropping support for these versions of Node.js starting wit
 - Node.js v22.13.0 and above
 - Node.js v24 and above
 
-**Codemod:** The migration codemods do not cover this change. 
+**Codemod:** The migration codemods do not cover this change.
 **To address:** Make sure you upgrade to at least Node.js v20.19.0 when using ESLint v10.0.0. One important thing to double check is the Node.js version supported by your editor when using ESLint via editor integrations. If you are unable to upgrade, we recommend continuing to use ESLint v9 until you are able to upgrade Node.js.
 
 **Related issue(s):** [#19969](https://github.com/eslint/eslint/issues/19969)

--- a/docs/src/use/migrate-to-10.0.0.md
+++ b/docs/src/use/migrate-to-10.0.0.md
@@ -7,11 +7,34 @@ eleventyNavigation:
     order: 9
 ---
 
+{%- from 'components/npx_tabs.macro.html' import npx_tabs %}
+
 ESLint v10.0.0 is a major release of ESLint, and as such, has several breaking changes that you need to be aware of. This guide is intended to walk you through the breaking changes.
+
+To help with this migration, ESLint provides migration codemods to automate many of the changes described in this guide. All official ESLint codemods are available in the [eslint/codemods](https://github.com/eslint/codemods) repository and through the [Codemod Registry](https://codemod.link/eslint).
+
+## Use migration codemods
+
+The `@eslint/v9-to-v10` codemod upgrades ESLint projects from v9 to v10. It includes four individual codemods that can also be run independently:
+
+- `@eslint/v9-to-v10-config`: Remove legacy env vars and CLI flags
+- `@eslint/v9-to-v10-custom-rules`: Replace removed `context` and `SourceCode` methods
+- `@eslint/v9-to-v10-ruletester`: Clean up `RuleTester` test cases
+- `@eslint/v9-to-v10-linter-api`: Fix `Linter`/`ESLint` API usage
+
+```shell
+npx codemod @eslint/v9-to-v10
+```
+
+Learn more in the [Codemod Registry](https://codemod.link/eslint).
+
+Codemods are a starting point. Review the changes and consult the breaking changes below for anything the codemods do not cover.
 
 The lists below are ordered roughly by the number of users each change is expected to affect, where the first items are expected to affect the most users.
 
 ## Table of Contents
+
+- [Use migration codemods](#use-migration-codemods)
 
 ### Breaking changes for users
 
@@ -62,7 +85,7 @@ ESLint is officially dropping support for these versions of Node.js starting wit
 - Node.js v22.13.0 and above
 - Node.js v24 and above
 
-**To address:** Make sure you upgrade to at least Node.js v20.19.0 when using ESLint v10.0.0. One important thing to double check is the Node.js version supported by your editor when using ESLint via editor integrations. If you are unable to upgrade, we recommend continuing to use ESLint v9 until you are able to upgrade Node.js.
+**To address:** The migration codemods do not cover this change. Make sure you upgrade to at least Node.js v20.19.0 when using ESLint v10.0.0. One important thing to double check is the Node.js version supported by your editor when using ESLint via editor integrations. If you are unable to upgrade, we recommend continuing to use ESLint v9 until you are able to upgrade Node.js.
 
 **Related issue(s):** [#19969](https://github.com/eslint/eslint/issues/19969)
 
@@ -74,7 +97,7 @@ Three new rules have been enabled in `eslint:recommended`:
 - [`no-useless-assignment`](../rules/no-useless-assignment)
 - [`preserve-caught-error`](../rules/preserve-caught-error)
 
-**To address:** Fix errors or disable these rules.
+**To address:** The migration codemods do not cover this change. Fix errors or disable these rules.
 
 **Related issue(s):** [#19966](https://github.com/eslint/eslint/issues/19966)
 
@@ -84,7 +107,7 @@ In ESLint v9, the alternate config lookup behavior could be enabled with the `v1
 
 **To address:**
 
-- Remove any usage of the flag in your setup:
+- Use the [@eslint/v9-to-v10-config](#use-migration-codemods) codemod to remove legacy flags from your setup, or remove them manually:
     - CLI: remove `--flag v10_config_lookup_from_file`.
     - Environment: remove `v10_config_lookup_from_file` from `ESLINT_FLAGS`.
     - API: remove `"v10_config_lookup_from_file"` from the `flags` array passed to `new ESLint()` or `new Linter()`.
@@ -100,8 +123,8 @@ Starting with ESLint v10.0.0, the old configuration format is no longer supporte
 
 **To address:**
 
-- Follow the instructions in the [configuration migration guide](./configure/migration-guide).
-- Be aware that the deprecated APIs `FlatESLint` and `LegacyESLint` have been removed. Always use `ESLint` instead.
+- Use the [@eslint/v9-to-v10](#use-migration-codemods) codemod to automate much of this migration, or follow the instructions in the [configuration migration guide](./configure/migration-guide).
+- Be aware that the deprecated APIs `FlatESLint` and `LegacyESLint` have been removed. Use the [@eslint/v9-to-v10-linter-api](#use-migration-codemods) codemod or always use `ESLint` instead.
 - The `configType` option of the `Linter` class can no longer be set to `"eslintrc"`. Remove the option to use the new configuration format.
 
 **Related issue(s):** [#13481](https://github.com/eslint/eslint/issues/13481)
@@ -122,7 +145,7 @@ export function createCard(name) {
 
 Prior to v10.0.0, ESLint did not recognize that `<Card>` is a reference to the imported `Card`, which could result in false positives such as reporting `Card` as "defined but never used" ([`no-unused-vars`](../rules/no-unused-vars)) or false negatives such as failing to report `Card` as undefined ([`no-undef`](../rules/no-undef)) if the import is removed. Starting with v10.0.0, `<Card>` is treated as a normal reference to the variable in scope. This brings JSX handling in line with developer expectations and improves the linting experience for modern JavaScript applications using JSX.
 
-**To address:**
+**To address:** The migration codemods do not cover this change.
 
 - For users:
     - New linting reports may appear in files with JSX. Update your code accordingly or adjust rule configurations if needed.
@@ -141,7 +164,7 @@ error: /* eslint-env */ comments are no longer supported at file.js:1:1:
     | ^
 ```
 
-**To address:** Remove any `eslint-env` comments from your code. If you are still using the old configuration system and need help migrating, check the [migration guide](./configure/migration-guide#eslint-env-configuration-comments).
+**To address:** The migration codemods do not cover this change. Remove any `eslint-env` comments from your code. If you are still using the old configuration system and need help migrating, check the [migration guide](./configure/migration-guide#eslint-env-configuration-comments).
 
 **Related issue(s):** [#13481](https://github.com/eslint/eslint/issues/13481)
 
@@ -149,7 +172,7 @@ error: /* eslint-env */ comments are no longer supported at file.js:1:1:
 
 ESLint is officially dropping support for versions of `jiti` that are less than v2.2.0.
 
-**To address:** If you've authored your config file in `TypeScript` and have `jiti` v2.1.2 or earlier installed, be sure to update it to at least `2.2.0` when using ESLint v10.0.0.
+**To address:** The migration codemods do not cover this change. If you've authored your config file in `TypeScript` and have `jiti` v2.1.2 or earlier installed, be sure to update it to at least `2.2.0` when using ESLint v10.0.0.
 
 **Related issue(s):** [#19765](https://github.com/eslint/eslint/issues/19765)
 
@@ -165,7 +188,7 @@ npx eslint "**/[[:upper:]]*.js"
 
 Here, `[[:upper:]]` is a POSIX character class that matches uppercase letters in different alphabets.
 
-**To address:** If any of the glob patterns in your configuration, CLI arguments, or Node.js API calls look like containing a POSIX character class, verify that they match files as intended.
+**To address:** The migration codemods do not cover this change. If any of the glob patterns in your configuration, CLI arguments, or Node.js API calls look like containing a POSIX character class, verify that they match files as intended.
 
 **Related issue(s):** [eslint/rewrite#66](https://github.com/eslint/rewrite/issues/66)
 
@@ -181,7 +204,7 @@ Starting in ESLint v10.0.0, the built-in [`stylish`](./formatters#stylish) forma
 
 2. Second, `--color` and `--no-color` CLI flags now have higher precedence than environment variables when determining whether to use colorized output. This change ensures that explicit user preferences via CLI flags are prioritized. However, if neither flag is provided, environment variables will be considered as before.
 
-**To address:**
+**To address:** The migration codemods do not cover this change.
 
 - Review any environment configuration related to terminal colors (for example, CI defaults or shell profiles). If ESLint's output appears uncolored after upgrading to v10.0.0, check whether `NO_COLOR` or `NODE_DISABLE_COLORS` (or similar settings) are being set in your environment.
 - If you rely on mixed approaches (for example, using `--color` flag but also setting `NO_COLOR` environment variable), be aware that the CLI flags now take precedence and adjust your setup accordingly.
@@ -194,7 +217,7 @@ As of ESLint v10.0.0, string options `"always"` and `"as-needed"` of the [`radix
 
 The default behavior of this rule has not been changed.
 
-**To address:**
+**To address:** The migration codemods do not cover this change.
 
 - If you are using this rule without any options specified, there is no action required.
 - If you are using this rule with the `"always"` option explicitly specified, remove the option. The behavior of this rule will remain the same.
@@ -206,7 +229,7 @@ The default behavior of this rule has not been changed.
 
 In ESLint v10.0.0, the [`no-shadow-restricted-names`](../rules/no-shadow-restricted-names) rule now treats `globalThis` as a restricted name by default. Consequently, the `reportGlobalThis` option now defaults to `true` (previously `false`). As a result, declarations such as `const globalThis = "foo";` or `function globalThis() {}` will now be reported by default.
 
-**To address:**
+**To address:** The migration codemods do not cover this change.
 
 - Rename local identifiers named `globalThis` to avoid shadowing the global.
 - Or restore the previous behavior by configuring the rule explicitly:
@@ -231,7 +254,7 @@ For example, this configuration is now invalid due to the extra element `"foo"`:
 /*eslint func-names: ["error", "always", { "generators": "never" }, "foo"]*/
 ```
 
-**To address:**
+**To address:** The migration codemods do not cover this change.
 
 - Remove any extra array elements from your `func-names` configuration so that it contains only:
     - a base string option: `"always" | "as-needed" | "never"`, and
@@ -249,7 +272,7 @@ For example, this configuration is now invalid due to the duplicate `"u"` flag:
 /*eslint no-invalid-regexp: ["error", { "allowConstructorFlags": ["u", "y", "u"] }]*/
 ```
 
-**To address:** Remove any duplicate flags from your `allowConstructorFlags` array configuration of `no-invalid-regexp` rule. Each flag should appear only once in the array.
+**To address:** The migration codemods do not cover this change. Remove any duplicate flags from your `allowConstructorFlags` array configuration of `no-invalid-regexp` rule. Each flag should appear only once in the array.
 
 **Related issue(s):** [#18755](https://github.com/eslint/eslint/issues/18755)
 
@@ -259,7 +282,7 @@ In ESLint v10.0.0, the `name` property has been restored to the ESLint core conf
 
 This change should not require any action for most users. However, if you are using `@eslint/js` v10.x with the `FlatCompat` utility from `@eslint/eslintrc`, you should upgrade `@eslint/eslintrc` to the latest version to ensure compatibility.
 
-**To address:** Upgrade `@eslint/eslintrc` to the latest version if you are using `FlatCompat`.
+**To address:** The migration codemods do not cover this change. Upgrade `@eslint/eslintrc` to the latest version if you are using `FlatCompat`.
 
 **Related issue(s):** [#19864](https://github.com/eslint/eslint/issues/19864)
 
@@ -267,7 +290,7 @@ This change should not require any action for most users. However, if you are us
 
 In ESLint v10.0.0, the deprecated `type` property in errors of invalid test cases for rules has been removed. Using the `type` property in test cases now throws an error.
 
-**To address:** Remove the `type` property from error objects in invalid test cases.
+**To address:** Use the [@eslint/v9-to-v10-ruletester](#use-migration-codemods) codemod to automate this change, or remove the `type` property from error objects in invalid test cases manually.
 
 **Related issue(s):** [#19029](https://github.com/eslint/eslint/issues/19029)
 
@@ -287,7 +310,7 @@ In ESLint v9 and earlier, `Program.range` covers only `const x = 1;` (excludes s
 
 Starting with ESLint v10.0.0, `Program.range` covers the entire source text, including the leading and trailing comments/whitespace.
 
-**To address:**
+**To address:** The migration codemods do not cover this change.
 
 - For rule and plugin authors: If your code depends on the previous `Program.range` behavior, or on `SourceCode` methods that assume it (such as `sourceCode.getCommentsBefore(programNode)` to retrieve all leading comments), update your logic. If your code reports on the `Program` node, update your logic to report on the first statement within the `Program` node, i.e. `node.body[0] ?? node`, to ensure the directive `/* eslint-disable your-rule */` can still work.
 - For custom parsers: Set `Program.range` to cover the full source text (typically `[0, code.length]`).
@@ -307,7 +330,7 @@ Affected methods:
 - `replaceText(nodeOrToken, text)`
 - `replaceTextRange(range, text)`
 
-**To address:** Ensure the `text` value you pass to fixer methods is a string.
+**To address:** The migration codemods do not cover this change. Ensure the `text` value you pass to fixer methods is a string.
 
 **Related issue(s):** [#18807](https://github.com/eslint/eslint/issues/18807)
 
@@ -319,7 +342,7 @@ The default `ScopeManager` implementation [`eslint-scope`](https://www.npmjs.com
 
 This change does not affect custom rules.
 
-**To address:** If you maintain a custom parser that provides a custom `ScopeManager` implementation, update your custom `ScopeManager` implementation.
+**To address:** The migration codemods do not cover this change. If you maintain a custom parser that provides a custom `ScopeManager` implementation, update your custom `ScopeManager` implementation.
 
 **Related issue(s):** [eslint/js#665](https://github.com/eslint/js/issues/665)
 
@@ -336,7 +359,7 @@ In ESLint v9.x, we deprecated the following [methods](https://eslint.org/blog/20
 
 In ESLint v10.0.0, all of these members have been removed.
 
-**To address:** In your custom rules, make the following changes:
+**To address:** Use the [@eslint/v9-to-v10-custom-rules](#use-migration-codemods) codemod to automate this change, or in your custom rules, make the following changes:
 
 | **Removed on `context`**        | **Replacement on `context`**                                         |
 | ------------------------------- | -------------------------------------------------------------------- |
@@ -375,7 +398,7 @@ The following deprecated `SourceCode` methods have been removed in ESLint v10.0.
 
 These methods have been deprecated for multiple major versions and were primarily used by deprecated formatting rules and internal ESLint utilities. Custom rules using these methods must be updated to use their modern replacements.
 
-**To address:** In your custom rules, make the following changes:
+**To address:** Use the [@eslint/v9-to-v10-custom-rules](#use-migration-codemods) codemod to automate this change, or in your custom rules, make the following changes:
 
 | **Removed on `SourceCode`**                  | **Replacement**                                                |
 | -------------------------------------------- | -------------------------------------------------------------- |
@@ -412,7 +435,7 @@ const validTestCases = [
 ruleTester.run("rule-id", rule, { valid: validTestCases, invalid: [] });
 ```
 
-**To address:** Remove any `errors`/`output` properties from valid test cases.
+**To address:** Use the [@eslint/v9-to-v10-ruletester](#use-migration-codemods) codemod to automate this change, or remove any `errors`/`output` properties from valid test cases manually.
 
 **Related issue(s):** [#18960](https://github.com/eslint/eslint/issues/18960)
 
@@ -420,6 +443,6 @@ ruleTester.run("rule-id", rule, { valid: validTestCases, invalid: [] });
 
 In ESLint v10.0.0, the deprecated `nodeType` property on `LintMessage` objects has been removed. This affects consumers of the Node.js API (for example, custom formatters and editor/tool integrations) that previously relied on `message.nodeType`.
 
-**To address:** Remove all usages of `message.nodeType` in your integrations and formatters.
+**To address:** Use the [@eslint/v9-to-v10-linter-api](#use-migration-codemods) codemod to automate this change, or remove all usages of `message.nodeType` in your integrations and formatters manually.
 
 **Related issue(s):** [#19029](https://github.com/eslint/eslint/issues/19029)

--- a/docs/src/use/migrate-to-10.0.0.md
+++ b/docs/src/use/migrate-to-10.0.0.md
@@ -7,8 +7,6 @@ eleventyNavigation:
     order: 9
 ---
 
-{%- from 'components/npx_tabs.macro.html' import npx_tabs %}
-
 ESLint v10.0.0 is a major release of ESLint, and as such, has several breaking changes that you need to be aware of. This guide is intended to walk you through the breaking changes.
 
 To help with this migration, ESLint provides migration codemods to automate many of the changes described in this guide. All official ESLint codemods are available in the [eslint/codemods](https://github.com/eslint/codemods) repository and through the [Codemod Registry](https://app.codemod.com/registry?q=scope%3Aeslint).

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -34,10 +34,6 @@ Codemods are a starting point. Review the changes and consult the breaking chang
 
 The lists below are ordered roughly by the number of users each change is expected to affect, where the first items are expected to affect the most users.
 
-## Table of Contents
-
-- [Use migration codemods](#use-migration-codemods)
-
 ### Breaking changes for users
 
 - [Node.js < v18.18, v19 are no longer supported](#drop-old-node)

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -32,6 +32,8 @@ Codemods are a starting point. Review the changes and consult the breaking chang
 
 The lists below are ordered roughly by the number of users each change is expected to affect, where the first items are expected to affect the most users.
 
+## Table of Contents
+
 ### Breaking changes for users
 
 - [Node.js < v18.18, v19 are no longer supported](#drop-old-node)

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -10,7 +10,7 @@ To help with this migration, ESLint provides codemods to automate many of the ch
 
 ### Migrate ESLint configuration
 
-The `@eslint/v8-to-v9-config` codemod migrates ESLint v8 configuration files to the ESLint v9 flat config format. It updates config structure, rule schemas, plugins, ignores, and deprecated JSDoc rules while preserving existing behavior as much as possible.
+The `@eslint/v8-to-v9-config` codemod migrates ESLint v8 configuration files to the ESLint v9 flat config format. It updates config structure, rule schemas, plugins, ignores, and deprecated JSDoc rules while preserving existing behavior as much as possible. It also modifies `package.json` entries containing `eslintConfig`, `.eslintignore`/`.gitignore` files, `/* exported */` comments, and certain `/* eslint */` comments.
 
 ```shell
 npx codemod @eslint/v8-to-v9-config
@@ -21,6 +21,10 @@ Learn more in the [Codemod Registry](https://app.codemod.com/registry/@eslint/v8
 ### Migrate custom rules
 
 If you maintain custom ESLint rules, the `@eslint/v8-to-v9-custom-rules` codemod converts function-style rules to the object format and updates deprecated rule APIs to their ESLint v9-compatible equivalents.
+
+::: warning
+The workflow runs on `**/*.js`, `**/*.mjs`, `**/*.cjs`, `**/*.jsx`, `**/*.ts`, `**/*.mts`, `**/*.cts`, and `**/*.tsx`. Run it only against rule files or directories, since it may incorrectly transform non-rule JavaScript files.
+:::
 
 ```shell
 npx codemod @eslint/v8-to-v9-custom-rules
@@ -86,8 +90,6 @@ ESLint is officially dropping support for these versions of Node.js starting wit
 - Node.js v20.9.0 and above
 - Node.js v21 and above
 
-**Codemod:** The migration codemods do not cover this change.
-
 **To address:** Make sure you upgrade to at least Node.js v18.18.0 when using ESLint v9.0.0. One important thing to double check is the Node.js version supported by your editor when using ESLint via editor integrations. If you are unable to upgrade, we recommend continuing to use ESLint v8.56.0 until you are able to upgrade Node.js.
 
 **Related issue(s):** [#17595](https://github.com/eslint/eslint/issues/17595)
@@ -116,7 +118,7 @@ ESLint v9.0.0 has removed the following formatters from the core:
 | `unix`                | `eslint-formatter-unix`         |
 | `visualstudio`        | `eslint-formatter-visualstudio` |
 
-**Codemod:** The migration codemods do not cover this change.
+**Codemod:** The [@eslint/v8-to-v9-config](#use-migration-codemods) codemod fully supports this change.
 
 **To address:** If you are using any of these formatters via the `-f` command line flag, you'll need to install the respective package for the formatter.
 
@@ -126,7 +128,7 @@ ESLint v9.0.0 has removed the following formatters from the core:
 
 The `require-jsdoc` and `valid-jsdoc` rules have been removed in ESLint v9.0.0. These rules were initially deprecated in 2018.
 
-**Codemod:** The [@eslint/v8-to-v9-config](#use-migration-codemods) codemod removes deprecated JSDoc rules from your configuration.
+**Codemod:** The [@eslint/v8-to-v9-config](#use-migration-codemods) codemod migrates deprecated JSDoc rules. When those rules are active in the configuration, it removes `require-jsdoc`/`valid-jsdoc`, adds `eslint-plugin-jsdoc` and `jsdoc({ config: 'flat/recommended' })`, and also removes file-level JSDoc ESLint comments.
 
 **To address:** Use the [replacement rules](https://github.com/gajus/eslint-plugin-jsdoc/wiki/Comparison-with-deprecated-JSdoc-related-ESLint-rules) in `eslint-plugin-jsdoc` for equivalent linting.
 
@@ -148,7 +150,7 @@ Additionally, the following rules have been removed from `eslint:recommended`:
 - [`no-mixed-spaces-and-tabs`](../rules/no-mixed-spaces-and-tabs)
 - [`no-new-symbol`](../rules/no-new-symbol)
 
-**Codemod:** The migration codemods do not cover this change.
+**Codemod:** The [@eslint/v8-to-v9-config](#use-migration-codemods) codemod partially covers this change. When your configuration extends `eslint:recommended`, it disables the four newly enabled recommended rules listed above (unless you already configure them explicitly) to preserve ESLint v8 lint behavior. It does not re-enable rules removed from the preset, fix new violations in source files, or change configs that use `@eslint/js` presets without a legacy `eslint:recommended` extend entry.
 
 **To address:** Fix errors or disable these rules.
 
@@ -160,8 +162,6 @@ Prior to ESLint v9.0.0, the `--quiet` CLI flag would run all rules set to either
 
 If `--max-warnings` is used then `--quiet` will not suppress the execution of rules set to `"warn"` but the output of those rules will be suppressed.
 
-**Codemod:** The migration codemods do not cover this change.
-
 **To address:** In most cases, this change is transparent. If, however, you are running a rule set to `"warn"` that makes changes to the data available to other rules (for example, if the rule uses `sourceCode.markVariableAsUsed()`), then this can result in a behavior change. In such a case, you'll need to either set the rule to `"error"` or stop using `--quiet`.
 
 **Related issue(s):** [#16450](https://github.com/eslint/eslint/issues/16450)
@@ -169,8 +169,6 @@ If `--max-warnings` is used then `--quiet` will not suppress the execution of ru
 ## <a name="output-file"></a> `--output-file` now writes a file to disk even with an empty output
 
 Prior to ESLint v9.0.0, the `--output-file` flag would skip writing a file to disk if the output was empty. However, in ESLint v9.0.0, `--output-file` now consistently writes a file to disk, even when the output is empty. This update ensures a more consistent and reliable behavior for `--output-file`.
-
-**Codemod:** The migration codemods do not cover this change.
 
 **To address:** Review your usage of the `--output-file` flag, especially if your processes depend on the file's presence or absence based on output content. If necessary, update your scripts or configurations to accommodate this change.
 
@@ -182,8 +180,6 @@ Prior to ESLint v9.0.0, running the ESLint CLI without any file or directory pat
 
 - **Flat config.** If you are using flat config, you can run `npx eslint` or `eslint` (if globally installed) and ESLint will assume you want to lint the current directory. Effectively, passing no patterns is equivalent to passing `.`.
 - **eslintrc.** If you are using the deprecated eslintrc config, you'll now receive an error when running the CLI without any patterns.
-
-**Codemod:** The migration codemods do not cover this change.
 
 **To address:** In most cases, no change is necessary, and you may find some locations where you thought ESLint was running but it wasn't. If you'd like to keep the v8.x behavior, where passing no patterns results in ESLint exiting with code 0, add the `--pass-on-no-patterns` flag to the CLI call.
 
@@ -221,8 +217,6 @@ the resulting configuration for the `curly` rule when linting `my-file.js` will 
 
 Note that this change only affects cases where the same rule is configured in the config file with options and using a configuration comment without options. In all other cases (e.g. the rule is only configured using a configuration comment), the behavior remains the same as prior to ESLint v9.0.0.
 
-**Codemod:** The migration codemods do not cover this change.
-
 **To address:** We expect that in most cases no change is necessary, as rules configured using configuration comments are typically not already configured in the config file. However, if you need a configuration comment to completely override configuration from the config file and enforce the default options, you'll need to specify at least one option:
 
 ```js
@@ -253,7 +247,7 @@ In ESLint v9.0.0, the first one is applied, while the others are reported as lin
 foo(); // error: Missing semicolon
 ```
 
-**Codemod:** The migration codemods do not cover this change.
+**Codemod:** The [@eslint/v8-to-v9-config](#use-migration-codemods) codemod includes a `remove-unnecessary-eslint-comments` step that modifies these comments. It removes all ESLint config comments matching its regex except the first one, not just duplicates of the same rule.
 
 **To address:** Remove duplicate `/* eslint */` comments.
 
@@ -275,7 +269,7 @@ The `true` and `false` in this example had no effect on ESLint's behavior, and i
 
 In ESLint v9.0.0, any `/* exported */` variables followed by a colon and value will be ignored as invalid.
 
-**Codemod:** The migration codemods do not cover this change.
+**Codemod:** The [@eslint/v8-to-v9-config](#use-migration-codemods) codemod rewrites both `/* exported foo: true, bar: false */` and the whitespace-separated form into a comma-separated format.
 
 **To address:** Update any `/* exported */` directives to eliminate the colons and subsequent values, and ensure there are commas between variable names such as:
 
@@ -318,8 +312,6 @@ In ESLint v9.0.0, the `no-implicit-coercion` rule additionally reports the follo
 foo - 0;
 ```
 
-**Codemod:** The migration codemods do not cover this change.
-
 **To address:** If you want to retain the previous behavior of this rule, set `"allow": ["-", "- -"]`.
 
 ```json
@@ -336,7 +328,7 @@ foo - 0;
 
 In ESLint v9.0.0, the option `allowConstructorFlags` is now case-sensitive.
 
-**Codemod:** The [@eslint/v8-to-v9-config](#use-migration-codemods) codemod may update your configuration for this.
+**Codemod:** The [@eslint/v8-to-v9-config](#use-migration-codemods) codemod expands `allowConstructorFlags` with opposite-case variants to preserve ESLint v8 behavior under v9's case-sensitive matching.
 
 **To address:** Update your configuration manually if needed.
 
@@ -357,7 +349,7 @@ try {
 }
 ```
 
-**Codemod:** The migration codemods do not cover this change.
+**Codemod:** The [@eslint/v8-to-v9-config](#use-migration-codemods) codemod copies `varsIgnorePattern` to `caughtErrorsIgnorePattern` when the rule is explicitly configured, catch errors are checked (`caughtErrors` is not `"none"`), and no separate `caughtErrorsIgnorePattern` is set. This preserves v8 behavior where `varsIgnorePattern` incorrectly applied to catch bindings. It does not apply when the rule comes only from a preset, when `caughtErrors` is `"none"`, or for `@typescript-eslint/no-unused-vars`.
 
 **To address:** If you want to specify ignore patterns for `catch` clause variable names, use the `caughtErrorsIgnorePattern` option in addition to `varsIgnorePattern`.
 
@@ -394,7 +386,7 @@ and both `import { Text } from "react-native"` and `import { View } from "react-
 
 In previous versions of ESLint, with this configuration only `import { View } from "react-native"` would be reported.
 
-**Codemod:** The migration codemods do not cover this change.
+**Codemod:** The [@eslint/v8-to-v9-config](#use-migration-codemods) codemod updates `no-restricted-imports` configurations during migration. When the rule uses a `paths` array, it restructures the options for flat config and deduplicates entries that share the same `name`, keeping the last entry so lint behavior matches ESLint v8 (where only the last matching entry applied).
 
 **To address:** If your configuration for this rule has multiple entries with the same `name`, you may need to remove unintentional ones.
 
@@ -411,7 +403,7 @@ export default ["eslint:recommended", "eslint:all"];
 
 In ESLint v9.0.0, this format is no longer supported and will result in an error.
 
-**Codemod:** Use the [@eslint/v8-to-v9-config](#use-migration-codemods) codemod to migrate these strings to the `@eslint/js` package.
+**Codemod:** Use the [@eslint/v8-to-v9-config](#use-migration-codemods) codemod. It converts legacy string presets in existing `eslint.config.*` files and migrates eslintrc configs via `FlatCompat` + `@eslint/js`.
 
 **To address:** Install and use `@eslint/js` manually:
 
@@ -437,7 +429,7 @@ if (test) {
 }
 ```
 
-**Codemod:** The migration codemods do not cover this change.
+**Codemod:** The [@eslint/v8-to-v9-config](#use-migration-codemods) codemod adds `blockScopedFunctions: "disallow"` when `no-inner-declarations` is explicitly configured, preserving v8 reporting behavior. It does not apply when the rule comes only from a preset.
 
 **To address:** If you want to report the block-level `function`s in every condition regardless of strict or non-strict mode, set the `blockScopeFunctions` option to `"disallow"`.
 
@@ -457,7 +449,7 @@ try {
 }
 ```
 
-**Codemod:** The migration codemods do not cover this change.
+**Codemod:** The [@eslint/v8-to-v9-config](#use-migration-codemods) codemod updates `no-unused-vars` when the rule is explicitly configured. It adds `caughtErrors: "none"` if that option is omitted, preserving ESLint v8 behavior. Existing `caughtErrors` values are kept unchanged. If catch errors are checked and `varsIgnorePattern` is set, it also copies that pattern to `caughtErrorsIgnorePattern`. It does not add the rule when it is enabled only through `eslint:recommended`, and it does not migrate `@typescript-eslint/no-unused-vars`.
 
 **To address:** If you want to allow unused caught errors, such as when writing code that will be directly run in an environment that does not support ES2019 optional catch bindings, set the `caughtErrors` option to `"none"`.
 Otherwise, delete the unused caught errors.
@@ -485,7 +477,7 @@ class SomeClass {
 }
 ```
 
-**Codemod:** The migration codemods do not cover this change.
+**Codemod:** The [@eslint/v8-to-v9-config](#use-migration-codemods) codemod sets `enforceForClassMembers` to `false` when the `no-useless-computed-key` rule is configured with an empty options object, preserving ESLint v8 behavior.
 
 **To address:** Fix the problems reported by the rule or revert to the previous behavior by setting the `enforceForClassMembers` option to `false`.
 
@@ -548,7 +540,7 @@ In addition to the methods in the above table, there are several other methods t
 
 ESLint v9.0.0 removes the deprecated `sourceCode.getComments()` method.
 
-**Codemod:** Use the [@eslint/v8-to-v9-custom-rules](#use-migration-codemods) codemod to automate this change.
+**Codemod:** Use the [@eslint/v8-to-v9-custom-rules](#use-migration-codemods) codemod. It converts both `context.getComments()` and `sourceCode.getComments()` to combinations of `getCommentsBefore()`, `getCommentsInside()`, and `getCommentsAfter()`.
 
 **To address:** Replace with `sourceCode.getCommentsBefore()`, `sourceCode.getCommentsAfter()`, or `sourceCode.getCommentsInside()`.
 
@@ -570,7 +562,7 @@ Prior to ESLint v9.0.0, code paths were calculated during the same AST traversal
 
 ESLint v9.0.0 now precalculates code path information before the traversal used by rules. As a result, the code path information is now complete regardless of where it is accessed inside of a rule.
 
-**Codemod:** The migration codemods do not cover this change.
+**Codemod:** The migration codemods do not cover code path precalculation. Rules that rely on when `CodePath` or `CodePathSegment` array properties are populated must be reviewed manually. The [@eslint/v8-to-v9-custom-rules](#use-migration-codemods) codemod only migrates removed `CodePath#currentSegments` usage.
 
 **To address:** If you are accessing any array properties on `CodePath` or `CodePathSegment`, you'll need to update your code. Specifically:
 
@@ -595,7 +587,7 @@ The [eslint-plugin/prefer-object-rule](https://github.com/eslint-community/eslin
 
 As of ESLint v9.0.0, an error will be thrown if any options are [passed](../use/configure/rules#use-configuration-files) to a rule that doesn't specify `meta.schema` property.
 
-**Codemod:** The migration codemods do not cover this change.
+**Codemod:** The [@eslint/v8-to-v9-custom-rules](#use-migration-codemods) codemod generates `meta.schema` for function-style and object-style rules, migrates legacy `module.exports.schema`, and inserts a TODO when it detects `context.options` without a schema. The limitation is that it does not fully infer the actual schema.
 
 **To address:**
 
@@ -611,7 +603,7 @@ The [eslint-plugin/require-meta-schema](https://github.com/eslint-community/esli
 
 As announced in our [blog post](/blog/2023/10/flat-config-rollout-plans/), the temporary `FlatRuleTester` class has been renamed to `RuleTester`, while the `RuleTester` class from v8.x has been removed. Additionally, the `FlatRuleTester` export from `eslint/use-at-your-own-risk` has been removed.
 
-**Codemod:** The migration codemods do not cover this change.
+**Codemod:** The [@eslint/v8-to-v9-custom-rules](#use-migration-codemods) codemod renames `FlatRuleTester` to `RuleTester` and moves `parserOptions` to `languageOptions` in test cases. Updating imports from `eslint/use-at-your-own-risk` to `eslint`, adjusting for new `RuleTester` defaults, and translating other eslintrc-style test config must be done manually.
 
 **To address:** Update your rule tests to use the new `RuleTester`. To do so, here are some of the common changes you'll need to make:
 
@@ -675,7 +667,7 @@ In order to aid in the development of high-quality custom rules that are free fr
 1. **`filename` and `only` must be of the expected type.** `RuleTester` now checks the type of `filename` and `only` properties of test objects. If specified, `filename` must be a string value. If specified, `only` must be a boolean value.
 1. **Messages cannot have unsubstituted placeholders.** The `RuleTester` now also checks if there are {% raw %}`{{ placeholder }}` {% endraw %} still in the message as their values were not passed via `data` in the respective `context.report()` call.
 
-**Codemod:** The migration codemods do not cover this change.
+**Codemod:** The [@eslint/v8-to-v9-custom-rules](#use-migration-codemods) codemod renames `FlatRuleTester` to `RuleTester`, moves `parserOptions` to `languageOptions` in test cases, and removes `output` when it equals `code`. All other stricter `RuleTester` checks must be fixed manually by running your rule tests and updating failing cases.
 
 **To address:** Run your rule tests using `RuleTester` and fix any errors that occur. The changes you'll need to make to satisfy `RuleTester` are compatible with ESLint v8.x.
 
@@ -685,7 +677,7 @@ In order to aid in the development of high-quality custom rules that are free fr
 
 As announced in our [blog post](/blog/2023/10/flat-config-rollout-plans/), the temporary `FlatESLint` class has been renamed to `ESLint`, while the `ESLint` class from v8.x has been renamed to `LegacyESLint`.
 
-**Codemod:** The migration codemods do not cover this change.
+**Codemod:** The [@eslint/v8-to-v9-custom-rules](#use-migration-codemods) codemod renames `FlatESLint` to `ESLint`.
 
 **To address:** If you are currently using the `ESLint` class, verify that your tests pass using the new `ESLint` class. Not all of the old options are supported, so you may need to update the arguments passed to the constructor. See the [Node.js API Reference](../integrate/nodejs-api) for details.
 
@@ -703,7 +695,7 @@ In ESLint v9.0.0, the `config` argument passed to `Linter#verify()` and `Linter#
 
 Additionally, methods `Linter#defineRule()`, `Linter#defineRules()`, `Linter#defineParser()`, and `Linter#getRules()` are no longer available.
 
-**Codemod:** The migration codemods do not cover this change.
+**Codemod:** The [@eslint/v8-to-v9-custom-rules](#use-migration-codemods) codemod renames `FlatESLint` to `ESLint` and moves `parserOptions` to `languageOptions` in `Linter#verify()` and `Linter#verifyAndFix()` calls. Calls to removed methods (`defineRule`, `defineRules`, `defineParser`, `getRules`) are marked with TODO comments; migrating rules and parsers into flat plugins / `languageOptions` config must be done manually.
 
 **To address:** If you are using the `Linter` class, verify that your tests pass.
 

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -86,7 +86,9 @@ ESLint is officially dropping support for these versions of Node.js starting wit
 - Node.js v20.9.0 and above
 - Node.js v21 and above
 
-**To address:** The migration codemods do not cover this change. Make sure you upgrade to at least Node.js v18.18.0 when using ESLint v9.0.0. One important thing to double check is the Node.js version supported by your editor when using ESLint via editor integrations. If you are unable to upgrade, we recommend continuing to use ESLint v8.56.0 until you are able to upgrade Node.js.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** Make sure you upgrade to at least Node.js v18.18.0 when using ESLint v9.0.0. One important thing to double check is the Node.js version supported by your editor when using ESLint via editor integrations. If you are unable to upgrade, we recommend continuing to use ESLint v8.56.0 until you are able to upgrade Node.js.
 
 **Related issue(s):** [#17595](https://github.com/eslint/eslint/issues/17595)
 
@@ -94,7 +96,9 @@ ESLint is officially dropping support for these versions of Node.js starting wit
 
 As announced in our [blog post](/blog/2023/10/flat-config-rollout-plans/), in ESLint v9.0.0, [`eslint.config.js`](./configure/configuration-files) is the new default configuration format. The previous format, eslintrc, is now deprecated and will not automatically be searched for.
 
-**To address:** Use the [@eslint/v8-to-v9-config](#use-migration-codemods) codemod to automate much of this migration, or update your configuration manually following the [Configuration Migration Guide](./configure/migration-guide). In case you still need to use the deprecated eslintrc config format, set environment variable `ESLINT_USE_FLAT_CONFIG` to `false`.
+**Codemod:** Use the [@eslint/v8-to-v9-config](#use-migration-codemods) codemod to automate much of this migration.
+
+**To address:** Update your configuration manually following the [Configuration Migration Guide](./configure/migration-guide). In case you still need to use the deprecated eslintrc config format, set environment variable `ESLINT_USE_FLAT_CONFIG` to `false`.
 
 **Related Issues(s):** [#13481](https://github.com/eslint/eslint/issues/13481)
 
@@ -112,7 +116,9 @@ ESLint v9.0.0 has removed the following formatters from the core:
 | `unix`                | `eslint-formatter-unix`         |
 | `visualstudio`        | `eslint-formatter-visualstudio` |
 
-**To address:** The migration codemods do not cover this change. If you are using any of these formatters via the `-f` command line flag, you'll need to install the respective package for the formatter.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** If you are using any of these formatters via the `-f` command line flag, you'll need to install the respective package for the formatter.
 
 **Related issue(s):** [#17524](https://github.com/eslint/eslint/issues/17524)
 
@@ -120,7 +126,9 @@ ESLint v9.0.0 has removed the following formatters from the core:
 
 The `require-jsdoc` and `valid-jsdoc` rules have been removed in ESLint v9.0.0. These rules were initially deprecated in 2018.
 
-**To address:** The [@eslint/v8-to-v9-config](#use-migration-codemods) codemod removes deprecated JSDoc rules from your configuration. Use the [replacement rules](https://github.com/gajus/eslint-plugin-jsdoc/wiki/Comparison-with-deprecated-JSdoc-related-ESLint-rules) in `eslint-plugin-jsdoc` for equivalent linting.
+**Codemod:** The [@eslint/v8-to-v9-config](#use-migration-codemods) codemod removes deprecated JSDoc rules from your configuration.
+
+**To address:** Use the [replacement rules](https://github.com/gajus/eslint-plugin-jsdoc/wiki/Comparison-with-deprecated-JSdoc-related-ESLint-rules) in `eslint-plugin-jsdoc` for equivalent linting.
 
 **Related issue(s):** [#15820](https://github.com/eslint/eslint/issues/15820)
 
@@ -140,7 +148,9 @@ Additionally, the following rules have been removed from `eslint:recommended`:
 - [`no-mixed-spaces-and-tabs`](../rules/no-mixed-spaces-and-tabs)
 - [`no-new-symbol`](../rules/no-new-symbol)
 
-**To address:** The migration codemods do not cover this change. Fix errors or disable these rules.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** Fix errors or disable these rules.
 
 **Related issue(s):** [#15576](https://github.com/eslint/eslint/issues/15576), [#17446](https://github.com/eslint/eslint/issues/17446), [#17596](https://github.com/eslint/eslint/issues/17596)
 
@@ -150,7 +160,9 @@ Prior to ESLint v9.0.0, the `--quiet` CLI flag would run all rules set to either
 
 If `--max-warnings` is used then `--quiet` will not suppress the execution of rules set to `"warn"` but the output of those rules will be suppressed.
 
-**To address:** The migration codemods do not cover this change. In most cases, this change is transparent. If, however, you are running a rule set to `"warn"` that makes changes to the data available to other rules (for example, if the rule uses `sourceCode.markVariableAsUsed()`), then this can result in a behavior change. In such a case, you'll need to either set the rule to `"error"` or stop using `--quiet`.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** In most cases, this change is transparent. If, however, you are running a rule set to `"warn"` that makes changes to the data available to other rules (for example, if the rule uses `sourceCode.markVariableAsUsed()`), then this can result in a behavior change. In such a case, you'll need to either set the rule to `"error"` or stop using `--quiet`.
 
 **Related issue(s):** [#16450](https://github.com/eslint/eslint/issues/16450)
 
@@ -158,7 +170,9 @@ If `--max-warnings` is used then `--quiet` will not suppress the execution of ru
 
 Prior to ESLint v9.0.0, the `--output-file` flag would skip writing a file to disk if the output was empty. However, in ESLint v9.0.0, `--output-file` now consistently writes a file to disk, even when the output is empty. This update ensures a more consistent and reliable behavior for `--output-file`.
 
-**To address:** The migration codemods do not cover this change. Review your usage of the `--output-file` flag, especially if your processes depend on the file's presence or absence based on output content. If necessary, update your scripts or configurations to accommodate this change.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** Review your usage of the `--output-file` flag, especially if your processes depend on the file's presence or absence based on output content. If necessary, update your scripts or configurations to accommodate this change.
 
 **Related Issues(s):** [#17660](https://github.com/eslint/eslint/issues/17660)
 
@@ -169,7 +183,9 @@ Prior to ESLint v9.0.0, running the ESLint CLI without any file or directory pat
 - **Flat config.** If you are using flat config, you can run `npx eslint` or `eslint` (if globally installed) and ESLint will assume you want to lint the current directory. Effectively, passing no patterns is equivalent to passing `.`.
 - **eslintrc.** If you are using the deprecated eslintrc config, you'll now receive an error when running the CLI without any patterns.
 
-**To address:** The migration codemods do not cover this change. In most cases, no change is necessary, and you may find some locations where you thought ESLint was running but it wasn't. If you'd like to keep the v8.x behavior, where passing no patterns results in ESLint exiting with code 0, add the `--pass-on-no-patterns` flag to the CLI call.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** In most cases, no change is necessary, and you may find some locations where you thought ESLint was running but it wasn't. If you'd like to keep the v8.x behavior, where passing no patterns results in ESLint exiting with code 0, add the `--pass-on-no-patterns` flag to the CLI call.
 
 **Related issue(s):** [#14308](https://github.com/eslint/eslint/issues/14308)
 
@@ -205,7 +221,9 @@ the resulting configuration for the `curly` rule when linting `my-file.js` will 
 
 Note that this change only affects cases where the same rule is configured in the config file with options and using a configuration comment without options. In all other cases (e.g. the rule is only configured using a configuration comment), the behavior remains the same as prior to ESLint v9.0.0.
 
-**To address:** The migration codemods do not cover this change. We expect that in most cases no change is necessary, as rules configured using configuration comments are typically not already configured in the config file. However, if you need a configuration comment to completely override configuration from the config file and enforce the default options, you'll need to specify at least one option:
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** We expect that in most cases no change is necessary, as rules configured using configuration comments are typically not already configured in the config file. However, if you need a configuration comment to completely override configuration from the config file and enforce the default options, you'll need to specify at least one option:
 
 ```js
 // my-file.js
@@ -235,7 +253,9 @@ In ESLint v9.0.0, the first one is applied, while the others are reported as lin
 foo(); // error: Missing semicolon
 ```
 
-**To address:** The migration codemods do not cover this change. Remove duplicate `/* eslint */` comments.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** Remove duplicate `/* eslint */` comments.
 
 **Related issue(s):** [#18132](https://github.com/eslint/eslint/issues/18132)
 
@@ -255,7 +275,9 @@ The `true` and `false` in this example had no effect on ESLint's behavior, and i
 
 In ESLint v9.0.0, any `/* exported */` variables followed by a colon and value will be ignored as invalid.
 
-**To address:** The migration codemods do not cover this change. Update any `/* exported */` directives to eliminate the colons and subsequent values, and ensure there are commas between variable names such as:
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** Update any `/* exported */` directives to eliminate the colons and subsequent values, and ensure there are commas between variable names such as:
 
 ```js
 /* exported foo, bar */
@@ -281,7 +303,9 @@ This has been fixed in ESLint v9.0.0:
 }
 ```
 
-**To address:** The [@eslint/v8-to-v9-config](#use-migration-codemods) codemod may update your configuration for this. If ESLint still reports invalid configuration for any of these rules, update your configuration manually.
+**Codemod:** The [@eslint/v8-to-v9-config](#use-migration-codemods) codemod may update your configuration for this.
+
+**To address:** If ESLint still reports invalid configuration for any of these rules, update your configuration manually.
 
 **Related issue(s):** [#16879](https://github.com/eslint/eslint/issues/16879)
 
@@ -294,7 +318,9 @@ In ESLint v9.0.0, the `no-implicit-coercion` rule additionally reports the follo
 foo - 0;
 ```
 
-**To address:** The migration codemods do not cover this change. If you want to retain the previous behavior of this rule, set `"allow": ["-", "- -"]`.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** If you want to retain the previous behavior of this rule, set `"allow": ["-", "- -"]`.
 
 ```json
 {
@@ -310,7 +336,9 @@ foo - 0;
 
 In ESLint v9.0.0, the option `allowConstructorFlags` is now case-sensitive.
 
-**To address:** The [@eslint/v8-to-v9-config](#use-migration-codemods) codemod may update your configuration for this. Update your configuration manually if needed.
+**Codemod:** The [@eslint/v8-to-v9-config](#use-migration-codemods) codemod may update your configuration for this.
+
+**To address:** Update your configuration manually if needed.
 
 ## <a name="vars-ignore-pattern"></a> `varsIgnorePattern` option of `no-unused-vars` no longer applies to catch arguments
 
@@ -327,7 +355,9 @@ try {
 }
 ```
 
-**To address:** The migration codemods do not cover this change. If you want to specify ignore patterns for `catch` clause variable names, use the `caughtErrorsIgnorePattern` option in addition to `varsIgnorePattern`.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** If you want to specify ignore patterns for `catch` clause variable names, use the `caughtErrorsIgnorePattern` option in addition to `varsIgnorePattern`.
 
 **Related issue(s):** [#17540](https://github.com/eslint/eslint/issues/17540)
 
@@ -362,7 +392,9 @@ and both `import { Text } from "react-native"` and `import { View } from "react-
 
 In previous versions of ESLint, with this configuration only `import { View } from "react-native"` would be reported.
 
-**To address:** The migration codemods do not cover this change. If your configuration for this rule has multiple entries with the same `name`, you may need to remove unintentional ones.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** If your configuration for this rule has multiple entries with the same `name`, you may need to remove unintentional ones.
 
 **Related issue(s):** [#15261](https://github.com/eslint/eslint/issues/15261)
 
@@ -377,7 +409,9 @@ export default ["eslint:recommended", "eslint:all"];
 
 In ESLint v9.0.0, this format is no longer supported and will result in an error.
 
-**To address:** Use the [@eslint/v8-to-v9-config](#use-migration-codemods) codemod to migrate these strings to the `@eslint/js` package, or install and use `@eslint/js` manually:
+**Codemod:** Use the [@eslint/v8-to-v9-config](#use-migration-codemods) codemod to migrate these strings to the `@eslint/js` package.
+
+**To address:** Install and use `@eslint/js` manually:
 
 ```js
 // eslint.config.js
@@ -401,7 +435,9 @@ if (test) {
 }
 ```
 
-**To address:** The migration codemods do not cover this change. If you want to report the block-level `function`s in every condition regardless of strict or non-strict mode, set the `blockScopeFunctions` option to `"disallow"`.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** If you want to report the block-level `function`s in every condition regardless of strict or non-strict mode, set the `blockScopeFunctions` option to `"disallow"`.
 
 **Related issue(s):** [#15576](https://github.com/eslint/eslint/issues/15576)
 
@@ -419,7 +455,9 @@ try {
 }
 ```
 
-**To address:** The migration codemods do not cover this change. If you want to allow unused caught errors, such as when writing code that will be directly run in an environment that does not support ES2019 optional catch bindings, set the `caughtErrors` option to `"none"`.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** If you want to allow unused caught errors, such as when writing code that will be directly run in an environment that does not support ES2019 optional catch bindings, set the `caughtErrors` option to `"none"`.
 Otherwise, delete the unused caught errors.
 
 ```js
@@ -445,7 +483,9 @@ class SomeClass {
 }
 ```
 
-**To address:** The migration codemods do not cover this change. Fix the problems reported by the rule or revert to the previous behavior by setting the `enforceForClassMembers` option to `false`.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** Fix the problems reported by the rule or revert to the previous behavior by setting the `enforceForClassMembers` option to `false`.
 
 **Related issue(s):** [#18042](https://github.com/eslint/eslint/issues/18042)
 
@@ -453,7 +493,9 @@ class SomeClass {
 
 Previously the camelcase rule didn't enforce the `allow` option to be an array of strings. In ESLint v9.0.0, the `allow` option now only accepts an array of strings.
 
-**To address:** The [@eslint/v8-to-v9-config](#use-migration-codemods) codemod may update your configuration for this. If ESLint still reports invalid configuration for this rule, update your configuration manually.
+**Codemod:** The [@eslint/v8-to-v9-config](#use-migration-codemods) codemod may update your configuration for this.
+
+**To address:** If ESLint still reports invalid configuration for this rule, update your configuration manually.
 
 ## <a name="removed-context-methods"></a> Removed multiple `context` methods
 
@@ -492,7 +534,9 @@ In addition to the methods in the above table, there are several other methods t
 | `context.getScope()`               | `sourceCode.getScope(node)`                 |
 | `context.markVariableAsUsed(name)` | `sourceCode.markVariableAsUsed(name, node)` |
 
-**To address:** Use the [@eslint/v8-to-v9-custom-rules](#use-migration-codemods) codemod to automate much of this migration. For more information, see the [blog post](https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/#automatically-update-your-rules).
+**Codemod:** Use the [@eslint/v8-to-v9-custom-rules](#use-migration-codemods) codemod to automate much of this migration.
+
+**To address:** For more information, see the [blog post](https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/#automatically-update-your-rules).
 
 **Related Issues(s):** [#16999](https://github.com/eslint/eslint/issues/16999), [#13481](https://github.com/eslint/eslint/issues/13481)
 
@@ -500,7 +544,9 @@ In addition to the methods in the above table, there are several other methods t
 
 ESLint v9.0.0 removes the deprecated `sourceCode.getComments()` method.
 
-**To address:** Use the [@eslint/v8-to-v9-custom-rules](#use-migration-codemods) codemod to automate this change. Replace with `sourceCode.getCommentsBefore()`, `sourceCode.getCommentsAfter()`, or `sourceCode.getCommentsInside()`.
+**Codemod:** Use the [@eslint/v8-to-v9-custom-rules](#use-migration-codemods) codemod to automate this change.
+
+**To address:** Replace with `sourceCode.getCommentsBefore()`, `sourceCode.getCommentsAfter()`, or `sourceCode.getCommentsInside()`.
 
 **Related Issues(s):** [#14744](https://github.com/eslint/eslint/issues/14744)
 
@@ -508,7 +554,9 @@ ESLint v9.0.0 removes the deprecated `sourceCode.getComments()` method.
 
 ESLint v9.0.0 removes the deprecated `CodePath#currentSegments` property.
 
-**To address:** The [@eslint/v8-to-v9-custom-rules](#use-migration-codemods) codemod may automate part of this migration. Update your code following the recommendations in the [blog post](https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/#codepath%23currentsegments).
+**Codemod:** The [@eslint/v8-to-v9-custom-rules](#use-migration-codemods) codemod may automate part of this migration.
+
+**To address:** Update your code following the recommendations in the [blog post](https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/#codepath%23currentsegments).
 
 **Related Issues(s):** [#17457](https://github.com/eslint/eslint/issues/17457)
 
@@ -518,7 +566,9 @@ Prior to ESLint v9.0.0, code paths were calculated during the same AST traversal
 
 ESLint v9.0.0 now precalculates code path information before the traversal used by rules. As a result, the code path information is now complete regardless of where it is accessed inside of a rule.
 
-**To address:** The migration codemods do not cover this change. If you are accessing any array properties on `CodePath` or `CodePathSegment`, you'll need to update your code. Specifically:
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** If you are accessing any array properties on `CodePath` or `CodePathSegment`, you'll need to update your code. Specifically:
 
 - If you are checking the `length` of any array properties, ensure you are using relative comparison operators like `<`, `>`, `<=`, and `>=` instead of equals.
 - If you are accessing the `nextSegments`, `prevSegments`, `allNextSegments`, or `allPrevSegments` properties on a `CodePathSegment`, or `CodePath#childCodePaths`, verify that your code will still work as expected. To be backwards compatible, consider moving the logic that checks these properties into `onCodePathEnd`.
@@ -529,7 +579,9 @@ ESLint v9.0.0 now precalculates code path information before the traversal used 
 
 ESLint v9.0.0 drops support for function-style rules. Function-style rules are rules created by exporting a function rather than an object with a `create()` method. This rule format was deprecated in 2016.
 
-**To address:** Use the [@eslint/v8-to-v9-custom-rules](#use-migration-codemods) codemod to convert function-style rules to the object format, or update your rules to [the most recent rule format](../extend/custom-rules). For rules written in CommonJS, you can also use [`eslint-transforms`](https://github.com/eslint/eslint-transforms/blob/main/README.md#new-rule-format).
+**Codemod:** Use the [@eslint/v8-to-v9-custom-rules](#use-migration-codemods) codemod to convert function-style rules to the object format.
+
+**To address:** Update your rules to [the most recent rule format](../extend/custom-rules). For rules written in CommonJS, you can also use [`eslint-transforms`](https://github.com/eslint/eslint-transforms/blob/main/README.md#new-rule-format).
 
 The [eslint-plugin/prefer-object-rule](https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/prefer-object-rule.md) rule can help enforce the usage of object-style rules and autofix any remaining function-style rules.
 
@@ -539,7 +591,9 @@ The [eslint-plugin/prefer-object-rule](https://github.com/eslint-community/eslin
 
 As of ESLint v9.0.0, an error will be thrown if any options are [passed](../use/configure/rules#use-configuration-files) to a rule that doesn't specify `meta.schema` property.
 
-**To address:** The migration codemods do not cover this change.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:**
 
 - If your rule expects [options](../extend/custom-rules#accessing-options-passed-to-a-rule), set [`meta.schema`](../extend/custom-rules#options-schemas) property to a JSON Schema format description of the rule’s options. This schema will be used by ESLint to validate configured options and prevent invalid or unexpected inputs to your rule.
 - If your rule doesn't expect any options, there is no action required. This change ensures that end users will not mistakenly configure options for rules that don't expect options.
@@ -553,7 +607,9 @@ The [eslint-plugin/require-meta-schema](https://github.com/eslint-community/esli
 
 As announced in our [blog post](/blog/2023/10/flat-config-rollout-plans/), the temporary `FlatRuleTester` class has been renamed to `RuleTester`, while the `RuleTester` class from v8.x has been removed. Additionally, the `FlatRuleTester` export from `eslint/use-at-your-own-risk` has been removed.
 
-**To address:** The migration codemods do not cover this change. Update your rule tests to use the new `RuleTester`. To do so, here are some of the common changes you'll need to make:
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** Update your rule tests to use the new `RuleTester`. To do so, here are some of the common changes you'll need to make:
 
 - **Be aware of new defaults for `ecmaVersion` and `sourceType`.** By default, `RuleTester` uses the flat config default of `ecmaVersion: "latest"` and `sourceType: "module"`. This may cause some tests to break if they were expecting the old default of `ecmaVersion: 5` and `sourceType: "script"`. If you'd like to use the old default, you'll need to manually specify that in your `RuleTester` like this:
 
@@ -615,7 +671,9 @@ In order to aid in the development of high-quality custom rules that are free fr
 1. **`filename` and `only` must be of the expected type.** `RuleTester` now checks the type of `filename` and `only` properties of test objects. If specified, `filename` must be a string value. If specified, `only` must be a boolean value.
 1. **Messages cannot have unsubstituted placeholders.** The `RuleTester` now also checks if there are {% raw %}`{{ placeholder }}` {% endraw %} still in the message as their values were not passed via `data` in the respective `context.report()` call.
 
-**To address:** The migration codemods do not cover this change. Run your rule tests using `RuleTester` and fix any errors that occur. The changes you'll need to make to satisfy `RuleTester` are compatible with ESLint v8.x.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** Run your rule tests using `RuleTester` and fix any errors that occur. The changes you'll need to make to satisfy `RuleTester` are compatible with ESLint v8.x.
 
 **Related Issues(s):** [#15104](https://github.com/eslint/eslint/issues/15104), [#15735](https://github.com/eslint/eslint/issues/15735), [#16908](https://github.com/eslint/eslint/issues/16908), [#18016](https://github.com/eslint/eslint/issues/18016)
 
@@ -623,7 +681,9 @@ In order to aid in the development of high-quality custom rules that are free fr
 
 As announced in our [blog post](/blog/2023/10/flat-config-rollout-plans/), the temporary `FlatESLint` class has been renamed to `ESLint`, while the `ESLint` class from v8.x has been renamed to `LegacyESLint`.
 
-**To address:** The migration codemods do not cover this change. If you are currently using the `ESLint` class, verify that your tests pass using the new `ESLint` class. Not all of the old options are supported, so you may need to update the arguments passed to the constructor. See the [Node.js API Reference](../integrate/nodejs-api) for details.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** If you are currently using the `ESLint` class, verify that your tests pass using the new `ESLint` class. Not all of the old options are supported, so you may need to update the arguments passed to the constructor. See the [Node.js API Reference](../integrate/nodejs-api) for details.
 
 If you still need the v8.x `ESLint` functionality, use the `LegacyESLint` class like this:
 
@@ -639,7 +699,9 @@ In ESLint v9.0.0, the `config` argument passed to `Linter#verify()` and `Linter#
 
 Additionally, methods `Linter#defineRule()`, `Linter#defineRules()`, `Linter#defineParser()`, and `Linter#getRules()` are no longer available.
 
-**To address:** The migration codemods do not cover this change. If you are using the `Linter` class, verify that your tests pass.
+**Codemod:** The migration codemods do not cover this change.
+
+**To address:** If you are using the `Linter` class, verify that your tests pass.
 
 If you're passing configuration objects that are incompatible with the flat config format, you'll need to update the code.
 

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -2,8 +2,6 @@
 title: Migrate to v9.x
 ---
 
-{%- from 'components/npx_tabs.macro.html' import npx_tabs %}
-
 ESLint v9.0.0 is a major release of ESLint, and as such, has several breaking changes that you need to be aware of. This guide is intended to walk you through the breaking changes.
 
 To help with this migration, ESLint provides codemods to automate many of the changes described in this guide. All official ESLint codemods are available in the [eslint/codemods](https://github.com/eslint/codemods) repository and through the [Codemod Registry](https://app.codemod.com/registry?q=scope%3Aeslint).

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -98,7 +98,7 @@ As announced in our [blog post](/blog/2023/10/flat-config-rollout-plans/), in ES
 
 **Codemod:** Use the [@eslint/v8-to-v9-config](#use-migration-codemods) codemod to automate much of this migration.
 
-**To address:** Update your configuration manually following the [Configuration Migration Guide](./configure/migration-guide). In case you still need to use the deprecated eslintrc config format, set environment variable `ESLINT_USE_FLAT_CONFIG` to `false`.
+**To address:** Update your configuration manually to the new format following the [Configuration Migration Guide](./configure/migration-guide). In case you still need to use the deprecated eslintrc config format, set environment variable `ESLINT_USE_FLAT_CONFIG` to `false`.
 
 **Related Issues(s):** [#13481](https://github.com/eslint/eslint/issues/13481)
 

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -2,11 +2,41 @@
 title: Migrate to v9.x
 ---
 
+{%- from 'components/npx_tabs.macro.html' import npx_tabs %}
+
 ESLint v9.0.0 is a major release of ESLint, and as such, has several breaking changes that you need to be aware of. This guide is intended to walk you through the breaking changes.
+
+To help with this migration, ESLint provides codemods to automate many of the changes described in this guide. All official ESLint codemods are available in the [eslint/codemods](https://github.com/eslint/codemods) repository and through the [Codemod Registry](https://codemod.link/eslint).
+
+## Use migration codemods
+
+### Migrate ESLint configuration
+
+The `@eslint/v8-to-v9-config` codemod migrates ESLint v8 configuration files to the ESLint v9 flat config format. It updates config structure, rule schemas, plugins, ignores, and deprecated JSDoc rules while preserving existing behavior as much as possible.
+
+```shell
+npx codemod @eslint/v8-to-v9-config
+```
+
+Learn more in the [Codemod Registry](https://app.codemod.com/registry/@eslint/v8-to-v9-config).
+
+### Migrate custom rules
+
+If you maintain custom ESLint rules, the `@eslint/v8-to-v9-custom-rules` codemod converts function-style rules to the object format and updates deprecated rule APIs to their ESLint v9-compatible equivalents.
+
+```shell
+npx codemod @eslint/v8-to-v9-custom-rules
+```
+
+Learn more in the [Codemod Registry](https://app.codemod.com/registry/@eslint/v8-to-v9-custom-rules).
+
+Codemods are a starting point. Review the changes and consult the breaking changes below for anything the codemods do not cover.
 
 The lists below are ordered roughly by the number of users each change is expected to affect, where the first items are expected to affect the most users.
 
 ## Table of Contents
+
+- [Use migration codemods](#use-migration-codemods)
 
 ### Breaking changes for users
 
@@ -60,7 +90,7 @@ ESLint is officially dropping support for these versions of Node.js starting wit
 - Node.js v20.9.0 and above
 - Node.js v21 and above
 
-**To address:** Make sure you upgrade to at least Node.js v18.18.0 when using ESLint v9.0.0. One important thing to double check is the Node.js version supported by your editor when using ESLint via editor integrations. If you are unable to upgrade, we recommend continuing to use ESLint v8.56.0 until you are able to upgrade Node.js.
+**To address:** The migration codemods do not cover this change. Make sure you upgrade to at least Node.js v18.18.0 when using ESLint v9.0.0. One important thing to double check is the Node.js version supported by your editor when using ESLint via editor integrations. If you are unable to upgrade, we recommend continuing to use ESLint v8.56.0 until you are able to upgrade Node.js.
 
 **Related issue(s):** [#17595](https://github.com/eslint/eslint/issues/17595)
 
@@ -68,7 +98,7 @@ ESLint is officially dropping support for these versions of Node.js starting wit
 
 As announced in our [blog post](/blog/2023/10/flat-config-rollout-plans/), in ESLint v9.0.0, [`eslint.config.js`](./configure/configuration-files) is the new default configuration format. The previous format, eslintrc, is now deprecated and will not automatically be searched for.
 
-**To address:** Update your configuration to the new format following the [Configuration Migration Guide](./configure/migration-guide). In case you still need to use the deprecated eslintrc config format, set environment variable `ESLINT_USE_FLAT_CONFIG` to `false`.
+**To address:** Use the [@eslint/v8-to-v9-config](#use-migration-codemods) codemod to automate much of this migration, or update your configuration manually following the [Configuration Migration Guide](./configure/migration-guide). In case you still need to use the deprecated eslintrc config format, set environment variable `ESLINT_USE_FLAT_CONFIG` to `false`.
 
 **Related Issues(s):** [#13481](https://github.com/eslint/eslint/issues/13481)
 
@@ -86,7 +116,7 @@ ESLint v9.0.0 has removed the following formatters from the core:
 | `unix`                | `eslint-formatter-unix`         |
 | `visualstudio`        | `eslint-formatter-visualstudio` |
 
-**To address:** If you are using any of these formatters via the `-f` command line flag, you'll need to install the respective package for the formatter.
+**To address:** The migration codemods do not cover this change. If you are using any of these formatters via the `-f` command line flag, you'll need to install the respective package for the formatter.
 
 **Related issue(s):** [#17524](https://github.com/eslint/eslint/issues/17524)
 
@@ -94,7 +124,7 @@ ESLint v9.0.0 has removed the following formatters from the core:
 
 The `require-jsdoc` and `valid-jsdoc` rules have been removed in ESLint v9.0.0. These rules were initially deprecated in 2018.
 
-**To address:** Use the [replacement rules](https://github.com/gajus/eslint-plugin-jsdoc/wiki/Comparison-with-deprecated-JSdoc-related-ESLint-rules) in `eslint-plugin-jsdoc`.
+**To address:** The [@eslint/v8-to-v9-config](#use-migration-codemods) codemod removes deprecated JSDoc rules from your configuration. Use the [replacement rules](https://github.com/gajus/eslint-plugin-jsdoc/wiki/Comparison-with-deprecated-JSdoc-related-ESLint-rules) in `eslint-plugin-jsdoc` for equivalent linting.
 
 **Related issue(s):** [#15820](https://github.com/eslint/eslint/issues/15820)
 
@@ -114,7 +144,7 @@ Additionally, the following rules have been removed from `eslint:recommended`:
 - [`no-mixed-spaces-and-tabs`](../rules/no-mixed-spaces-and-tabs)
 - [`no-new-symbol`](../rules/no-new-symbol)
 
-**To address:** Fix errors or disable these rules.
+**To address:** The migration codemods do not cover this change. Fix errors or disable these rules.
 
 **Related issue(s):** [#15576](https://github.com/eslint/eslint/issues/15576), [#17446](https://github.com/eslint/eslint/issues/17446), [#17596](https://github.com/eslint/eslint/issues/17596)
 
@@ -124,7 +154,7 @@ Prior to ESLint v9.0.0, the `--quiet` CLI flag would run all rules set to either
 
 If `--max-warnings` is used then `--quiet` will not suppress the execution of rules set to `"warn"` but the output of those rules will be suppressed.
 
-**To address:** In most cases, this change is transparent. If, however, you are running a rule set to `"warn"` that makes changes to the data available to other rules (for example, if the rule uses `sourceCode.markVariableAsUsed()`), then this can result in a behavior change. In such a case, you'll need to either set the rule to `"error"` or stop using `--quiet`.
+**To address:** The migration codemods do not cover this change. In most cases, this change is transparent. If, however, you are running a rule set to `"warn"` that makes changes to the data available to other rules (for example, if the rule uses `sourceCode.markVariableAsUsed()`), then this can result in a behavior change. In such a case, you'll need to either set the rule to `"error"` or stop using `--quiet`.
 
 **Related issue(s):** [#16450](https://github.com/eslint/eslint/issues/16450)
 
@@ -132,7 +162,7 @@ If `--max-warnings` is used then `--quiet` will not suppress the execution of ru
 
 Prior to ESLint v9.0.0, the `--output-file` flag would skip writing a file to disk if the output was empty. However, in ESLint v9.0.0, `--output-file` now consistently writes a file to disk, even when the output is empty. This update ensures a more consistent and reliable behavior for `--output-file`.
 
-**To address:** Review your usage of the `--output-file` flag, especially if your processes depend on the file's presence or absence based on output content. If necessary, update your scripts or configurations to accommodate this change.
+**To address:** The migration codemods do not cover this change. Review your usage of the `--output-file` flag, especially if your processes depend on the file's presence or absence based on output content. If necessary, update your scripts or configurations to accommodate this change.
 
 **Related Issues(s):** [#17660](https://github.com/eslint/eslint/issues/17660)
 
@@ -143,7 +173,7 @@ Prior to ESLint v9.0.0, running the ESLint CLI without any file or directory pat
 - **Flat config.** If you are using flat config, you can run `npx eslint` or `eslint` (if globally installed) and ESLint will assume you want to lint the current directory. Effectively, passing no patterns is equivalent to passing `.`.
 - **eslintrc.** If you are using the deprecated eslintrc config, you'll now receive an error when running the CLI without any patterns.
 
-**To address:** In most cases, no change is necessary, and you may find some locations where you thought ESLint was running but it wasn't. If you'd like to keep the v8.x behavior, where passing no patterns results in ESLint exiting with code 0, add the `--pass-on-no-patterns` flag to the CLI call.
+**To address:** The migration codemods do not cover this change. In most cases, no change is necessary, and you may find some locations where you thought ESLint was running but it wasn't. If you'd like to keep the v8.x behavior, where passing no patterns results in ESLint exiting with code 0, add the `--pass-on-no-patterns` flag to the CLI call.
 
 **Related issue(s):** [#14308](https://github.com/eslint/eslint/issues/14308)
 
@@ -179,7 +209,7 @@ the resulting configuration for the `curly` rule when linting `my-file.js` will 
 
 Note that this change only affects cases where the same rule is configured in the config file with options and using a configuration comment without options. In all other cases (e.g. the rule is only configured using a configuration comment), the behavior remains the same as prior to ESLint v9.0.0.
 
-**To address:** We expect that in most cases no change is necessary, as rules configured using configuration comments are typically not already configured in the config file. However, if you need a configuration comment to completely override configuration from the config file and enforce the default options, you'll need to specify at least one option:
+**To address:** The migration codemods do not cover this change. We expect that in most cases no change is necessary, as rules configured using configuration comments are typically not already configured in the config file. However, if you need a configuration comment to completely override configuration from the config file and enforce the default options, you'll need to specify at least one option:
 
 ```js
 // my-file.js
@@ -209,7 +239,7 @@ In ESLint v9.0.0, the first one is applied, while the others are reported as lin
 foo(); // error: Missing semicolon
 ```
 
-**To address:** Remove duplicate `/* eslint */` comments.
+**To address:** The migration codemods do not cover this change. Remove duplicate `/* eslint */` comments.
 
 **Related issue(s):** [#18132](https://github.com/eslint/eslint/issues/18132)
 
@@ -229,7 +259,7 @@ The `true` and `false` in this example had no effect on ESLint's behavior, and i
 
 In ESLint v9.0.0, any `/* exported */` variables followed by a colon and value will be ignored as invalid.
 
-**To address:** Update any `/* exported */` directives to eliminate the colons and subsequent values, and ensure there are commas between variable names such as:
+**To address:** The migration codemods do not cover this change. Update any `/* exported */` directives to eliminate the colons and subsequent values, and ensure there are commas between variable names such as:
 
 ```js
 /* exported foo, bar */
@@ -255,7 +285,7 @@ This has been fixed in ESLint v9.0.0:
 }
 ```
 
-**To address:** If ESLint reports invalid configuration for any of these rules, update your configuration.
+**To address:** The [@eslint/v8-to-v9-config](#use-migration-codemods) codemod may update your configuration for this. If ESLint still reports invalid configuration for any of these rules, update your configuration manually.
 
 **Related issue(s):** [#16879](https://github.com/eslint/eslint/issues/16879)
 
@@ -268,7 +298,7 @@ In ESLint v9.0.0, the `no-implicit-coercion` rule additionally reports the follo
 foo - 0;
 ```
 
-**To address:** If you want to retain the previous behavior of this rule, set `"allow": ["-", "- -"]`.
+**To address:** The migration codemods do not cover this change. If you want to retain the previous behavior of this rule, set `"allow": ["-", "- -"]`.
 
 ```json
 {
@@ -284,9 +314,7 @@ foo - 0;
 
 In ESLint v9.0.0, the option `allowConstructorFlags` is now case-sensitive.
 
-**To address:** Update your configuration if needed.
-
-**Related issue(s):** [#16574](https://github.com/eslint/eslint/issues/16574)
+**To address:** The [@eslint/v8-to-v9-config](#use-migration-codemods) codemod may update your configuration for this. Update your configuration manually if needed.
 
 ## <a name="vars-ignore-pattern"></a> `varsIgnorePattern` option of `no-unused-vars` no longer applies to catch arguments
 
@@ -303,7 +331,7 @@ try {
 }
 ```
 
-**To address:** If you want to specify ignore patterns for `catch` clause variable names, use the `caughtErrorsIgnorePattern` option in addition to `varsIgnorePattern`.
+**To address:** The migration codemods do not cover this change. If you want to specify ignore patterns for `catch` clause variable names, use the `caughtErrorsIgnorePattern` option in addition to `varsIgnorePattern`.
 
 **Related issue(s):** [#17540](https://github.com/eslint/eslint/issues/17540)
 
@@ -338,7 +366,7 @@ and both `import { Text } from "react-native"` and `import { View } from "react-
 
 In previous versions of ESLint, with this configuration only `import { View } from "react-native"` would be reported.
 
-**To address:** If your configuration for this rule has multiple entries with the same `name`, you may need to remove unintentional ones.
+**To address:** The migration codemods do not cover this change. If your configuration for this rule has multiple entries with the same `name`, you may need to remove unintentional ones.
 
 **Related issue(s):** [#15261](https://github.com/eslint/eslint/issues/15261)
 
@@ -353,7 +381,7 @@ export default ["eslint:recommended", "eslint:all"];
 
 In ESLint v9.0.0, this format is no longer supported and will result in an error.
 
-**To address:** Install and use the `@eslint/js` package instead:
+**To address:** Use the [@eslint/v8-to-v9-config](#use-migration-codemods) codemod to migrate these strings to the `@eslint/js` package, or install and use `@eslint/js` manually:
 
 ```js
 // eslint.config.js
@@ -377,7 +405,7 @@ if (test) {
 }
 ```
 
-**To address:** If you want to report the block-level `function`s in every condition regardless of strict or non-strict mode, set the `blockScopeFunctions` option to `"disallow"`.
+**To address:** The migration codemods do not cover this change. If you want to report the block-level `function`s in every condition regardless of strict or non-strict mode, set the `blockScopeFunctions` option to `"disallow"`.
 
 **Related issue(s):** [#15576](https://github.com/eslint/eslint/issues/15576)
 
@@ -395,7 +423,7 @@ try {
 }
 ```
 
-**To address:** If you want to allow unused caught errors, such as when writing code that will be directly run in an environment that does not support ES2019 optional catch bindings, set the `caughtErrors` option to `"none"`.
+**To address:** The migration codemods do not cover this change. If you want to allow unused caught errors, such as when writing code that will be directly run in an environment that does not support ES2019 optional catch bindings, set the `caughtErrors` option to `"none"`.
 Otherwise, delete the unused caught errors.
 
 ```js
@@ -421,7 +449,7 @@ class SomeClass {
 }
 ```
 
-**To address:** Fix the problems reported by the rule or revert to the previous behavior by setting the `enforceForClassMembers` option to `false`.
+**To address:** The migration codemods do not cover this change. Fix the problems reported by the rule or revert to the previous behavior by setting the `enforceForClassMembers` option to `false`.
 
 **Related issue(s):** [#18042](https://github.com/eslint/eslint/issues/18042)
 
@@ -429,9 +457,7 @@ class SomeClass {
 
 Previously the camelcase rule didn't enforce the `allow` option to be an array of strings. In ESLint v9.0.0, the `allow` option now only accepts an array of strings.
 
-**To address:** If ESLint reports invalid configuration for this rule, update your configuration.
-
-**Related issue(s):** [#18232](https://github.com/eslint/eslint/pull/18232)
+**To address:** The [@eslint/v8-to-v9-config](#use-migration-codemods) codemod may update your configuration for this. If ESLint still reports invalid configuration for this rule, update your configuration manually.
 
 ## <a name="removed-context-methods"></a> Removed multiple `context` methods
 
@@ -470,7 +496,7 @@ In addition to the methods in the above table, there are several other methods t
 | `context.getScope()`               | `sourceCode.getScope(node)`                 |
 | `context.markVariableAsUsed(name)` | `sourceCode.markVariableAsUsed(name, node)` |
 
-**To address:** Use the automated upgrade tool as recommended in the [blog post](https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/#automatically-update-your-rules).
+**To address:** Use the [@eslint/v8-to-v9-custom-rules](#use-migration-codemods) codemod to automate much of this migration. For more information, see the [blog post](https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/#automatically-update-your-rules).
 
 **Related Issues(s):** [#16999](https://github.com/eslint/eslint/issues/16999), [#13481](https://github.com/eslint/eslint/issues/13481)
 
@@ -478,7 +504,7 @@ In addition to the methods in the above table, there are several other methods t
 
 ESLint v9.0.0 removes the deprecated `sourceCode.getComments()` method.
 
-**To address:** Replace with `sourceCode.getCommentsBefore()`, `sourceCode.getCommentsAfter()`, or `sourceCode.getCommentsInside()`.
+**To address:** Use the [@eslint/v8-to-v9-custom-rules](#use-migration-codemods) codemod to automate this change. Replace with `sourceCode.getCommentsBefore()`, `sourceCode.getCommentsAfter()`, or `sourceCode.getCommentsInside()`.
 
 **Related Issues(s):** [#14744](https://github.com/eslint/eslint/issues/14744)
 
@@ -486,7 +512,7 @@ ESLint v9.0.0 removes the deprecated `sourceCode.getComments()` method.
 
 ESLint v9.0.0 removes the deprecated `CodePath#currentSegments` property.
 
-**To address:** Update your code following the recommendations in the [blog post](https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/#codepath%23currentsegments).
+**To address:** The [@eslint/v8-to-v9-custom-rules](#use-migration-codemods) codemod may automate part of this migration. Update your code following the recommendations in the [blog post](https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/#codepath%23currentsegments).
 
 **Related Issues(s):** [#17457](https://github.com/eslint/eslint/issues/17457)
 
@@ -496,7 +522,7 @@ Prior to ESLint v9.0.0, code paths were calculated during the same AST traversal
 
 ESLint v9.0.0 now precalculates code path information before the traversal used by rules. As a result, the code path information is now complete regardless of where it is accessed inside of a rule.
 
-**To address:** If you are accessing any array properties on `CodePath` or `CodePathSegment`, you'll need to update your code. Specifically:
+**To address:** The migration codemods do not cover this change. If you are accessing any array properties on `CodePath` or `CodePathSegment`, you'll need to update your code. Specifically:
 
 - If you are checking the `length` of any array properties, ensure you are using relative comparison operators like `<`, `>`, `<=`, and `>=` instead of equals.
 - If you are accessing the `nextSegments`, `prevSegments`, `allNextSegments`, or `allPrevSegments` properties on a `CodePathSegment`, or `CodePath#childCodePaths`, verify that your code will still work as expected. To be backwards compatible, consider moving the logic that checks these properties into `onCodePathEnd`.
@@ -507,7 +533,7 @@ ESLint v9.0.0 now precalculates code path information before the traversal used 
 
 ESLint v9.0.0 drops support for function-style rules. Function-style rules are rules created by exporting a function rather than an object with a `create()` method. This rule format was deprecated in 2016.
 
-**To address:** Update your rules to [the most recent rule format](../extend/custom-rules). For rules written in CommonJS, you can also use [`eslint-transforms`](https://github.com/eslint/eslint-transforms/blob/main/README.md#new-rule-format).
+**To address:** Use the [@eslint/v8-to-v9-custom-rules](#use-migration-codemods) codemod to convert function-style rules to the object format, or update your rules to [the most recent rule format](../extend/custom-rules). For rules written in CommonJS, you can also use [`eslint-transforms`](https://github.com/eslint/eslint-transforms/blob/main/README.md#new-rule-format).
 
 The [eslint-plugin/prefer-object-rule](https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/prefer-object-rule.md) rule can help enforce the usage of object-style rules and autofix any remaining function-style rules.
 
@@ -517,7 +543,7 @@ The [eslint-plugin/prefer-object-rule](https://github.com/eslint-community/eslin
 
 As of ESLint v9.0.0, an error will be thrown if any options are [passed](../use/configure/rules#use-configuration-files) to a rule that doesn't specify `meta.schema` property.
 
-**To address:**
+**To address:** The migration codemods do not cover this change.
 
 - If your rule expects [options](../extend/custom-rules#accessing-options-passed-to-a-rule), set [`meta.schema`](../extend/custom-rules#options-schemas) property to a JSON Schema format description of the rule’s options. This schema will be used by ESLint to validate configured options and prevent invalid or unexpected inputs to your rule.
 - If your rule doesn't expect any options, there is no action required. This change ensures that end users will not mistakenly configure options for rules that don't expect options.
@@ -531,7 +557,7 @@ The [eslint-plugin/require-meta-schema](https://github.com/eslint-community/esli
 
 As announced in our [blog post](/blog/2023/10/flat-config-rollout-plans/), the temporary `FlatRuleTester` class has been renamed to `RuleTester`, while the `RuleTester` class from v8.x has been removed. Additionally, the `FlatRuleTester` export from `eslint/use-at-your-own-risk` has been removed.
 
-**To address:** Update your rule tests to use the new `RuleTester`. To do so, here are some of the common changes you'll need to make:
+**To address:** The migration codemods do not cover this change. Update your rule tests to use the new `RuleTester`. To do so, here are some of the common changes you'll need to make:
 
 - **Be aware of new defaults for `ecmaVersion` and `sourceType`.** By default, `RuleTester` uses the flat config default of `ecmaVersion: "latest"` and `sourceType: "module"`. This may cause some tests to break if they were expecting the old default of `ecmaVersion: 5` and `sourceType: "script"`. If you'd like to use the old default, you'll need to manually specify that in your `RuleTester` like this:
 
@@ -593,7 +619,7 @@ In order to aid in the development of high-quality custom rules that are free fr
 1. **`filename` and `only` must be of the expected type.** `RuleTester` now checks the type of `filename` and `only` properties of test objects. If specified, `filename` must be a string value. If specified, `only` must be a boolean value.
 1. **Messages cannot have unsubstituted placeholders.** The `RuleTester` now also checks if there are {% raw %}`{{ placeholder }}` {% endraw %} still in the message as their values were not passed via `data` in the respective `context.report()` call.
 
-**To address:** Run your rule tests using `RuleTester` and fix any errors that occur. The changes you'll need to make to satisfy `RuleTester` are compatible with ESLint v8.x.
+**To address:** The migration codemods do not cover this change. Run your rule tests using `RuleTester` and fix any errors that occur. The changes you'll need to make to satisfy `RuleTester` are compatible with ESLint v8.x.
 
 **Related Issues(s):** [#15104](https://github.com/eslint/eslint/issues/15104), [#15735](https://github.com/eslint/eslint/issues/15735), [#16908](https://github.com/eslint/eslint/issues/16908), [#18016](https://github.com/eslint/eslint/issues/18016)
 
@@ -601,7 +627,7 @@ In order to aid in the development of high-quality custom rules that are free fr
 
 As announced in our [blog post](/blog/2023/10/flat-config-rollout-plans/), the temporary `FlatESLint` class has been renamed to `ESLint`, while the `ESLint` class from v8.x has been renamed to `LegacyESLint`.
 
-**To address:** If you are currently using the `ESLint` class, verify that your tests pass using the new `ESLint` class. Not all of the old options are supported, so you may need to update the arguments passed to the constructor. See the [Node.js API Reference](../integrate/nodejs-api) for details.
+**To address:** The migration codemods do not cover this change. If you are currently using the `ESLint` class, verify that your tests pass using the new `ESLint` class. Not all of the old options are supported, so you may need to update the arguments passed to the constructor. See the [Node.js API Reference](../integrate/nodejs-api) for details.
 
 If you still need the v8.x `ESLint` functionality, use the `LegacyESLint` class like this:
 
@@ -617,7 +643,7 @@ In ESLint v9.0.0, the `config` argument passed to `Linter#verify()` and `Linter#
 
 Additionally, methods `Linter#defineRule()`, `Linter#defineRules()`, `Linter#defineParser()`, and `Linter#getRules()` are no longer available.
 
-**To address:** If you are using the `Linter` class, verify that your tests pass.
+**To address:** The migration codemods do not cover this change. If you are using the `Linter` class, verify that your tests pass.
 
 If you're passing configuration objects that are incompatible with the flat config format, you'll need to update the code.
 

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -6,7 +6,7 @@ title: Migrate to v9.x
 
 ESLint v9.0.0 is a major release of ESLint, and as such, has several breaking changes that you need to be aware of. This guide is intended to walk you through the breaking changes.
 
-To help with this migration, ESLint provides codemods to automate many of the changes described in this guide. All official ESLint codemods are available in the [eslint/codemods](https://github.com/eslint/codemods) repository and through the [Codemod Registry](https://codemod.link/eslint).
+To help with this migration, ESLint provides codemods to automate many of the changes described in this guide. All official ESLint codemods are available in the [eslint/codemods](https://github.com/eslint/codemods) repository and through the [Codemod Registry](https://app.codemod.com/registry?q=scope%3Aeslint).
 
 ## Use migration codemods
 

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -499,6 +499,8 @@ Previously the camelcase rule didn't enforce the `allow` option to be an array o
 
 **To address:** If ESLint still reports invalid configuration for this rule, update your configuration manually.
 
+**Related issue(s):** [#18232](https://github.com/eslint/eslint/pull/18232)
+
 ## <a name="removed-context-methods"></a> Removed multiple `context` methods
 
 ESLint v9.0.0 removes multiple deprecated methods from the `context` object and moves them onto the `SourceCode` object:

--- a/docs/src/use/migrate-to-9.0.0.md
+++ b/docs/src/use/migrate-to-9.0.0.md
@@ -340,6 +340,8 @@ In ESLint v9.0.0, the option `allowConstructorFlags` is now case-sensitive.
 
 **To address:** Update your configuration manually if needed.
 
+**Related issue(s):** [#16574](https://github.com/eslint/eslint/issues/16574)
+
 ## <a name="vars-ignore-pattern"></a> `varsIgnorePattern` option of `no-unused-vars` no longer applies to catch arguments
 
 In previous versions of ESLint, the `varsIgnorePattern` option of `no-unused-vars` incorrectly ignored errors specified in a `catch` clause. In ESLint v9.0.0, `varsIgnorePattern` no longer applies to errors in `catch` clauses. For example:


### PR DESCRIPTION
## Summary

- Add a "Use migration codemods" section to the [Migrate to v9.x](https://eslint.org/docs/latest/use/migrate-to-9.0.0) and [Migrate to v10.x](https://eslint.org/docs/latest/use/migrate-to-10.0.0) guides
- Document official `@eslint/v8-to-v9-*` and `@eslint/v9-to-v10` codemods from the [eslint/codemods](https://github.com/eslint/codemods) repository and [Codemod Registry](https://codemod.link/eslint)
- Update individual breaking change "To address" sections to reference applicable codemods or note when codemods do not cover a change

depends on: https://github.com/eslint/eslint.org/pull/1058

## Test plan

- [x] Review rendered migration guide pages for correct formatting and links
- [x] Verify codemod package names and registry URLs are accurate
- [x] Confirm table of contents links resolve correctly


Made with [Cursor](https://cursor.com)