### PR TITLE
fix: prefer-exponentiation-operator invalid autofix at statement start

### DIFF
--- a/lib/rules/prefer-exponentiation-operator.js
+++ b/lib/rules/prefer-exponentiation-operator.js
@@ -148,12 +148,35 @@ module.exports = {
 						exponentText = sourceCode.getText(exponent),
 						shouldParenthesizeBase = doesBaseNeedParens(base),
 						shouldParenthesizeExponent =
-							doesExponentNeedParens(exponent),
-						shouldParenthesizeAll =
-							doesExponentiationExpressionNeedParens(
-								node,
-								sourceCode,
-							);
+							doesExponentNeedParens(exponent);
+
+					let shouldParenthesizeAll =
+						doesExponentiationExpressionNeedParens(
+							node,
+							sourceCode,
+						);
+
+					/*
+					 * `function`, `class`, or `{` token at the start of an expression statement
+					 * would cause incorrect parsing.
+					 * https://github.com/eslint/eslint/issues/20987
+					 */
+					if (
+						!shouldParenthesizeAll &&
+						!shouldParenthesizeBase &&
+						astUtils.isStartOfExpressionStatement(node)
+					) {
+						const firstTokenOfBase = sourceCode.getFirstToken(base);
+
+						if (
+							astUtils.isOpeningBraceToken(firstTokenOfBase) ||
+							(firstTokenOfBase.type === "Keyword" &&
+								(firstTokenOfBase.value === "function" ||
+									firstTokenOfBase.value === "class"))
+						) {
+							shouldParenthesizeAll = true;
+						}
+					}
 
 					let prefix = "",
 						suffix = "";

--- a/lib/rules/prefer-exponentiation-operator.js
+++ b/lib/rules/prefer-exponentiation-operator.js
@@ -21,6 +21,11 @@ const PRECEDENCE_OF_EXPONENTIATION_EXPR = astUtils.getPrecedence({
 	operator: "**",
 });
 
+/*
+ * Characters that can cause continuation without preceding semi
+ */
+const continuationChars = new Set(["(", "[", "/", "`"]);
+
 /**
  * Determines whether the given node needs parens if used as the base in an exponentiation binary expression.
  * @param {ASTNode} base The node to check.
@@ -148,7 +153,9 @@ module.exports = {
 						exponentText = sourceCode.getText(exponent),
 						shouldParenthesizeBase = doesBaseNeedParens(base),
 						shouldParenthesizeExponent =
-							doesExponentNeedParens(exponent);
+							doesExponentNeedParens(exponent),
+						isStartOfExpressionStatement =
+							astUtils.isStartOfExpressionStatement(node);
 
 					let shouldParenthesizeAll =
 						doesExponentiationExpressionNeedParens(
@@ -164,7 +171,7 @@ module.exports = {
 					if (
 						!shouldParenthesizeAll &&
 						!shouldParenthesizeBase &&
-						astUtils.isStartOfExpressionStatement(node)
+						isStartOfExpressionStatement
 					) {
 						const firstTokenOfBase = sourceCode.getFirstToken(base);
 
@@ -228,6 +235,15 @@ module.exports = {
 							`${baseReplacement}**${exponentReplacement}`,
 							shouldParenthesizeAll,
 						);
+
+					if (
+						!prefix &&
+						isStartOfExpressionStatement &&
+						continuationChars.has(replacement[0]) &&
+						astUtils.needsPrecedingSemicolon(sourceCode, node)
+					) {
+						prefix = ";";
+					}
 
 					return fixer.replaceText(
 						node,

--- a/tests/lib/rules/prefer-exponentiation-operator.js
+++ b/tests/lib/rules/prefer-exponentiation-operator.js
@@ -489,6 +489,8 @@ ruleTester.run("prefer-exponentiation-operator", rule, {
 
 		// preceding semicolon needed
 		invalid("foo\nMath.pow(a + b, c)", "foo\n;(a + b)**c"),
+		invalid("foo\nMath.pow(+a, b)", "foo\n;(+a)**b"),
+		invalid("foo\nMath.pow(-a, b)", "foo\n;(-a)**b"),
 		invalid("foo\nMath.pow({a:1}.a, 2)", "foo\n;({a:1}.a**2)"),
 		invalid("foo\nMath.pow((a).b, c)", "foo\n;(a).b**c"),
 		invalid(

--- a/tests/lib/rules/prefer-exponentiation-operator.js
+++ b/tests/lib/rules/prefer-exponentiation-operator.js
@@ -486,5 +486,26 @@ ruleTester.run("prefer-exponentiation-operator", rule, {
 			"Math.pow(class{static x=2}.x + 100, 4);",
 			"(class{static x=2}.x + 100)**4;",
 		),
+
+		// preceding semicolon needed
+		invalid("foo\nMath.pow(a + b, c)", "foo\n;(a + b)**c"),
+		invalid("foo\nMath.pow({a:1}.a, 2)", "foo\n;({a:1}.a**2)"),
+		invalid("foo\nMath.pow((a).b, c)", "foo\n;(a).b**c"),
+		invalid(
+			"foo\nMath.pow([a, b].find(fn), c)",
+			"foo\n;[a, b].find(fn)**c",
+		),
+		invalid("foo\nMath.pow(/regex/, 2)", "foo\n;/regex/**2"),
+		invalid(
+			"foo\nMath.pow(`template literal`, 2)",
+			"foo\n;`template literal`**2",
+		),
+
+		// preceding semicolon not needed
+		invalid("foo\n100 + Math.pow((a).b, c)", "foo\n100 + (a).b**c"), // not at the start of an expression statement
+		invalid("foo\nMath.pow(a.b, c)", "foo\na.b**c"), // first token cannot cause continuation
+		invalid("Math.pow((a).b, c)", "(a).b**c"), // no previous statement
+		invalid("foo;\nMath.pow((a).b, c)", "foo;\n(a).b**c"), // previous statement is safe
+		invalid("if (foo) {}\nMath.pow((a).b, c)", "if (foo) {}\n(a).b**c"), // previous statement is safe
 	],
 });

--- a/tests/lib/rules/prefer-exponentiation-operator.js
+++ b/tests/lib/rules/prefer-exponentiation-operator.js
@@ -442,12 +442,17 @@ ruleTester.run("prefer-exponentiation-operator", rule, {
 
 		// https://github.com/eslint/eslint/issues/20987
 		invalid("Math.pow({a:1}.a, 2);", "({a:1}.a**2);"),
+		invalid("Math.pow({a:1}.a, 2) + 100;", "({a:1}.a**2) + 100;"),
 		invalid("(Math.pow({a:1}.a, 2));", "({a:1}.a**2);"),
 		invalid("100 + Math.pow({a:1}.a, 2);", "100 + {a:1}.a**2;"),
 		invalid("Math.pow({a:1}.a + 100, 2);", "({a:1}.a + 100)**2;"),
 		invalid(
 			"Math.pow(function(){return 2}(), 3);",
 			"(function(){return 2}()**3);",
+		),
+		invalid(
+			"Math.pow(function(){return 2}(), 3) + 100;",
+			"(function(){return 2}()**3) + 100;",
 		),
 		invalid(
 			"(Math.pow(function(){return 2}(), 3));",
@@ -464,6 +469,10 @@ ruleTester.run("prefer-exponentiation-operator", rule, {
 		invalid(
 			"Math.pow(class{static x=2}.x, 4);",
 			"(class{static x=2}.x**4);",
+		),
+		invalid(
+			"Math.pow(class{static x=2}.x, 4) + 100;",
+			"(class{static x=2}.x**4) + 100;",
 		),
 		invalid(
 			"(Math.pow(class{static x=2}.x, 4));",

--- a/tests/lib/rules/prefer-exponentiation-operator.js
+++ b/tests/lib/rules/prefer-exponentiation-operator.js
@@ -439,5 +439,43 @@ ruleTester.run("prefer-exponentiation-operator", rule, {
 				},
 			],
 		},
+
+		// https://github.com/eslint/eslint/issues/20987
+		invalid("Math.pow({a:1}.a, 2);", "({a:1}.a**2);"),
+		invalid("(Math.pow({a:1}.a, 2));", "({a:1}.a**2);"),
+		invalid("100 + Math.pow({a:1}.a, 2);", "100 + {a:1}.a**2;"),
+		invalid("Math.pow({a:1}.a + 100, 2);", "({a:1}.a + 100)**2;"),
+		invalid(
+			"Math.pow(function(){return 2}(), 3);",
+			"(function(){return 2}()**3);",
+		),
+		invalid(
+			"(Math.pow(function(){return 2}(), 3));",
+			"(function(){return 2}()**3);",
+		),
+		invalid(
+			"100 + Math.pow(function(){return 2}(), 3);",
+			"100 + function(){return 2}()**3;",
+		),
+		invalid(
+			"Math.pow(function(){return 2}() + 100, 3);",
+			"(function(){return 2}() + 100)**3;",
+		),
+		invalid(
+			"Math.pow(class{static x=2}.x, 4);",
+			"(class{static x=2}.x**4);",
+		),
+		invalid(
+			"(Math.pow(class{static x=2}.x, 4));",
+			"(class{static x=2}.x**4);",
+		),
+		invalid(
+			"100 + Math.pow(class{static x=2}.x, 4);",
+			"100 + class{static x=2}.x**4;",
+		),
+		invalid(
+			"Math.pow(class{static x=2}.x + 100, 4);",
+			"(class{static x=2}.x + 100)**4;",
+		),
 	],
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #20987

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated autofix of the `prefer-exponentiation-operator` rule to add parentheses in cases described in #20987, where `function`, `class` or `{` tokens would cause incorrect parsing.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
