### PR TITLE
feat: report invalid signed numeric radix literals in radix

### DIFF
--- a/docs/src/rules/radix.md
+++ b/docs/src/rules/radix.md
@@ -43,7 +43,9 @@ const num2 = parseInt("071", "abc");
 
 const num3 = parseInt("071", 37);
 
-const num4 = parseInt();
+const num4 = parseInt("071", -1);
+
+const num5 = parseInt();
 ```
 
 :::

--- a/lib/rules/radix.js
+++ b/lib/rules/radix.js
@@ -55,12 +55,27 @@ function isParseIntMethod(node) {
  * The following values are invalid.
  *
  * - A literal except integers between 2 and 36.
+ * - A signed numeric literal (e.g. `-1`, `+1`) whose value is not an integer between 2 and 36.
  * - undefined.
  * @param {ASTNode} radix A node of radix to check.
  * @param {SourceCode} sourceCode The source code object.
  * @returns {boolean} `true` if the node is valid.
  */
 function isValidRadix(radix, sourceCode) {
+	if (
+		radix.type === "UnaryExpression" &&
+		(radix.operator === "-" || radix.operator === "+") &&
+		radix.argument.type === "Literal" &&
+		typeof radix.argument.value === "number"
+	) {
+		const value =
+			radix.operator === "-"
+				? -radix.argument.value
+				: radix.argument.value;
+
+		return validRadixValues.has(value);
+	}
+
 	return !(
 		(radix.type === "Literal" && !validRadixValues.has(radix.value)) ||
 		(radix.type === "Identifier" &&

--- a/lib/types/rules.d.ts
+++ b/lib/types/rules.d.ts
@@ -5054,6 +5054,7 @@ export interface ESLintRules extends Linter.RulesRecord {
 	 * @since 0.0.7
 	 * @see https://eslint.org/docs/latest/rules/radix
 	 */
+    
 	radix: Linter.RuleEntry<["always" | "as-needed"]>;
 
 	/**

--- a/lib/types/rules.d.ts
+++ b/lib/types/rules.d.ts
@@ -5054,7 +5054,7 @@ export interface ESLintRules extends Linter.RulesRecord {
 	 * @since 0.0.7
 	 * @see https://eslint.org/docs/latest/rules/radix
 	 */
-    
+
 	radix: Linter.RuleEntry<["always" | "as-needed"]>;
 
 	/**

--- a/tests/lib/rules/radix.js
+++ b/tests/lib/rules/radix.js
@@ -27,6 +27,9 @@ ruleTester.run("radix", rule, {
 		'parseInt("10", 1.6e1);',
 		'parseInt("10", 10.0);',
 		'parseInt("10", foo);',
+		'parseInt("10", +10);',
+		'parseInt("10", +36);',
+		'Number.parseInt("10", +16);',
 		'function foo(undefined) { parseInt("10", undefined); }',
 		'Number.parseInt("10", foo);',
 		"parseInt",
@@ -198,6 +201,46 @@ ruleTester.run("radix", rule, {
 		},
 		{
 			code: 'parseInt("10", 37);',
+			errors: [
+				{
+					messageId: "invalidRadix",
+				},
+			],
+		},
+		{
+			code: 'parseInt("10", -1);',
+			errors: [
+				{
+					messageId: "invalidRadix",
+				},
+			],
+		},
+		{
+			code: 'parseInt("10", +1);',
+			errors: [
+				{
+					messageId: "invalidRadix",
+				},
+			],
+		},
+		{
+			code: 'parseInt("10", -10);',
+			errors: [
+				{
+					messageId: "invalidRadix",
+				},
+			],
+		},
+		{
+			code: 'parseInt("10", +37);',
+			errors: [
+				{
+					messageId: "invalidRadix",
+				},
+			],
+		},
+		{
+			code: 'Number.parseInt("10", -16);',
 			errors: [
 				{
 					messageId: "invalidRadix",


### PR DESCRIPTION
#### Prerequisites checklist
- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #21012

#### What changes did you make? (Give an overview)

Updated the `radix` rule to report signed numeric radix literals that are
out of range.

Previously, `isValidRadix` only handled `Literal` nodes, so a signed radix
such as `parseInt("10", -1)` was parsed as a `UnaryExpression` and skipped
the validation entirely, allowing invalid values through.

The rule now unwraps `UnaryExpression` nodes with a `+` or `-` operator and
a numeric `Literal` argument, computes the actual signed value, and checks
it against the valid range (integers 2–36). For example:

- `parseInt("10", +10)` — valid, not reported
- `parseInt("10", -1)` / `parseInt("10", +1)` / `parseInt("10", -10)` — reported as `invalidRadix`

I also added test cases in `tests/lib/rules/radix.js` and updated the
incorrect examples in `docs/src/rules/radix.md`.

#### Is there anything you'd like reviewers to focus on?

The handling of the unary `+` operator — `+10` should remain valid while
`-10` and `+1` are reported. Please confirm the edge cases in the added
tests match the intended behavior.