### PR TITLE
fix: parenthesize sequence expression operands in no-implicit-coercion

### DIFF
--- a/lib/rules/no-implicit-coercion.js
+++ b/lib/rules/no-implicit-coercion.js
@@ -245,6 +245,21 @@ module.exports = {
 		const sourceCode = context.sourceCode;
 
 		/**
+		 * Gets the source text of a node to be used as the argument of a
+		 * `Boolean()`, `Number()`, or `String()` call in a recommendation. A
+		 * `SequenceExpression` operand must be parenthesized, otherwise its commas
+		 * would be parsed as argument separators, which changes the evaluated
+		 * operand (for example `!!(a, b)` becomes `Boolean(a, b)`).
+		 * @param {ASTNode} node The operand node.
+		 * @returns {string} The source text, parenthesized if needed.
+		 */
+		function getOperandText(node) {
+			const text = sourceCode.getText(node);
+
+			return node.type === "SequenceExpression" ? `(${text})` : text;
+		}
+
+		/**
 		 * Reports an error and autofixes the node
 		 * @param {ASTNode} node An ast node to report the error on.
 		 * @param {string} recommendation The recommended code for the issue
@@ -309,7 +324,7 @@ module.exports = {
 					options.boolean &&
 					isDoubleLogicalNegating(node)
 				) {
-					const recommendation = `Boolean(${sourceCode.getText(node.argument.argument)})`;
+					const recommendation = `Boolean(${getOperandText(node.argument.argument)})`;
 					const variable = astUtils.getVariableByName(
 						sourceCode.getScope(node),
 						"Boolean",
@@ -344,7 +359,7 @@ module.exports = {
 					node.operator === "+" &&
 					!isNumeric(node.argument)
 				) {
-					const recommendation = `Number(${sourceCode.getText(node.argument)})`;
+					const recommendation = `Number(${getOperandText(node.argument)})`;
 
 					report(node, recommendation, true, false);
 				}
@@ -359,7 +374,7 @@ module.exports = {
 					node.argument.operator === "-" &&
 					!isNumeric(node.argument.argument)
 				) {
-					const recommendation = `Number(${sourceCode.getText(node.argument.argument)})`;
+					const recommendation = `Number(${getOperandText(node.argument.argument)})`;
 
 					report(node, recommendation, true, false);
 				}
@@ -379,7 +394,7 @@ module.exports = {
 					getNonNumericOperand(node);
 
 				if (nonNumericOperand) {
-					const recommendation = `Number(${sourceCode.getText(nonNumericOperand)})`;
+					const recommendation = `Number(${getOperandText(nonNumericOperand)})`;
 
 					report(node, recommendation, true, false);
 				}
@@ -394,7 +409,7 @@ module.exports = {
 					node.right.value === 0 &&
 					!isNumeric(node.left)
 				) {
-					const recommendation = `Number(${sourceCode.getText(node.left)})`;
+					const recommendation = `Number(${getOperandText(node.left)})`;
 
 					report(node, recommendation, true, false);
 				}
@@ -406,7 +421,7 @@ module.exports = {
 					options.string &&
 					isConcatWithEmptyString(node)
 				) {
-					const recommendation = `String(${sourceCode.getText(getNonEmptyOperand(node))})`;
+					const recommendation = `String(${getOperandText(getNonEmptyOperand(node))})`;
 
 					report(node, recommendation, true, false);
 				}
@@ -458,8 +473,7 @@ module.exports = {
 					return;
 				}
 
-				const code = sourceCode.getText(node.expressions[0]);
-				const recommendation = `String(${code})`;
+				const recommendation = `String(${getOperandText(node.expressions[0])})`;
 
 				report(node, recommendation, true, false);
 			},

--- a/tests/lib/rules/no-implicit-coercion.js
+++ b/tests/lib/rules/no-implicit-coercion.js
@@ -202,6 +202,93 @@ ruleTester.run("no-implicit-coercion", rule, {
 			],
 		},
 		{
+			code: "+(a, b)",
+			output: null,
+			errors: [
+				{
+					messageId: "implicitCoercion",
+					data: { recommendation: "Number((a, b))" },
+					suggestions: [
+						{
+							messageId: "useRecommendation",
+							data: { recommendation: "Number((a, b))" },
+							output: "Number((a, b))",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "-(-(a, b))",
+			output: null,
+			errors: [
+				{
+					messageId: "implicitCoercion",
+					data: { recommendation: "Number((a, b))" },
+					suggestions: [
+						{
+							messageId: "useRecommendation",
+							data: { recommendation: "Number((a, b))" },
+							output: "Number((a, b))",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "(a, b) * 1",
+			output: null,
+			errors: [
+				{
+					messageId: "implicitCoercion",
+					data: { recommendation: "Number((a, b))" },
+					suggestions: [
+						{
+							messageId: "useRecommendation",
+							data: { recommendation: "Number((a, b))" },
+							output: "Number((a, b))",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: '(a, b) + ""',
+			output: null,
+			errors: [
+				{
+					messageId: "implicitCoercion",
+					data: { recommendation: "String((a, b))" },
+					suggestions: [
+						{
+							messageId: "useRecommendation",
+							data: { recommendation: "String((a, b))" },
+							output: "String((a, b))",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "`${(a, b)}`",
+			output: null,
+			options: [{ disallowTemplateShorthand: true }],
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "implicitCoercion",
+					data: { recommendation: "String((a, b))" },
+					suggestions: [
+						{
+							messageId: "useRecommendation",
+							data: { recommendation: "String((a, b))" },
+							output: "String((a, b))",
+						},
+					],
+				},
+			],
+		},
+		{
 			code: "!!(foo + bar)",
 			output: "Boolean(foo + bar)",
 			errors: [

--- a/tests/lib/rules/no-implicit-coercion.js
+++ b/tests/lib/rules/no-implicit-coercion.js
@@ -175,6 +175,33 @@ ruleTester.run("no-implicit-coercion", rule, {
 			],
 		},
 		{
+			code: "!!(a, b)",
+			output: "Boolean((a, b))",
+			errors: [
+				{
+					messageId: "implicitCoercion",
+					data: { recommendation: "Boolean((a, b))" },
+				},
+			],
+		},
+		{
+			code: "(a, b) - 0",
+			output: null,
+			errors: [
+				{
+					messageId: "implicitCoercion",
+					data: { recommendation: "Number((a, b))" },
+					suggestions: [
+						{
+							messageId: "useRecommendation",
+							data: { recommendation: "Number((a, b))" },
+							output: "Number((a, b))",
+						},
+					],
+				},
+			],
+		},
+		{
 			code: "!!(foo + bar)",
 			output: "Boolean(foo + bar)",
 			errors: [


### PR DESCRIPTION
The `no-implicit-coercion` rule builds its `Boolean()`, `Number()` and `String()`
recommendations by splicing the operand's raw source text into a call. When the
operand is a `SequenceExpression` (a parenthesized comma expression),
`sourceCode.getText` returns the text without the wrapping parentheses, so the
commas are parsed as call argument separators and the recommendation evaluates a
different operand.

For `!!(a, b)`, which is autofixed, the rule rewrote it to `Boolean(a, b)`. With
`a = ''` and `b = 'x'`, the original value is `true` but the fixed value is
`false`, so the autofix silently inverts the result. The `Number` and `String`
suggestion paths are wrong the same way, for example `(a, b) - 0` recommends
`Number(a, b)`.

The fix wraps a `SequenceExpression` operand in parentheses through a small
`getOperandText` helper, used by every recommendation path. Non sequence
operands are unchanged, so nothing is over parenthesized.

This change was prepared with AI assistance and reviewed before submission.
