### PR TITLE
feat: suggest Object.is() in no-compare-neg-zero

### DIFF
--- a/lib/rules/no-compare-neg-zero.js
+++ b/lib/rules/no-compare-neg-zero.js
@@ -11,6 +11,7 @@
 /** @type {import('../types').Rule.RuleModule} */
 module.exports = {
 	meta: {
+		hasSuggestions: true,
 		type: "problem",
 
 		docs: {
@@ -25,10 +26,13 @@ module.exports = {
 		messages: {
 			unexpected:
 				"Do not use the '{{operator}}' operator to compare against -0.",
+			useObjectIs: "Use Object.is() to compare against -0.",
 		},
 	},
 
 	create(context) {
+		const sourceCode = context.sourceCode;
+
 		//--------------------------------------------------------------------------
 		// Helpers
 		//--------------------------------------------------------------------------
@@ -56,15 +60,50 @@ module.exports = {
 			"!=",
 			"!==",
 		]);
+		const OPERATORS_TO_SUGGEST = new Set(["===", "!=="]);
+
+		/**
+		 * Gets the source text for a node when replacing its parent expression.
+		 * @param {ASTNode} node A node to get text for.
+		 * @returns {string} The node's source text.
+		 */
+		function getReplacementText(node) {
+			const text = sourceCode.getText(node);
+
+			return node.type === "SequenceExpression" ? `(${text})` : text;
+		}
+
+		/**
+		 * Gets a suggestion to replace strict comparisons against -0 with Object.is().
+		 * @param {ASTNode} node A BinaryExpression node.
+		 * @returns {Object|null} A suggestion descriptor or null if no suggestion applies.
+		 */
+		function getSuggestion(node) {
+			if (!OPERATORS_TO_SUGGEST.has(node.operator)) {
+				return null;
+			}
+
+			const objectIsCall = `Object.is(${getReplacementText(node.left)}, ${getReplacementText(node.right)})`;
+			const replacement =
+				node.operator === "!==" ? `!${objectIsCall}` : objectIsCall;
+
+			return {
+				messageId: "useObjectIs",
+				fix: fixer => fixer.replaceText(node, replacement),
+			};
+		}
 
 		return {
 			BinaryExpression(node) {
 				if (OPERATORS_TO_CHECK.has(node.operator)) {
 					if (isNegZero(node.left) || isNegZero(node.right)) {
+						const suggestion = getSuggestion(node);
+
 						context.report({
 							node,
 							messageId: "unexpected",
 							data: { operator: node.operator },
+							suggest: suggestion ? [suggestion] : [],
 						});
 					}
 				}

--- a/tests/lib/rules/no-compare-neg-zero.js
+++ b/tests/lib/rules/no-compare-neg-zero.js
@@ -55,6 +55,12 @@ ruleTester.run("no-compare-neg-zero", rule, {
 				{
 					messageId: "unexpected",
 					data: { operator: "===" },
+					suggestions: [
+						{
+							messageId: "useObjectIs",
+							output: "Object.is(x, -0)",
+						},
+					],
 				},
 			],
 		},
@@ -64,6 +70,57 @@ ruleTester.run("no-compare-neg-zero", rule, {
 				{
 					messageId: "unexpected",
 					data: { operator: "===" },
+					suggestions: [
+						{
+							messageId: "useObjectIs",
+							output: "Object.is(-0, x)",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "x !== -0",
+			errors: [
+				{
+					messageId: "unexpected",
+					data: { operator: "!==" },
+					suggestions: [
+						{
+							messageId: "useObjectIs",
+							output: "!Object.is(x, -0)",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "-0 !== x",
+			errors: [
+				{
+					messageId: "unexpected",
+					data: { operator: "!==" },
+					suggestions: [
+						{
+							messageId: "useObjectIs",
+							output: "!Object.is(-0, x)",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "(x, y) === -0",
+			errors: [
+				{
+					messageId: "unexpected",
+					data: { operator: "===" },
+					suggestions: [
+						{
+							messageId: "useObjectIs",
+							output: "Object.is((x, y), -0)",
+						},
+					],
 				},
 			],
 		},
@@ -73,6 +130,7 @@ ruleTester.run("no-compare-neg-zero", rule, {
 				{
 					messageId: "unexpected",
 					data: { operator: "==" },
+					suggestions: [],
 				},
 			],
 		},
@@ -82,6 +140,27 @@ ruleTester.run("no-compare-neg-zero", rule, {
 				{
 					messageId: "unexpected",
 					data: { operator: "==" },
+					suggestions: [],
+				},
+			],
+		},
+		{
+			code: "x != -0",
+			errors: [
+				{
+					messageId: "unexpected",
+					data: { operator: "!=" },
+					suggestions: [],
+				},
+			],
+		},
+		{
+			code: "-0 != x",
+			errors: [
+				{
+					messageId: "unexpected",
+					data: { operator: "!=" },
+					suggestions: [],
 				},
 			],
 		},
@@ -91,6 +170,7 @@ ruleTester.run("no-compare-neg-zero", rule, {
 				{
 					messageId: "unexpected",
 					data: { operator: ">" },
+					suggestions: [],
 				},
 			],
 		},
@@ -100,6 +180,7 @@ ruleTester.run("no-compare-neg-zero", rule, {
 				{
 					messageId: "unexpected",
 					data: { operator: ">" },
+					suggestions: [],
 				},
 			],
 		},
@@ -109,6 +190,7 @@ ruleTester.run("no-compare-neg-zero", rule, {
 				{
 					messageId: "unexpected",
 					data: { operator: ">=" },
+					suggestions: [],
 				},
 			],
 		},
@@ -118,6 +200,7 @@ ruleTester.run("no-compare-neg-zero", rule, {
 				{
 					messageId: "unexpected",
 					data: { operator: ">=" },
+					suggestions: [],
 				},
 			],
 		},
@@ -127,6 +210,7 @@ ruleTester.run("no-compare-neg-zero", rule, {
 				{
 					messageId: "unexpected",
 					data: { operator: "<" },
+					suggestions: [],
 				},
 			],
 		},
@@ -136,6 +220,7 @@ ruleTester.run("no-compare-neg-zero", rule, {
 				{
 					messageId: "unexpected",
 					data: { operator: "<" },
+					suggestions: [],
 				},
 			],
 		},
@@ -145,6 +230,7 @@ ruleTester.run("no-compare-neg-zero", rule, {
 				{
 					messageId: "unexpected",
 					data: { operator: "<=" },
+					suggestions: [],
 				},
 			],
 		},
@@ -154,6 +240,7 @@ ruleTester.run("no-compare-neg-zero", rule, {
 				{
 					messageId: "unexpected",
 					data: { operator: "<=" },
+					suggestions: [],
 				},
 			],
 		},


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Refs #21025

#### What changes did you make? (Give an overview)

This adds editor suggestions to `no-compare-neg-zero` for strict comparisons against `-0`:

- `x === -0` and `-0 === x` suggest the corresponding `Object.is(...)` call.
- `x !== -0` and `-0 !== x` suggest the corresponding negated `!Object.is(...)` call.
- Loose equality and relational comparisons continue to report without suggestions.

This was AI-assisted, and I manually reviewed the generated changes before submitting.

#### Is there anything you'd like reviewers to focus on?

Please check that the suggestion scope matches #21025, especially leaving loose equality and relational operators without suggestions.

Tests run:

- `npx mocha tests/lib/rules/no-compare-neg-zero.js`
- `npm run lint`
- `npm run fmt:check -- lib/rules/no-compare-neg-zero.js tests/lib/rules/no-compare-neg-zero.js`
- `npm run lint:rule-types`
- `node Makefile.js test -- tests/lib/rules/no-compare-neg-zero.js`
- `git diff --check`
