### PR TITLE
fix: check globalThis native nonconstructors

### DIFF
--- a/lib/rules/no-new-native-nonconstructor.js
+++ b/lib/rules/no-new-native-nonconstructor.js
@@ -6,10 +6,40 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const astUtils = require("./utils/ast-utils");
+
+//------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
 
 const nonConstructorGlobalFunctionNames = ["Symbol", "BigInt"];
+
+/**
+ * Gets the non-constructor global name when a constructor call uses globalThis.
+ * @param {ASTNode} node A callee node to check.
+ * @param {SourceCode} sourceCode The source code object.
+ * @returns {string|null} The non-constructor global name.
+ */
+function getGlobalThisNonConstructorName(node, sourceCode) {
+	const callee = astUtils.skipChainExpression(node);
+
+	if (
+		callee.type !== "MemberExpression" ||
+		!astUtils.isSpecificId(callee.object, "globalThis") ||
+		!sourceCode.isGlobalReference(callee.object)
+	) {
+		return null;
+	}
+
+	const propertyName = astUtils.getStaticPropertyName(callee);
+
+	return nonConstructorGlobalFunctionNames.includes(propertyName)
+		? propertyName
+		: null;
+}
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -39,6 +69,21 @@ module.exports = {
 		const sourceCode = context.sourceCode;
 
 		return {
+			NewExpression(node) {
+				const nonConstructorName = getGlobalThisNonConstructorName(
+					node.callee,
+					sourceCode,
+				);
+
+				if (nonConstructorName) {
+					context.report({
+						node: node.callee,
+						messageId: "noNewNonconstructor",
+						data: { name: nonConstructorName },
+					});
+				}
+			},
+
 			"Program:exit"(node) {
 				const globalScope = sourceCode.getScope(node);
 

--- a/tests/lib/rules/no-new-native-nonconstructor.js
+++ b/tests/lib/rules/no-new-native-nonconstructor.js
@@ -33,6 +33,10 @@ ruleTester.run("no-new-native-nonconstructor", rule, {
 		"function BigInt() {} new BigInt();",
 		"new foo(BigInt);",
 		"new foo(bar, BigInt);",
+		{
+			code: "const globalThis = { Symbol }; new globalThis.Symbol();",
+			languageOptions: { ecmaVersion: 2020 },
+		},
 	],
 	invalid: [
 		// Symbol
@@ -64,6 +68,24 @@ ruleTester.run("no-new-native-nonconstructor", rule, {
 		},
 		{
 			code: "function bar() { return function BigInt() {}; } var baz = new BigInt(9007199254740991);",
+			errors: [
+				{
+					message: "`BigInt` cannot be called as a constructor.",
+				},
+			],
+		},
+		{
+			code: "var foo = new globalThis.Symbol('foo');",
+			languageOptions: { ecmaVersion: 2020 },
+			errors: [
+				{
+					message: "`Symbol` cannot be called as a constructor.",
+				},
+			],
+		},
+		{
+			code: "var foo = new globalThis['BigInt'](9007199254740991);",
+			languageOptions: { ecmaVersion: 2020 },
 			errors: [
 				{
 					message: "`BigInt` cannot be called as a constructor.",


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Bug fix details:

- Affected rule: `no-new-native-nonconstructor`.
- Expected behavior: references through the built-in `globalThis` object should be handled the same way as direct built-in references when `globalThis` is not shadowed.
- Previous behavior: the rule missed the `globalThis` member form covered by the new regression tests.

#### What changes did you make? (Give an overview)

`no-new-native-nonconstructor` now reports `new globalThis.Symbol()` and `new globalThis["BigInt"](...)` when `globalThis` resolves to the global object.

Tests run:

- `npx mocha tests/lib/rules/no-new-native-nonconstructor.js --timeout 60000`
- `git diff --check`

#### Is there anything you'd like reviewers to focus on?

Please check that the new helper path still respects shadowed `globalThis` bindings.