### PR TITLE
fix: avoid prefer-numeric-literals false positive for shadowed globals

### DIFF
--- a/lib/rules/prefer-numeric-literals.js
+++ b/lib/rules/prefer-numeric-literals.js
@@ -25,14 +25,22 @@ const radixMap = new Map([
  * Checks to see if a CallExpression's callee node is `parseInt` or
  * `Number.parseInt`.
  * @param {ASTNode} calleeNode The callee node to evaluate.
+ * @param {SourceCode} sourceCode The source code object.
  * @returns {boolean} True if the callee is `parseInt` or `Number.parseInt`,
  * false otherwise.
  */
-function isParseInt(calleeNode) {
-	return (
-		astUtils.isSpecificId(calleeNode, "parseInt") ||
-		astUtils.isSpecificMemberAccess(calleeNode, "Number", "parseInt")
-	);
+function isParseInt(calleeNode, sourceCode) {
+	if (astUtils.isSpecificId(calleeNode, "parseInt")) {
+		return sourceCode.isGlobalReference(calleeNode);
+	}
+
+	if (astUtils.isSpecificMemberAccess(calleeNode, "Number", "parseInt")) {
+		const objectNode = astUtils.skipChainExpression(calleeNode).object;
+
+		return sourceCode.isGlobalReference(objectNode);
+	}
+
+	return false;
 }
 
 //------------------------------------------------------------------------------
@@ -81,7 +89,7 @@ module.exports = {
 					radixNode.type === "Literal" &&
 					typeof radix === "number" &&
 					radixMap.has(radix) &&
-					isParseInt(node.callee)
+					isParseInt(node.callee, sourceCode)
 				) {
 					const { system, literalPrefix } = radixMap.get(radix);
 

--- a/tests/lib/rules/prefer-numeric-literals.js
+++ b/tests/lib/rules/prefer-numeric-literals.js
@@ -63,6 +63,12 @@ ruleTester.run("prefer-numeric-literals", rule, {
 			code: 'class C { #parseInt; foo() { Number.#parseInt("111110111", 2); } }',
 			languageOptions: { ecmaVersion: 2022 },
 		},
+
+		// Shadowed `parseInt` and `Number` should not be reported.
+		'function foo(parseInt) { parseInt("111110111", 2); }',
+		'function foo() { var parseInt; parseInt("111110111", 2); }',
+		'function foo(Number) { Number.parseInt("111110111", 2); }',
+		'function foo() { var Number; Number.parseInt("111110111", 2); }',
 	],
 	invalid: [
 		{


### PR DESCRIPTION
## Summary

`prefer-numeric-literals` detects calls to `parseInt()` / `Number.parseInt()` purely by identifier/property name, without checking whether `parseInt` or `Number` actually resolve to the global built-ins. If either is shadowed by a local binding, the rule still reports it, and its `--fix` autofix replaces the call with a numeric literal — silently changing the program's behavior since the call is no longer to the (unrelated) shadowed binding at all.

```js
function parse(parseInt) {
  return parseInt("11", 2); // user's own `parseInt` parameter, not the global
}
```

`--fix` turns this into:

```js
function parse(parseInt) {
  return 0b11; // the call disappeared entirely
}
```

Sibling rules `radix` and `use-isnan` were already fixed for the same class of bug (see #21044 and #20958), by checking `sourceCode.isGlobalReference(...)` in addition to the name-based check. This PR applies the same fix to `prefer-numeric-literals`.

## Test plan

- [x] Added `valid` test cases for shadowed `parseInt` (both as a parameter and a `var` declaration) and shadowed `Number` (member access form)
- [x] `npm test -- tests/lib/rules/prefer-numeric-literals.js` passes (91 tests)
- [x] Verified manually with `Linter#verify`/`verifyAndFix` that the false positive and the destructive autofix are both gone after the fix