### PR TITLE
fix: don't report inner non-callbacks in `max-nested-callbacks`

### DIFF
--- a/lib/rules/max-nested-callbacks.js
+++ b/lib/rules/max-nested-callbacks.js
@@ -91,9 +91,11 @@ module.exports = {
 		function checkFunction(node) {
 			const parent = node.parent;
 
-			if (parent.type === "CallExpression") {
-				callbackStack.push(node);
+			if (parent.type !== "CallExpression") {
+				return;
 			}
+
+			callbackStack.push(node);
 
 			if (callbackStack.length > THRESHOLD) {
 				const opts = { num: callbackStack.length, max: THRESHOLD };

--- a/tests/lib/rules/max-nested-callbacks.js
+++ b/tests/lib/rules/max-nested-callbacks.js
@@ -109,6 +109,42 @@ ruleTester.run("max-nested-callbacks", rule, {
 			],
 		},
 		{
+			code: "foo(function() { bar(function() { baz(function() { qux(function() {}); }); }); });",
+			options: [2],
+			errors: [
+				{
+					messageId: "exceed",
+					data: { num: 3, max: 2 },
+					line: 1,
+					column: 39,
+					endLine: 1,
+					endColumn: 47,
+				},
+				{
+					messageId: "exceed",
+					data: { num: 4, max: 2 },
+					line: 1,
+					column: 56,
+					endLine: 1,
+					endColumn: 64,
+				},
+			],
+		},
+		{
+			code: "foo(function() { bar(function() { baz(function() { const qux = function() {}; }); }); });",
+			options: [2],
+			errors: [
+				{
+					messageId: "exceed",
+					data: { num: 3, max: 2 },
+					line: 1,
+					column: 39,
+					endLine: 1,
+					endColumn: 47,
+				},
+			],
+		},
+		{
 			code: "foo(function() { bar(thing, (data) => { baz(function() {}); }); });",
 			options: [2],
 			languageOptions: { ecmaVersion: 6 },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:** 24.16.0
- **npm version:** 11.13.0
- **Local ESLint version:** 10.5.0
- **Global ESLint version:** no
- **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->

```js
export default [{}];
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint max-nested-callbacks: ["error", { max: 2 }] */

foo(function() { 
  bar(function() { 
    baz(function() { 
      const qux = function() {}; 
    });
  });
});
```

[Playground](https://eslint.org/play/#eyJ0ZXh0IjoiLyogZXNsaW50IG1heC1uZXN0ZWQtY2FsbGJhY2tzOiBbXCJlcnJvclwiLCB7IG1heDogMiB9XSAqL1xuXG5mb28oZnVuY3Rpb24oKSB7IFxuICBiYXIoZnVuY3Rpb24oKSB7IFxuICAgIGJheihmdW5jdGlvbigpIHsgXG4gICAgICBjb25zdCBxdXggPSBmdW5jdGlvbigpIHt9OyBcbiAgICB9KTtcbiAgfSk7XG59KTsiLCJvcHRpb25zIjp7InJ1bGVzIjp7fSwibGFuZ3VhZ2VPcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYUZlYXR1cmVzIjp7fX19fX0=)

**What did you expect to happen?**

1 error on `function` after `baz(`, on line 5.

**What actually happened? Please include the actual, raw output from ESLint.**

```
  5:9   error  Too many nested callbacks (3). Maximum allowed is 2  max-nested-callbacks
  6:19  error  Too many nested callbacks (3). Maximum allowed is 2  max-nested-callbacks
```

It also reports `function` after `qux = `, on line 6, although it's not a callback.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated the `max-nested-callback` rule to not report on non-callback functions.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
