### PR TITLE
fix: check globalThis Promise executors

### DIFF
--- a/lib/rules/no-async-promise-executor.js
+++ b/lib/rules/no-async-promise-executor.js
@@ -5,6 +5,39 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const astUtils = require("./utils/ast-utils");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Determines whether a callee references the global Promise constructor.
+ * @param {ASTNode} node The callee node to check.
+ * @param {SourceCode} sourceCode The source code object.
+ * @returns {boolean} `true` if the callee references the global Promise constructor.
+ */
+function isGlobalPromiseCallee(node, sourceCode) {
+	const callee = astUtils.skipChainExpression(node);
+
+	if (callee.type === "Identifier") {
+		return (
+			callee.name === "Promise" && sourceCode.isGlobalReference(callee)
+		);
+	}
+
+	return (
+		callee.type === "MemberExpression" &&
+		astUtils.isSpecificId(callee.object, "globalThis") &&
+		sourceCode.isGlobalReference(callee.object) &&
+		astUtils.getStaticPropertyName(callee) === "Promise"
+	);
+}
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -31,10 +64,13 @@ module.exports = {
 		const sourceCode = context.sourceCode;
 
 		return {
-			"NewExpression[callee.name='Promise'][arguments.0.async=true]"(
-				node,
-			) {
-				if (!sourceCode.isGlobalReference(node.callee)) {
+			NewExpression(node) {
+				const [executor] = node.arguments;
+
+				if (
+					!executor?.async ||
+					!isGlobalPromiseCallee(node.callee, sourceCode)
+				) {
 					return;
 				}
 

--- a/tests/lib/rules/no-async-promise-executor.js
+++ b/tests/lib/rules/no-async-promise-executor.js
@@ -32,6 +32,10 @@ ruleTester.run("no-async-promise-executor", rule, {
 		"let Promise; new Promise(async (resolve, reject) => {})",
 		"function f() { new Promise(async (resolve, reject) => {}); var Promise; }",
 		"function f(Promise) { new Promise(async (resolve, reject) => {}); }",
+		{
+			code: "const globalThis = { Promise }; new globalThis.Promise(async (resolve, reject) => {});",
+			languageOptions: { ecmaVersion: 2020 },
+		},
 	],
 
 	invalid: [
@@ -68,6 +72,32 @@ ruleTester.run("no-async-promise-executor", rule, {
 					column: 17,
 					endLine: 1,
 					endColumn: 22,
+				},
+			],
+		},
+		{
+			code: "new globalThis.Promise(async (resolve, reject) => {})",
+			languageOptions: { ecmaVersion: 2020 },
+			errors: [
+				{
+					messageId: "async",
+					line: 1,
+					column: 24,
+					endLine: 1,
+					endColumn: 29,
+				},
+			],
+		},
+		{
+			code: "new globalThis['Promise'](async () => {})",
+			languageOptions: { ecmaVersion: 2020 },
+			errors: [
+				{
+					messageId: "async",
+					line: 1,
+					column: 27,
+					endLine: 1,
+					endColumn: 32,
 				},
 			],
 		},


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Bug fix details:

- Affected rule: `no-async-promise-executor`.
- Expected behavior: references through the built-in `globalThis` object should be handled the same way as direct built-in references when `globalThis` is not shadowed.
- Previous behavior: the rule missed the `globalThis` member form covered by the new regression tests.

#### What changes did you make? (Give an overview)

`no-async-promise-executor` now reports async executors passed to `new globalThis.Promise(...)` and `new globalThis["Promise"](...)` when `globalThis` is not shadowed.

Tests run:

- `npx prettier --check lib/rules/no-async-promise-executor.js`
- `npx mocha tests/lib/rules/no-async-promise-executor.js --timeout 60000`
- `git diff --check`

#### Is there anything you'd like reviewers to focus on?

Please check that the `globalThis` detection matches direct Promise detection without reporting shadowed objects.