### PR TITLE
fix: Fix prefer-exponentiation-operator autofix parens

### DIFF
--- a/lib/rules/prefer-exponentiation-operator.js
+++ b/lib/rules/prefer-exponentiation-operator.js
@@ -85,6 +85,37 @@ function doesExponentiationExpressionNeedParens(node, sourceCode) {
 }
 
 /**
+ * Determines whether replacing the given node with an exponentiation expression
+ * would make an expression statement start with syntax that is ambiguous as a
+ * statement.
+ * @param {ASTNode} node A node that would be replaced by an exponentiation binary expression.
+ * @param {ASTNode} base The base argument of the exponentiation expression.
+ * @param {SourceCode} sourceCode A SourceCode object.
+ * @returns {boolean} `true` if the expression needs to be parenthesised.
+ */
+function doesExpressionStatementNeedParens(node, base, sourceCode) {
+	const expression =
+			node.parent.type === "ChainExpression" ? node.parent : node,
+		parent = expression.parent;
+
+	if (
+		parent.type !== "ExpressionStatement" ||
+		parent.expression !== expression ||
+		astUtils.isParenthesised(sourceCode, expression)
+	) {
+		return false;
+	}
+
+	const firstReplacementToken = sourceCode.getFirstToken(base);
+
+	return (
+		firstReplacementToken.value === "{" ||
+		firstReplacementToken.value === "function" ||
+		firstReplacementToken.value === "class"
+	);
+}
+
+/**
  * Optionally parenthesizes given text.
  * @param {string} text The text to parenthesize.
  * @param {boolean} shouldParenthesize If `true`, the text will be parenthesised.
@@ -152,6 +183,11 @@ module.exports = {
 						shouldParenthesizeAll =
 							doesExponentiationExpressionNeedParens(
 								node,
+								sourceCode,
+							) ||
+							doesExpressionStatementNeedParens(
+								node,
+								base,
 								sourceCode,
 							);
 

--- a/tests/lib/rules/prefer-exponentiation-operator.js
+++ b/tests/lib/rules/prefer-exponentiation-operator.js
@@ -137,6 +137,17 @@ ruleTester.run("prefer-exponentiation-operator", rule, {
 		invalid("Math[`${'pow'}`](a, b)", "a**b"),
 		invalid("Math['p' + 'o' + 'w'](a, b)", "a**b"),
 
+		// expression statements that require parens after autofix
+		invalid("Math.pow({ a: 1 }.a, 2);", "({ a: 1 }.a**2);"),
+		invalid(
+			"Math.pow(function() { return 2; }(), 3);",
+			"(function() { return 2; }()**3);",
+		),
+		invalid(
+			"Math.pow(class { static x = 2; }.x, 4);",
+			"(class { static x = 2; }.x**4);",
+		),
+
 		// non-expression parents that don't require parens
 		invalid("var x = Math.pow(a, b);", "var x = a**b;"),
 		invalid("if(Math.pow(a, b)){}", "if(a**b){}"),


### PR DESCRIPTION
Fixes https://github.com/eslint/eslint/issues/20987.

## What changed

This updates `prefer-exponentiation-operator` so the autofix wraps the replacement exponentiation expression when `Math.pow(...)` is the full expression statement and the base starts with syntax that cannot safely begin a statement (`{`, `function`, or `class`).

Without the wrapping, cases like `Math.pow({ a: 1 }.a, 2);` can be fixed into code that parses differently or fails to parse. The new behavior fixes those cases to outputs like `({ a: 1 }.a**2);`.

## Tests

```text
npm run test:cli tests/lib/rules/prefer-exponentiation-operator.js
```
