### PR TITLE
refactor: clean up radix rule internals

### DIFF
--- a/lib/rules/radix.js
+++ b/lib/rules/radix.js
@@ -12,6 +12,12 @@
 const astUtils = require("./utils/ast-utils");
 
 //------------------------------------------------------------------------------
+// Types
+//------------------------------------------------------------------------------
+
+/** @typedef {import("eslint-scope").Variable} Variable */
+
+//------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
 
@@ -20,16 +26,23 @@ const validRadixValues = new Set(
 );
 
 /**
- * Checks whether a given node is a MemberExpression of `Number.parseInt` method or not.
+ * Checks whether a given variable is shadowed or not.
+ * @param {Variable} variable A variable to check.
+ * @returns {boolean} `true` if the variable is shadowed.
+ */
+function isShadowed(variable) {
+	return variable.defs.length >= 1;
+}
+
+/**
+ * Checks whether a given node is a MemberExpression of `parseInt` method or not.
  * @param {ASTNode} node A node to check.
- * @returns {boolean} `true` if the node is a MemberExpression of `Number.parseInt`
+ * @returns {boolean} `true` if the node is a MemberExpression of `parseInt`
  *      method.
  */
-function isNumberParseIntMethod(node) {
+function isParseIntMethod(node) {
 	return (
 		node.type === "MemberExpression" &&
-		node.object.type === "Identifier" &&
-		node.object.name === "Number" &&
 		!node.computed &&
 		node.property.type === "Identifier" &&
 		node.property.name === "parseInt"
@@ -103,62 +116,82 @@ module.exports = {
 		function checkArguments(node) {
 			const args = node.arguments;
 
-			switch (args.length) {
-				case 0:
-					context.report({
-						node,
-						messageId: "missingParameters",
-					});
-					break;
+			if (args.length === 0) {
+				context.report({
+					node,
+					messageId: "missingParameters",
+				});
+				return;
+			}
 
-				case 1:
-					context.report({
-						node,
-						messageId: "missingRadix",
-						suggest: [
-							{
-								messageId: "addRadixParameter10",
-								fix(fixer) {
-									const tokens = sourceCode.getTokens(node);
-									const lastToken = tokens.at(-1); // Parenthesis.
-									const secondToLastToken = tokens.at(-2); // May or may not be a comma.
-									const hasTrailingComma =
-										secondToLastToken.type ===
-											"Punctuator" &&
-										secondToLastToken.value === ",";
+			if (args.length === 1) {
+				context.report({
+					node,
+					messageId: "missingRadix",
+					suggest: [
+						{
+							messageId: "addRadixParameter10",
+							fix(fixer) {
+								const lastToken = sourceCode.getLastToken(node);
+								const prevToken =
+									sourceCode.getTokenBefore(lastToken);
 
-									return fixer.insertTextBefore(
-										lastToken,
-										hasTrailingComma ? " 10," : ", 10",
-									);
-								},
+								const hasTrailingComma =
+									astUtils.isCommaToken(prevToken);
+
+								return fixer.insertTextBefore(
+									lastToken,
+									hasTrailingComma ? " 10," : ", 10",
+								);
 							},
-						],
-					});
-					break;
+						},
+					],
+				});
+				return;
+			}
 
-				default:
-					if (!isValidRadix(args[1], sourceCode)) {
-						context.report({
-							node,
-							messageId: "invalidRadix",
-						});
-					}
-					break;
+			if (!isValidRadix(args[1], sourceCode)) {
+				context.report({
+					node,
+					messageId: "invalidRadix",
+				});
 			}
 		}
 
 		return {
-			CallExpression(node) {
-				const callee = astUtils.skipChainExpression(node.callee);
+			"Program:exit"(node) {
+				const scope = sourceCode.getScope(node);
+				let variable;
 
-				if (
-					(astUtils.isSpecificId(callee, "parseInt") &&
-						sourceCode.isGlobalReference(callee)) ||
-					(isNumberParseIntMethod(callee) &&
-						sourceCode.isGlobalReference(callee.object))
-				) {
-					checkArguments(node);
+				// Check `parseInt()`
+				variable = astUtils.getVariableByName(scope, "parseInt");
+				if (variable && !isShadowed(variable)) {
+					variable.references.forEach(reference => {
+						const idNode = reference.identifier;
+
+						if (astUtils.isCallee(idNode)) {
+							checkArguments(idNode.parent);
+						}
+					});
+				}
+
+				// Check `Number.parseInt()`
+				variable = astUtils.getVariableByName(scope, "Number");
+				if (variable && !isShadowed(variable)) {
+					variable.references.forEach(reference => {
+						const parentNode = reference.identifier.parent;
+						const maybeCallee =
+							parentNode.parent.type === "ChainExpression"
+								? parentNode.parent
+								: parentNode;
+
+						if (
+							isParseIntMethod(parentNode) &&
+							astUtils.isCallee(maybeCallee)
+						) {
+							checkArguments(maybeCallee.parent);
+						}
+					});
 				}
 			},
 		};

--- a/lib/rules/radix.js
+++ b/lib/rules/radix.js
@@ -121,10 +121,7 @@ module.exports = {
 					node,
 					messageId: "missingParameters",
 				});
-				return;
-			}
-
-			if (args.length === 1) {
+			} else if (args.length === 1) {
 				context.report({
 					node,
 					messageId: "missingRadix",
@@ -147,10 +144,7 @@ module.exports = {
 						},
 					],
 				});
-				return;
-			}
-
-			if (!isValidRadix(args[1], sourceCode)) {
+			} else if (!isValidRadix(args[1], sourceCode)) {
 				context.report({
 					node,
 					messageId: "invalidRadix",

--- a/lib/rules/radix.js
+++ b/lib/rules/radix.js
@@ -12,12 +12,6 @@
 const astUtils = require("./utils/ast-utils");
 
 //------------------------------------------------------------------------------
-// Types
-//------------------------------------------------------------------------------
-
-/** @typedef {import("eslint-scope").Variable} Variable */
-
-//------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
 
@@ -26,23 +20,16 @@ const validRadixValues = new Set(
 );
 
 /**
- * Checks whether a given variable is shadowed or not.
- * @param {Variable} variable A variable to check.
- * @returns {boolean} `true` if the variable is shadowed.
- */
-function isShadowed(variable) {
-	return variable.defs.length >= 1;
-}
-
-/**
- * Checks whether a given node is a MemberExpression of `parseInt` method or not.
+ * Checks whether a given node is a MemberExpression of `Number.parseInt` method or not.
  * @param {ASTNode} node A node to check.
- * @returns {boolean} `true` if the node is a MemberExpression of `parseInt`
+ * @returns {boolean} `true` if the node is a MemberExpression of `Number.parseInt`
  *      method.
  */
-function isParseIntMethod(node) {
+function isNumberParseIntMethod(node) {
 	return (
 		node.type === "MemberExpression" &&
+		node.object.type === "Identifier" &&
+		node.object.name === "Number" &&
 		!node.computed &&
 		node.property.type === "Identifier" &&
 		node.property.name === "parseInt"
@@ -162,39 +149,16 @@ module.exports = {
 		}
 
 		return {
-			"Program:exit"(node) {
-				const scope = sourceCode.getScope(node);
-				let variable;
+			CallExpression(node) {
+				const callee = astUtils.skipChainExpression(node.callee);
 
-				// Check `parseInt()`
-				variable = astUtils.getVariableByName(scope, "parseInt");
-				if (variable && !isShadowed(variable)) {
-					variable.references.forEach(reference => {
-						const idNode = reference.identifier;
-
-						if (astUtils.isCallee(idNode)) {
-							checkArguments(idNode.parent);
-						}
-					});
-				}
-
-				// Check `Number.parseInt()`
-				variable = astUtils.getVariableByName(scope, "Number");
-				if (variable && !isShadowed(variable)) {
-					variable.references.forEach(reference => {
-						const parentNode = reference.identifier.parent;
-						const maybeCallee =
-							parentNode.parent.type === "ChainExpression"
-								? parentNode.parent
-								: parentNode;
-
-						if (
-							isParseIntMethod(parentNode) &&
-							astUtils.isCallee(maybeCallee)
-						) {
-							checkArguments(maybeCallee.parent);
-						}
-					});
+				if (
+					(astUtils.isSpecificId(callee, "parseInt") &&
+						sourceCode.isGlobalReference(callee)) ||
+					(isNumberParseIntMethod(callee) &&
+						sourceCode.isGlobalReference(callee.object))
+				) {
+					checkArguments(node);
 				}
 			},
 		};


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Refactored the `radix` rule to check `parseInt()` and `Number.parseInt()` calls directly from a `CallExpression` listener.

The rule now uses `astUtils.skipChainExpression()` and `sourceCode.isGlobalReference()` instead of walking global scope variables and checking whether they are shadowed.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
