### PR TITLE
fix: don't report shadowed undefined in prefer-promise-reject-errors

### DIFF
--- a/lib/rules/prefer-promise-reject-errors.js
+++ b/lib/rules/prefer-promise-reject-errors.js
@@ -63,11 +63,15 @@ module.exports = {
 			if (!callExpression.arguments.length && allowEmptyReject) {
 				return;
 			}
+
+			const rejectionReason = callExpression.arguments[0];
+
 			if (
 				!callExpression.arguments.length ||
-				!astUtils.couldBeError(callExpression.arguments[0]) ||
-				(callExpression.arguments[0].type === "Identifier" &&
-					callExpression.arguments[0].name === "undefined")
+				!astUtils.couldBeError(rejectionReason) ||
+				(rejectionReason.type === "Identifier" &&
+					rejectionReason.name === "undefined" &&
+					sourceCode.isGlobalReference(rejectionReason))
 			) {
 				context.report({
 					node: callExpression,

--- a/tests/lib/rules/prefer-promise-reject-errors.js
+++ b/tests/lib/rules/prefer-promise-reject-errors.js
@@ -71,6 +71,10 @@ ruleTester.run("prefer-promise-reject-errors", rule, {
 		"function f(Promise) { return Promise.reject('x'); }",
 		"{ class Promise { static reject(x) { return x; } } Promise.reject('x'); }",
 		"function g(Promise) { return new Promise((resolve, reject) => { reject('x'); }); }",
+
+		// Shadowed `undefined` could be an Error object
+		"function f(undefined) { Promise.reject(undefined); }",
+		"function f(undefined) { new Promise((resolve, reject) => reject(undefined)); }",
 	],
 
 	invalid: [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:** v24.16.0
- **npm version:** v11.13.0
- **Local ESLint version:** v10.5.0
- **Global ESLint version:** no
- **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->

```js
export default [{}];
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint prefer-promise-reject-errors: "error" */

function f(undefined) {
    Promise.reject(undefined);
}
```

**What did you expect to happen?**

The rule should not report this code because the local `undefined` binding could contain an Error object.

**What actually happened? Please include the actual, raw output from ESLint.**

The rule reported `Expected the Promise rejection reason to be an Error.` because it treated any identifier named `undefined` as the global `undefined`.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated `prefer-promise-reject-errors` to report `undefined` only when the identifier is a global reference.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
