### PR TITLE
chore: correct JSDoc param types in html formatter

### DIFF
--- a/lib/cli-engine/formatters/html.js
+++ b/lib/cli-engine/formatters/html.js
@@ -191,8 +191,8 @@ function pluralize(word, count) {
 
 /**
  * Renders text along the template of x problems (x errors, x warnings)
- * @param {string} totalErrors Total errors
- * @param {string} totalWarnings Total warnings
+ * @param {number} totalErrors Total errors
+ * @param {number} totalWarnings Total warnings
  * @returns {string} The formatted string, pluralized where necessary
  */
 function renderSummary(totalErrors, totalWarnings) {
@@ -207,8 +207,8 @@ function renderSummary(totalErrors, totalWarnings) {
 
 /**
  * Get the color based on whether there are errors/warnings...
- * @param {string} totalErrors Total errors
- * @param {string} totalWarnings Total warnings
+ * @param {number} totalErrors Total errors
+ * @param {number} totalWarnings Total warnings
  * @returns {number} The color code (0 = green, 1 = yellow, 2 = red)
  */
 function renderColor(totalErrors, totalWarnings) {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Corrected the JSDoc parameter types for `renderSummary` and `renderColor`
in the HTML formatter.

Both functions were documented as `@param {string}` for `totalErrors` and
`totalWarnings`, but they are always called with numeric values
(`result.errorCount` and `result.warningCount`, which are numbers according
to the `LintResult` type). Updated the JSDoc to `@param {number}` to match
the actual call sites.

#### Is there anything you'd like reviewers to focus on?
The `{string}` → `{number}` correction. The previous JSDoc contradicted the
call sites in `renderResults` (e.g. `renderColor(result.errorCount,
result.warningCount)`), where the arguments are numbers.
<!-- markdownlint-disable-file MD004 -->
