### PR TITLE
fix: check globalThis wrapper constructors

### DIFF
--- a/lib/rules/no-new-wrappers.js
+++ b/lib/rules/no-new-wrappers.js
@@ -9,7 +9,35 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const { getVariableByName } = require("./utils/ast-utils");
+const astUtils = require("./utils/ast-utils");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+const wrapperObjects = new Set(["String", "Number", "Boolean"]);
+
+/**
+ * Gets a wrapper object name from a globalThis member expression.
+ * @param {ASTNode} node The callee node to check.
+ * @param {SourceCode} sourceCode The source code object.
+ * @returns {string|null} The wrapper object name.
+ */
+function getGlobalThisWrapperName(node, sourceCode) {
+	const callee = astUtils.skipChainExpression(node);
+
+	if (
+		callee.type !== "MemberExpression" ||
+		!astUtils.isSpecificId(callee.object, "globalThis") ||
+		!sourceCode.isGlobalReference(callee.object)
+	) {
+		return null;
+	}
+
+	const propertyName = astUtils.getStaticPropertyName(callee);
+
+	return wrapperObjects.has(propertyName) ? propertyName : null;
+}
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -39,20 +67,35 @@ module.exports = {
 
 		return {
 			NewExpression(node) {
-				const wrapperObjects = ["String", "Number", "Boolean"];
-				const { name } = node.callee;
+				const callee = astUtils.skipChainExpression(node.callee);
+				const globalThisWrapperName = getGlobalThisWrapperName(
+					callee,
+					sourceCode,
+				);
 
-				if (wrapperObjects.includes(name)) {
-					const variable = getVariableByName(
+				if (globalThisWrapperName) {
+					context.report({
+						node,
+						messageId: "noConstructor",
+						data: { fn: globalThisWrapperName },
+					});
+					return;
+				}
+
+				if (
+					callee.type === "Identifier" &&
+					wrapperObjects.has(callee.name)
+				) {
+					const variable = astUtils.getVariableByName(
 						sourceCode.getScope(node),
-						name,
+						callee.name,
 					);
 
 					if (variable && variable.identifiers.length === 0) {
 						context.report({
 							node,
 							messageId: "noConstructor",
-							data: { fn: name },
+							data: { fn: callee.name },
 						});
 					}
 				}

--- a/tests/lib/rules/no-new-wrappers.js
+++ b/tests/lib/rules/no-new-wrappers.js
@@ -49,6 +49,10 @@ ruleTester.run("no-new-wrappers", rule, {
 				},
 			},
 		},
+		{
+			code: "const globalThis = { String }; new globalThis.String();",
+			languageOptions: { ecmaVersion: 2020 },
+		},
 		`
         /* global Boolean:off */
         assert(new Boolean);
@@ -104,6 +108,54 @@ ruleTester.run("no-new-wrappers", rule, {
 						fn: "String",
 					},
 					line: 2,
+				},
+			],
+		},
+		{
+			code: "var a = new globalThis.String('hello');",
+			languageOptions: { ecmaVersion: 2020 },
+			errors: [
+				{
+					messageId: "noConstructor",
+					data: {
+						fn: "String",
+					},
+				},
+			],
+		},
+		{
+			code: "var a = new globalThis['Number'](10);",
+			languageOptions: { ecmaVersion: 2020 },
+			errors: [
+				{
+					messageId: "noConstructor",
+					data: {
+						fn: "Number",
+					},
+				},
+			],
+		},
+		{
+			code: "var a = new globalThis.Boolean(false);",
+			languageOptions: { ecmaVersion: 2020 },
+			errors: [
+				{
+					messageId: "noConstructor",
+					data: {
+						fn: "Boolean",
+					},
+				},
+			],
+		},
+		{
+			code: "const String = CustomString; var a = new globalThis.String('hello');",
+			languageOptions: { ecmaVersion: 2020 },
+			errors: [
+				{
+					messageId: "noConstructor",
+					data: {
+						fn: "String",
+					},
 				},
 			],
 		},


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Bug fix details:

- Affected rule: `no-new-wrappers`.
- Expected behavior: references through the built-in `globalThis` object should be handled the same way as direct built-in references when `globalThis` is not shadowed.
- Previous behavior: the rule missed the `globalThis` member form covered by the new regression tests.

#### What changes did you make? (Give an overview)

`no-new-wrappers` now reports `new globalThis.String(...)`, `new globalThis["Number"](...)`, and `new globalThis.Boolean(...)` when `globalThis` is not shadowed.

Tests run:

- `npx prettier --check lib/rules/no-new-wrappers.js`
- `npx mocha tests/lib/rules/no-new-wrappers.js --timeout 60000`
- `npx eslint lib/rules/no-new-wrappers.js tests/lib/rules/no-new-wrappers.js --format stylish`
- `git diff --check`

#### Is there anything you'd like reviewers to focus on?

Please check the new member-expression path and the shadowed `globalThis` valid cases.