### PR TITLE
fix: require descriptions for globalThis Symbol

### DIFF
--- a/lib/rules/symbol-description.js
+++ b/lib/rules/symbol-description.js
@@ -12,6 +12,27 @@
 const astUtils = require("./utils/ast-utils");
 
 //------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Determines whether a callee references globalThis.Symbol.
+ * @param {ASTNode} node The callee node to check.
+ * @param {SourceCode} sourceCode The source code object.
+ * @returns {boolean} `true` if the callee references globalThis.Symbol.
+ */
+function isGlobalThisSymbolCallee(node, sourceCode) {
+	const callee = astUtils.skipChainExpression(node);
+
+	return (
+		callee.type === "MemberExpression" &&
+		astUtils.isSpecificId(callee.object, "globalThis") &&
+		sourceCode.isGlobalReference(callee.object) &&
+		astUtils.getStaticPropertyName(callee) === "Symbol"
+	);
+}
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -51,6 +72,12 @@ module.exports = {
 		}
 
 		return {
+			CallExpression(node) {
+				if (isGlobalThisSymbolCallee(node.callee, sourceCode)) {
+					checkArgument(node);
+				}
+			},
+
 			"Program:exit"(node) {
 				const scope = sourceCode.getScope(node);
 				const variable = astUtils.getVariableByName(scope, "Symbol");

--- a/tests/lib/rules/symbol-description.js
+++ b/tests/lib/rules/symbol-description.js
@@ -27,11 +27,19 @@ ruleTester.run("symbol-description", rule, {
 	valid: [
 		'Symbol("Foo");',
 		'var foo = "foo"; Symbol(foo);',
+		{
+			code: 'globalThis.Symbol("Foo");',
+			languageOptions: { ecmaVersion: 2020 },
+		},
 
 		// Ignore if it's shadowed.
 		"var Symbol = function () {}; Symbol();",
 		"Symbol(); var Symbol = function () {};",
 		"function bar() { var Symbol = function () {}; Symbol(); }",
+		{
+			code: "const globalThis = { Symbol }; globalThis.Symbol();",
+			languageOptions: { ecmaVersion: 2020 },
+		},
 
 		// Ignore if it's an argument.
 		"function bar(Symbol) { Symbol(); }",
@@ -48,6 +56,24 @@ ruleTester.run("symbol-description", rule, {
 		},
 		{
 			code: "Symbol(); Symbol = function () {};",
+			errors: [
+				{
+					messageId: "expected",
+				},
+			],
+		},
+		{
+			code: "globalThis.Symbol();",
+			languageOptions: { ecmaVersion: 2020 },
+			errors: [
+				{
+					messageId: "expected",
+				},
+			],
+		},
+		{
+			code: "globalThis['Symbol']();",
+			languageOptions: { ecmaVersion: 2020 },
 			errors: [
 				{
 					messageId: "expected",


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Bug fix details:

- Affected rule: `symbol-description`.
- Expected behavior: references through the built-in `globalThis` object should be handled the same way as direct built-in references when `globalThis` is not shadowed.
- Previous behavior: the rule missed the `globalThis` member form covered by the new regression tests.

#### What changes did you make? (Give an overview)

`symbol-description` now requires descriptions for `globalThis.Symbol()` calls when `globalThis` resolves to the global object.

Tests run:

- `npx mocha tests/lib/rules/symbol-description.js --timeout 60000`
- `git diff --check`

#### Is there anything you'd like reviewers to focus on?

Please check that shadowed `globalThis` cases remain valid and direct Symbol behavior is unchanged.