### PR TITLE
fix: don't report shadowed undefined in no-throw-literal

### DIFF
--- a/lib/rules/no-throw-literal.js
+++ b/lib/rules/no-throw-literal.js
@@ -31,12 +31,17 @@ module.exports = {
 	},
 
 	create(context) {
+		const sourceCode = context.sourceCode;
+
 		return {
 			ThrowStatement(node) {
 				if (!astUtils.couldBeError(node.argument)) {
 					context.report({ node, messageId: "object" });
 				} else if (node.argument.type === "Identifier") {
-					if (node.argument.name === "undefined") {
+					if (
+						node.argument.name === "undefined" &&
+						sourceCode.isGlobalReference(node.argument)
+					) {
 						context.report({ node, messageId: "undef" });
 					}
 				}

--- a/tests/lib/rules/no-throw-literal.js
+++ b/tests/lib/rules/no-throw-literal.js
@@ -24,6 +24,7 @@ ruleTester.run("no-throw-literal", rule, {
 		"throw new Error('error');",
 		"throw Error('error');",
 		"var e = new Error(); throw e;",
+		"function foo(undefined) { throw undefined; }",
 		"try {throw new Error();} catch (e) {throw e;};",
 		"throw a;", // Identifier
 		"throw foo();", // CallExpression


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:** v24.16.0
- **npm version:** v11.13.0
- **Local ESLint version:** v10.5.0
- **Global ESLint version:** no
- **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->

```js
export default [{}];
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/*eslint no-throw-literal: "error"*/

function foo(undefined) { throw undefined; }
```

**What did you expect to happen?**

The rule should not report `throw undefined` when `undefined` is a local binding, because that binding could contain an Error object.

**What actually happened? Please include the actual, raw output from ESLint.**

The rule reported:
```
Do not throw undefined.
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated `no-throw-literal` to report `throw undefined` only when `undefined` is the global reference.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
