### PR TITLE
feat: detect Symbol() and BigInt() in no-constant-binary-expression

### DIFF
--- a/lib/rules/no-constant-binary-expression.js
+++ b/lib/rules/no-constant-binary-expression.js
@@ -87,7 +87,9 @@ function hasConstantNullishness(scope, node, nonNullish) {
 			return (
 				(functionName === "Boolean" ||
 					functionName === "String" ||
-					functionName === "Number") &&
+					functionName === "Number" ||
+					functionName === "Symbol" ||
+					functionName === "BigInt") &&
 				isReferenceToGlobalVariable(scope, node.callee)
 			);
 		}

--- a/lib/rules/no-constant-binary-expression.js
+++ b/lib/rules/no-constant-binary-expression.js
@@ -374,7 +374,10 @@ function hasConstantStrictBooleanComparison(scope, node) {
 			const functionName = node.callee.name;
 
 			if (
-				(functionName === "String" || functionName === "Number") &&
+				(functionName === "String" ||
+					functionName === "Number" ||
+					functionName === "BigInt" ||
+					functionName === "Symbol") &&
 				isReferenceToGlobalVariable(scope, node.callee)
 			) {
 				return true;

--- a/tests/lib/rules/no-constant-binary-expression.js
+++ b/tests/lib/rules/no-constant-binary-expression.js
@@ -1480,6 +1480,24 @@ ruleTester.run("no-constant-binary-expression", rule, {
 			],
 		},
 		{
+			code: "true === Symbol(x)",
+			errors: [
+				{
+					messageId: "constantBinaryOperand",
+					data: { otherSide: "left", operator: "===" },
+				},
+			],
+		},
+		{
+			code: "true === BigInt(x)",
+			errors: [
+				{
+					messageId: "constantBinaryOperand",
+					data: { otherSide: "left", operator: "===" },
+				},
+			],
+		},
+		{
 			code: "Boolean(0) == !({})",
 			errors: [
 				{

--- a/tests/lib/rules/no-constant-binary-expression.js
+++ b/tests/lib/rules/no-constant-binary-expression.js
@@ -55,6 +55,8 @@ ruleTester.run("no-constant-binary-expression", rule, {
 		"function Boolean(n) { return n; }; Boolean(x) ?? foo",
 		"function String(n) { return n; }; String(x) ?? foo",
 		"function Number(n) { return n; }; Number(x) ?? foo",
+		"function Symbol(n) { return n; }; Symbol(x) ?? foo",
+		"function BigInt(n) { return n; }; BigInt(x) ?? foo",
 		"function Boolean(n) { return Math.random(); }; Boolean(x) === 1",
 		"function Boolean(n) { return Math.random(); }; Boolean(1) == true",
 
@@ -903,6 +905,42 @@ ruleTester.run("no-constant-binary-expression", rule, {
 				{
 					messageId: "constantBinaryOperand",
 					data: { otherSide: "left", operator: "==" },
+				},
+			],
+		},
+		{
+			code: "Symbol(x) != null",
+			errors: [
+				{
+					messageId: "constantBinaryOperand",
+					data: { otherSide: "right", operator: "!=" },
+				},
+			],
+		},
+		{
+			code: "Symbol(x) != undefined",
+			errors: [
+				{
+					messageId: "constantBinaryOperand",
+					data: { otherSide: "right", operator: "!=" },
+				},
+			],
+		},
+		{
+			code: "BigInt(x) != null",
+			errors: [
+				{
+					messageId: "constantBinaryOperand",
+					data: { otherSide: "right", operator: "!=" },
+				},
+			],
+		},
+		{
+			code: "BigInt(x) != undefined",
+			errors: [
+				{
+					messageId: "constantBinaryOperand",
+					data: { otherSide: "right", operator: "!=" },
 				},
 			],
 		},

--- a/tests/lib/rules/no-constant-binary-expression.js
+++ b/tests/lib/rules/no-constant-binary-expression.js
@@ -841,6 +841,24 @@ ruleTester.run("no-constant-binary-expression", rule, {
 				},
 			],
 		},
+		{
+			code: "Symbol(x) ?? foo",
+			errors: [
+				{
+					messageId: "constantShortCircuit",
+					data: { property: "nullishness", operator: "??" },
+				},
+			],
+		},
+		{
+			code: "BigInt(x) ?? foo",
+			errors: [
+				{
+					messageId: "constantShortCircuit",
+					data: { property: "nullishness", operator: "??" },
+				},
+			],
+		},
 
 		// Binary expression with comparison to null
 		{
@@ -1668,6 +1686,24 @@ ruleTester.run("no-constant-binary-expression", rule, {
 				},
 			],
 		},
+		{
+			code: "Symbol(x) === null",
+			errors: [
+				{
+					messageId: "constantBinaryOperand",
+					data: { otherSide: "right", operator: "===" },
+				},
+			],
+		},
+		{
+			code: "BigInt(x) === null",
+			errors: [
+				{
+					messageId: "constantBinaryOperand",
+					data: { otherSide: "right", operator: "===" },
+				},
+			],
+		},
 
 		// Binary expression with strict comparison to undefined
 		{
@@ -1897,6 +1933,24 @@ ruleTester.run("no-constant-binary-expression", rule, {
 		},
 		{
 			code: "(a, b, {}) === undefined",
+			errors: [
+				{
+					messageId: "constantBinaryOperand",
+					data: { otherSide: "right", operator: "===" },
+				},
+			],
+		},
+		{
+			code: "Symbol(x) === undefined",
+			errors: [
+				{
+					messageId: "constantBinaryOperand",
+					data: { otherSide: "right", operator: "===" },
+				},
+			],
+		},
+		{
+			code: "BigInt(x) === undefined",
 			errors: [
 				{
 					messageId: "constantBinaryOperand",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:



#### What changes did you make? (Give an overview)
I reported an issue #20977 

Adds `Symbol` and `BigInt` to the list of recognized wrapper function calls in `lib/rules/no-constant-binary-expression.js`.

Tests added in three sections to cover the new cases:
- `Logical expression with constant nullishness` — `Symbol(x) ?? foo`, `BigInt(x) ?? foo`
- `Binary expression with strict comparison to null` — `Symbol(x) === null`, `BigInt(x) === null`
- `Binary expression with strict comparison to undefined` — `Symbol(x) === undefined`, `BigInt(x) === undefined`


#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
