### PR TITLE
fix: check globalThis Promise executor returns

### DIFF
--- a/lib/rules/no-promise-executor-return.js
+++ b/lib/rules/no-promise-executor-return.js
@@ -21,6 +21,29 @@ const functionTypesToCheck = new Set([
 ]);
 
 /**
+ * Determines whether a callee references the global Promise constructor.
+ * @param {ASTNode} node The callee node to check.
+ * @param {SourceCode} sourceCode The source code object.
+ * @returns {boolean} `true` if the callee references the global Promise constructor.
+ */
+function isGlobalPromiseCallee(node, sourceCode) {
+	const callee = astUtils.skipChainExpression(node);
+
+	if (callee.type === "Identifier") {
+		return (
+			callee.name === "Promise" && sourceCode.isGlobalReference(callee)
+		);
+	}
+
+	return (
+		callee.type === "MemberExpression" &&
+		astUtils.isSpecificId(callee.object, "globalThis") &&
+		sourceCode.isGlobalReference(callee.object) &&
+		astUtils.getStaticPropertyName(callee) === "Promise"
+	);
+}
+
+/**
  * Determines whether the given function node is used as a Promise executor.
  * @param {ASTNode} node The node to check.
  * @param {SourceCode} sourceCode Source code to which the node belongs.
@@ -32,9 +55,7 @@ function isPromiseExecutor(node, sourceCode) {
 	return (
 		parent.type === "NewExpression" &&
 		parent.arguments[0] === node &&
-		parent.callee.type === "Identifier" &&
-		parent.callee.name === "Promise" &&
-		sourceCode.isGlobalReference(parent.callee)
+		isGlobalPromiseCallee(parent.callee, sourceCode)
 	);
 }
 

--- a/tests/lib/rules/no-promise-executor-return.js
+++ b/tests/lib/rules/no-promise-executor-return.js
@@ -77,6 +77,10 @@ ruleTester.run("no-promise-executor-return", rule, {
 		"function f(Promise) { new Promise((resolve, reject) => 1); }",
 		"if (x) { const Promise = foo(); new Promise(function (resolve, reject) { return 1; }); }",
 		"x = function Promise() { new Promise((resolve, reject) => { return 1; }); }",
+		{
+			code: "const globalThis = { Promise }; new globalThis.Promise((resolve, reject) => 1);",
+			languageOptions: { ecmaVersion: 2020 },
+		},
 
 		// return without a value is allowed
 		"new Promise(function (resolve, reject) { return; });",
@@ -1060,6 +1064,32 @@ ruleTester.run("no-promise-executor-return", rule, {
 		},
 		{
 			code: "new Promise(function Promise(resolve, reject) { return 1; })",
+			errors: [
+				{
+					messageId: "returnsValue",
+					suggestions: null,
+				},
+			],
+		},
+		{
+			code: "new globalThis.Promise((resolve, reject) => 1)",
+			languageOptions: { ecmaVersion: 2020 },
+			errors: [
+				{
+					messageId: "returnsValue",
+					column: 45,
+					suggestions: [
+						{
+							messageId: "wrapBraces",
+							output: "new globalThis.Promise((resolve, reject) => {1})",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "new globalThis['Promise']((resolve, reject) => { return 1; })",
+			languageOptions: { ecmaVersion: 2020 },
 			errors: [
 				{
 					messageId: "returnsValue",


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Bug fix details:

- Affected rule: `no-promise-executor-return`.
- Expected behavior: references through the built-in `globalThis` object should be handled the same way as direct built-in references when `globalThis` is not shadowed.
- Previous behavior: the rule missed the `globalThis` member form covered by the new regression tests.

#### What changes did you make? (Give an overview)

`no-promise-executor-return` now reports returned values from executors passed to `new globalThis.Promise(...)` and `new globalThis["Promise"](...)` when `globalThis` is not shadowed.

Tests run:

- `npx prettier --check lib/rules/no-promise-executor-return.js`
- `npx mocha tests/lib/rules/no-promise-executor-return.js --timeout 60000`
- `git diff --check`

#### Is there anything you'd like reviewers to focus on?

Please check the scope handling around local `globalThis` bindings and Promise constructor resolution.