### PR TITLE
fix: avoid false positives in `radix` rule for spread arguments

### DIFF
--- a/lib/rules/radix.js
+++ b/lib/rules/radix.js
@@ -129,6 +129,13 @@ module.exports = {
 		 */
 		function checkArguments(node) {
 			const args = node.arguments;
+			const spreadIndex = args.findIndex(
+				arg => arg.type === "SpreadElement",
+			);
+
+			if (spreadIndex !== -1 && spreadIndex < 2) {
+				return;
+			}
 
 			if (args.length === 0) {
 				context.report({

--- a/tests/lib/rules/radix.js
+++ b/tests/lib/rules/radix.js
@@ -41,6 +41,14 @@ ruleTester.run("radix", rule, {
 		'Number.parseInt("10", ~1);',
 		'Number.parseInt("10", +radix);',
 		'Number.parseInt("10", -radix);',
+		"parseInt(...args);",
+		"parseInt(...args, 1);",
+		'parseInt("10", ...args);',
+		'parseInt("10", 10, ...args);',
+		"Number.parseInt(...args);",
+		"Number.parseInt(...args, 1);",
+		'Number.parseInt("10", ...args);',
+		'Number.parseInt("10", 10, ...args);',
 		"parseInt",
 		"Number.foo();",
 		"Number[parseInt]();",
@@ -257,6 +265,14 @@ ruleTester.run("radix", rule, {
 			],
 		},
 		{
+			code: 'parseInt("10", 1, ...args);',
+			errors: [
+				{
+					messageId: "invalidRadix",
+				},
+			],
+		},
+		{
 			code: "Number.parseInt();",
 			errors: [
 				{
@@ -304,6 +320,14 @@ ruleTester.run("radix", rule, {
 		},
 		{
 			code: 'Number.parseInt("10", 10.5);',
+			errors: [
+				{
+					messageId: "invalidRadix",
+				},
+			],
+		},
+		{
+			code: 'Number.parseInt("10", 1, ...args);',
 			errors: [
 				{
 					messageId: "invalidRadix",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:** v24.16.0
- **npm version:** v11.13.0
- **Local ESLint version:** v10.6.0
- **Global ESLint version:** no
- **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->

```js
export default [{}];
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint radix: "error" */

parseInt(...args);
Number.parseInt(...args);
```

**What did you expect to happen?**

The rule should not report an error because the spread argument can supply both the string and radix arguments at runtime.

**What actually happened? Please include the actual, raw output from ESLint.**

The rule reports missing radix errors for both calls.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated `radix` to skip checking calls when a `SpreadElement` appears in argument position `0` or `1`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
