### PR TITLE
fix: don't report shadowed undefined in `radix` rule

### DIFF
--- a/lib/rules/radix.js
+++ b/lib/rules/radix.js
@@ -57,12 +57,15 @@ function isParseIntMethod(node) {
  * - A literal except integers between 2 and 36.
  * - undefined.
  * @param {ASTNode} radix A node of radix to check.
+ * @param {SourceCode} sourceCode The source code object.
  * @returns {boolean} `true` if the node is valid.
  */
-function isValidRadix(radix) {
+function isValidRadix(radix, sourceCode) {
 	return !(
 		(radix.type === "Literal" && !validRadixValues.has(radix.value)) ||
-		(radix.type === "Identifier" && radix.name === "undefined")
+		(radix.type === "Identifier" &&
+			radix.name === "undefined" &&
+			sourceCode.isGlobalReference(radix))
 	);
 }
 
@@ -148,7 +151,7 @@ module.exports = {
 					break;
 
 				default:
-					if (!isValidRadix(args[1])) {
+					if (!isValidRadix(args[1], sourceCode)) {
 						context.report({
 							node,
 							messageId: "invalidRadix",

--- a/tests/lib/rules/radix.js
+++ b/tests/lib/rules/radix.js
@@ -27,6 +27,7 @@ ruleTester.run("radix", rule, {
 		'parseInt("10", 1.6e1);',
 		'parseInt("10", 10.0);',
 		'parseInt("10", foo);',
+		'function foo(undefined) { parseInt("10", undefined); }',
 		'Number.parseInt("10", foo);',
 		"parseInt",
 		"Number.foo();",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:** v24.16.0
- **npm version:** v11.13.0
- **Local ESLint version:** v10.5.0
- **Global ESLint version:** no
- **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->

```js
export default [{}];
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint radix: "error" */

function foo(undefined) { parseInt("10", undefined); }
```

**What did you expect to happen?**

The rule should not report `undefined` when it is shadowed by a local binding.

**What actually happened? Please include the actual, raw output from ESLint.**

The rule reported:
```
Invalid radix parameter, must be an integer between 2 and 36.
```
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated the `radix` rule to treat `undefined` as an invalid radix only when the identifier is a global reference.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
