### PR TITLE
fix: avoid `no-control-regex` false positive for shadowed RegExp

### DIFF
--- a/lib/rules/no-control-regex.js
+++ b/lib/rules/no-control-regex.js
@@ -81,6 +81,8 @@ module.exports = {
 	},
 
 	create(context) {
+		const sourceCode = context.sourceCode;
+
 		/**
 		 * Get the regex expression
 		 * @param {ASTNode} node `Literal` node to evaluate
@@ -99,6 +101,7 @@ module.exports = {
 					node.parent.type === "CallExpression") &&
 				node.parent.callee.type === "Identifier" &&
 				node.parent.callee.name === "RegExp" &&
+				sourceCode.isGlobalReference(node.parent.callee) &&
 				node.parent.arguments[0] === node
 			) {
 				const pattern = node.value;

--- a/tests/lib/rules/no-control-regex.js
+++ b/tests/lib/rules/no-control-regex.js
@@ -26,6 +26,13 @@ ruleTester.run("no-control-regex", rule, {
 		"var regex = RegExp('x1f')",
 		"new RegExp('[')",
 		"RegExp('[')",
+		String.raw`function foo(RegExp) { RegExp("\x1f"); }`,
+		String.raw`function foo(RegExp) { new RegExp("\x1f"); }`,
+		String.raw`let RegExp; RegExp("\x1f");`,
+		{
+			code: String.raw`RegExp("\x1f")`,
+			languageOptions: { globals: { RegExp: "off" } },
+		},
 		"new (function foo(){})('\\x1f')",
 		{ code: String.raw`/\u{20}/u`, languageOptions: { ecmaVersion: 2015 } },
 		String.raw`/\u{1F}/`,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:** v24.16.0
- **npm version:** v11.13.0
- **Local ESLint version:** v10.6.0
- **Global ESLint version:** no
- **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->

```js
export default [{}];
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint no-control-regex: "error" */

function foo(RegExp) {
    RegExp("\\x1f");
}
```

**What did you expect to happen?**

No error should be reported because `RegExp` is shadowed.

**What actually happened? Please include the actual, raw output from ESLint.**

```
Unexpected control character(s) in regular expression: \x1f.
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated `no-control-regex` to verify that `RegExp` is a global reference before validating string arguments as regular expression patterns.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
