### PR TITLE
fix: suppress invalid class suggestion in no-promise-executor-return

### DIFF
--- a/lib/rules/no-promise-executor-return.js
+++ b/lib/rules/no-promise-executor-return.js
@@ -199,10 +199,11 @@ module.exports = {
 						});
 					}
 
-					// Do not suggest wrapping an unnamed FunctionExpression in braces as that would be invalid syntax.
+					// Do not suggest wrapping an unnamed function or class expression in braces as that would be invalid syntax.
 					if (
 						!(
-							node.body.type === "FunctionExpression" &&
+							(node.body.type === "FunctionExpression" ||
+								node.body.type === "ClassExpression") &&
 							!node.body.id
 						)
 					) {

--- a/tests/lib/rules/no-promise-executor-return.js
+++ b/tests/lib/rules/no-promise-executor-return.js
@@ -992,6 +992,17 @@ ruleTester.run("no-promise-executor-return", rule, {
 			],
 		},
 		{
+			// No suggestion since an unnamed ClassExpression inside braces is invalid syntax.
+			code: "() => new Promise(() => class {});",
+			errors: [
+				{
+					messageId: "returnsValue",
+					column: 25,
+					suggestions: [],
+				},
+			],
+		},
+		{
 			code: "() => new Promise(() => function foo() {});",
 			errors: [
 				{
@@ -1001,6 +1012,21 @@ ruleTester.run("no-promise-executor-return", rule, {
 						{
 							messageId: "wrapBraces",
 							output: "() => new Promise(() => {function foo() {}});",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "() => new Promise(() => class Foo {});",
+			errors: [
+				{
+					messageId: "returnsValue",
+					column: 25,
+					suggestions: [
+						{
+							messageId: "wrapBraces",
+							output: "() => new Promise(() => {class Foo {}});",
 						},
 					],
 				},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:** v24.16.0
- **npm version:** v11.13.0
- **Local ESLint version:** v10.5.0
- **Global ESLint version:** no
- **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->

```js
export default [{}];
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint no-promise-executor-return: "error" */

new Promise(() => class {});
```

**What did you expect to happen?**

The rule should report the returned class expression without suggesting a brace-wrapping fix that creates invalid syntax.

**What actually happened? Please include the actual, raw output from ESLint.**

The rule suggested wrapping the anonymous class expression in braces, producing invalid syntax:
```js
new Promise(() => {class {}});
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated `no-promise-executor-return` to suppress the `wrapBraces` suggestion for anonymous `ClassExpression` nodes, matching the existing behavior for anonymous function expressions.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
