### PR TITLE
feat: suggest Object.is for negative zero comparisons

### DIFF
--- a/lib/rules/no-compare-neg-zero.js
+++ b/lib/rules/no-compare-neg-zero.js
@@ -20,9 +20,11 @@ module.exports = {
 		},
 
 		fixable: null,
+		hasSuggestions: true,
 		schema: [],
 
 		messages: {
+			suggestObjectIs: "Use `Object.is()` to compare against -0 instead.",
 			unexpected:
 				"Do not use the '{{operator}}' operator to compare against -0.",
 		},
@@ -46,6 +48,34 @@ module.exports = {
 				node.argument.value === 0
 			);
 		}
+
+		/**
+		 * Creates suggestions for strict comparisons against -0.
+		 * @param {ASTNode} node A BinaryExpression node to check.
+		 * @returns {Array<Object>|null} Suggestions for this node.
+		 */
+		function buildSuggestions(node) {
+			if (node.operator !== "===" && node.operator !== "!==") {
+				return null;
+			}
+
+			const sourceCode = context.sourceCode;
+			const leftText = sourceCode.getText(node.left);
+			const rightText = sourceCode.getText(node.right);
+			const objectIsCall = `Object.is(${leftText}, ${rightText})`;
+			const replacement =
+				node.operator === "!==" ? `!${objectIsCall}` : objectIsCall;
+
+			return [
+				{
+					messageId: "suggestObjectIs",
+					fix(fixer) {
+						return fixer.replaceText(node, replacement);
+					},
+				},
+			];
+		}
+
 		const OPERATORS_TO_CHECK = new Set([
 			">",
 			">=",
@@ -65,6 +95,7 @@ module.exports = {
 							node,
 							messageId: "unexpected",
 							data: { operator: node.operator },
+							suggest: buildSuggestions(node),
 						});
 					}
 				}

--- a/tests/lib/rules/no-compare-neg-zero.js
+++ b/tests/lib/rules/no-compare-neg-zero.js
@@ -55,6 +55,12 @@ ruleTester.run("no-compare-neg-zero", rule, {
 				{
 					messageId: "unexpected",
 					data: { operator: "===" },
+					suggestions: [
+						{
+							messageId: "suggestObjectIs",
+							output: "Object.is(x, -0)",
+						},
+					],
 				},
 			],
 		},
@@ -64,6 +70,42 @@ ruleTester.run("no-compare-neg-zero", rule, {
 				{
 					messageId: "unexpected",
 					data: { operator: "===" },
+					suggestions: [
+						{
+							messageId: "suggestObjectIs",
+							output: "Object.is(-0, x)",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "x !== -0",
+			errors: [
+				{
+					messageId: "unexpected",
+					data: { operator: "!==" },
+					suggestions: [
+						{
+							messageId: "suggestObjectIs",
+							output: "!Object.is(x, -0)",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "-0 !== x",
+			errors: [
+				{
+					messageId: "unexpected",
+					data: { operator: "!==" },
+					suggestions: [
+						{
+							messageId: "suggestObjectIs",
+							output: "!Object.is(-0, x)",
+						},
+					],
 				},
 			],
 		},
@@ -73,6 +115,7 @@ ruleTester.run("no-compare-neg-zero", rule, {
 				{
 					messageId: "unexpected",
 					data: { operator: "==" },
+					suggestions: null,
 				},
 			],
 		},
@@ -82,6 +125,7 @@ ruleTester.run("no-compare-neg-zero", rule, {
 				{
 					messageId: "unexpected",
 					data: { operator: "==" },
+					suggestions: null,
 				},
 			],
 		},
@@ -91,6 +135,7 @@ ruleTester.run("no-compare-neg-zero", rule, {
 				{
 					messageId: "unexpected",
 					data: { operator: ">" },
+					suggestions: null,
 				},
 			],
 		},


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Refs #21025.

#### What changes did you make? (Give an overview)

This PR adds suggestions to `no-compare-neg-zero` for strict comparisons against `-0`:

- `x === -0` and `-0 === x` suggest the matching `Object.is(...)` call.
- `x !== -0` and `-0 !== x` suggest negating the matching `Object.is(...)` call.
- Loose equality and relational comparisons are still reported without suggestions.

This PR was AI-assisted and manually reviewed before submission.

#### Is there anything you'd like reviewers to focus on?

Please check that the suggestion scope is intentionally limited to `===` and `!==`, because rewriting loose equality or relational comparisons would change semantics in less direct ways.

#### Testing

- `npx mocha tests/lib/rules/no-compare-neg-zero.js`
- `npx eslint lib/rules/no-compare-neg-zero.js tests/lib/rules/no-compare-neg-zero.js`
- `git diff --check HEAD~1..HEAD`
