### PR TITLE
chore: update prettier to v3.9.0

### DIFF
--- a/docs/src/assets/js/css-vars-ponyfill@2.js
+++ b/docs/src/assets/js/css-vars-ponyfill@2.js
@@ -341,7 +341,7 @@
 			u = r.indexOf(t, i + 1),
 			l = i;
 		if (i >= 0 && u > 0) {
-			for (n = [], s = r.length; l >= 0 && !c; )
+			for (n = [], s = r.length; l >= 0 && !c;)
 				(l == i
 					? (n.push(l), (i = r.indexOf(e, l + 1)))
 					: 1 == n.length
@@ -377,7 +377,7 @@
 		}
 		function u() {
 			if ((i(), "/" === t[0] && "*" === t[1])) {
-				for (var e = 2; t[e] && ("*" !== t[e] || "/" !== t[e + 1]); )
+				for (var e = 2; t[e] && ("*" !== t[e] || "/" !== t[e + 1]);)
 					e++;
 				if (!t[e]) return n("end of comment is missing");
 				var r = t.slice(2, e);
@@ -385,11 +385,11 @@
 			}
 		}
 		function l() {
-			for (var e, t = []; (e = u()); ) t.push(e);
+			for (var e, t = []; (e = u());) t.push(e);
 			return r.removeComments ? [] : t;
 		}
 		function f() {
-			for (i(); "}" === t[0]; ) n("extra closing bracket");
+			for (i(); "}" === t[0];) n("extra closing bracket");
 			var e = o(/^(("(?:\\"|[^"])*"|'(?:\\'|[^'])*'|[^{])+)/);
 			if (e)
 				return e[0]
@@ -426,15 +426,12 @@
 		}
 		function p() {
 			if (!a()) return n("missing '{'");
-			for (var e, t = l(); (e = d()); ) (t.push(e), (t = t.concat(l())));
+			for (var e, t = l(); (e = d());) (t.push(e), (t = t.concat(l())));
 			return c() ? t : n("missing '}'");
 		}
 		function m() {
 			i();
-			for (
-				var e, t = [];
-				(e = o(/^((\d+\.\d+|\.\d+|\d+)%?|[a-z]+)\s*/));
-			)
+			for (var e, t = []; (e = o(/^((\d+\.\d+|\.\d+|\d+)%?|[a-z]+)\s*/));)
 				(t.push(e[1]), o(/^,\s*/));
 			if (t.length)
 				return { type: "keyframe", values: t, declarations: p() };
@@ -451,7 +448,7 @@
 							var r,
 								s = e[1];
 							if (!a()) return n("@keyframes missing '{'");
-							for (var i = l(); (r = m()); )
+							for (var i = l(); (r = m());)
 								(i.push(r), (i = i.concat(l())));
 							return c()
 								? {

--- a/docs/src/assets/js/inert-polyfill.js
+++ b/docs/src/assets/js/inert-polyfill.js
@@ -5,21 +5,21 @@ window.addEventListener("load", function () {
 	function h(a, b, c) {
 		if (0 > b) {
 			if (a.previousElementSibling) {
-				for (a = a.previousElementSibling; a.lastElementChild; )
+				for (a = a.previousElementSibling; a.lastElementChild;)
 					a = a.lastElementChild;
 				return a;
 			}
 			return a.parentElement;
 		}
 		if (a != c && a.firstElementChild) return a.firstElementChild;
-		for (; null != a; ) {
+		for (; null != a;) {
 			if (a.nextElementSibling) return a.nextElementSibling;
 			a = a.parentElement;
 		}
 		return null;
 	}
 	function g(a) {
-		for (; a && a !== document.documentElement; ) {
+		for (; a && a !== document.documentElement;) {
 			if (a.hasAttribute("inert")) return a;
 			a = a.parentElement;
 		}
@@ -62,7 +62,7 @@ window.addEventListener("load", function () {
 					Object.defineProperty(e, "keyCode", { value: 9 });
 					document.activeElement.dispatchEvent(e);
 					if (d != document.activeElement) return;
-					for (d = f; ; ) {
+					for (d = f; ;) {
 						d = h(d, c, f);
 						if (!d) break;
 						a: {

--- a/docs/src/extend/custom-rules.md
+++ b/docs/src/extend/custom-rules.md
@@ -866,9 +866,7 @@ export default {
 	create(context) {
 		const [{ alias }] = context.options;
 
-		return {
-			/* ... */
-		};
+		return {/* ... */};
 	},
 };
 ```

--- a/docs/src/use/configure/ignore.md
+++ b/docs/src/use/configure/ignore.md
@@ -56,9 +56,7 @@ export default defineConfig([
 	{
 		files: ["**/*.ts"],
 		ignores: [".config/**"],
-		rules: {
-			/* ... */
-		},
+		rules: {/* ... */},
 	},
 ]);
 ```

--- a/lib/rules/func-name-matching.js
+++ b/lib/rules/func-name-matching.js
@@ -250,9 +250,9 @@ module.exports = {
 			},
 
 			"Property, PropertyDefinition[value]"(node) {
-				if (
-					!(node.value.type === "FunctionExpression" && node.value.id)
-				) {
+				if (!(
+					node.value.type === "FunctionExpression" && node.value.id
+				)) {
 					return;
 				}
 

--- a/lib/rules/generator-star-spacing.js
+++ b/lib/rules/generator-star-spacing.js
@@ -226,12 +226,10 @@ module.exports = {
 			}
 
 			// Only check before when preceded by `function`|`static` keyword
-			if (
-				!(
-					kind === "method" &&
-					starToken === sourceCode.getFirstToken(node.parent)
-				)
-			) {
+			if (!(
+				kind === "method" &&
+				starToken === sourceCode.getFirstToken(node.parent)
+			)) {
 				checkSpacing(kind, "before", prevToken, starToken);
 			}
 

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1872,12 +1872,10 @@ module.exports = {
 			},
 
 			SwitchCase(node) {
-				if (
-					!(
-						node.consequent.length === 1 &&
-						node.consequent[0].type === "BlockStatement"
-					)
-				) {
+				if (!(
+					node.consequent.length === 1 &&
+					node.consequent[0].type === "BlockStatement"
+				)) {
 					const caseKeyword = sourceCode.getFirstToken(node);
 					const tokenAfterCurrentCase =
 						sourceCode.getTokenAfter(node);

--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -380,12 +380,10 @@ module.exports = {
 		 */
 		function isKeyValueProperty(property) {
 			return !(
-				(
-					property.method ||
-					property.shorthand ||
-					property.kind !== "init" ||
-					property.type !== "Property"
-				) // Could be "ExperimentalSpreadProperty" or "SpreadElement"
+				property.method ||
+				property.shorthand ||
+				property.kind !== "init" ||
+				property.type !== "Property" // Could be "ExperimentalSpreadProperty" or "SpreadElement"
 			);
 		}
 

--- a/lib/rules/no-mixed-spaces-and-tabs.js
+++ b/lib/rules/no-mixed-spaces-and-tabs.js
@@ -125,14 +125,12 @@ module.exports = {
 									sourceCode.getIndexFromLoc(loc.start),
 								);
 
-							if (
-								!(
-									containingNode &&
-									["Literal", "TemplateElement"].includes(
-										containingNode.type,
-									)
+							if (!(
+								containingNode &&
+								["Literal", "TemplateElement"].includes(
+									containingNode.type,
 								)
-							) {
+							)) {
 								context.report({
 									node,
 									loc,

--- a/lib/rules/no-promise-executor-return.js
+++ b/lib/rules/no-promise-executor-return.js
@@ -200,13 +200,11 @@ module.exports = {
 					}
 
 					// Do not suggest wrapping an unnamed function or class expression in braces as that would be invalid syntax.
-					if (
-						!(
-							(node.body.type === "FunctionExpression" ||
-								node.body.type === "ClassExpression") &&
-							!node.body.id
-						)
-					) {
+					if (!(
+						(node.body.type === "FunctionExpression" ||
+							node.body.type === "ClassExpression") &&
+						!node.body.id
+					)) {
 						suggest.push({
 							messageId: "wrapBraces",
 							fix(fixer) {

--- a/lib/rules/no-script-url.js
+++ b/lib/rules/no-script-url.js
@@ -54,12 +54,10 @@ module.exports = {
 				}
 			},
 			TemplateLiteral(node) {
-				if (
-					!(
-						node.parent &&
-						node.parent.type === "TaggedTemplateExpression"
-					)
-				) {
+				if (!(
+					node.parent &&
+					node.parent.type === "TaggedTemplateExpression"
+				)) {
 					check(node);
 				}
 			},

--- a/lib/rules/no-shadow.js
+++ b/lib/rules/no-shadow.js
@@ -275,12 +275,10 @@ module.exports = {
 
 			const { variableScope } = variable.scope;
 
-			if (
-				!(
-					FUNC_EXPR_NODE_TYPES.has(variableScope.block.type) &&
-					getOuterScope(variableScope) === shadowedVariable.scope
-				)
-			) {
+			if (!(
+				FUNC_EXPR_NODE_TYPES.has(variableScope.block.type) &&
+				getOuterScope(variableScope) === shadowedVariable.scope
+			)) {
 				return false;
 			}
 
@@ -405,14 +403,12 @@ module.exports = {
 				return false;
 			}
 
-			if (
-				!(
-					(innerDef.type === "FunctionName" &&
-						innerDef.node.type === "FunctionExpression") ||
-					(innerDef.type === "ClassName" &&
-						innerDef.node.type === "ClassExpression")
-				)
-			) {
+			if (!(
+				(innerDef.type === "FunctionName" &&
+					innerDef.node.type === "FunctionExpression") ||
+				(innerDef.type === "ClassName" &&
+					innerDef.node.type === "ClassExpression")
+			)) {
 				return false;
 			}
 
@@ -432,12 +428,10 @@ module.exports = {
 			const nodeToCheck = innerDef.node; // FunctionExpression or ClassExpression node
 
 			// Exit early if the node to check isn't inside the initializer
-			if (
-				!(
-					initializerNode.range[0] <= nodeToCheck.range[0] &&
-					nodeToCheck.range[1] <= initializerNode.range[1]
-				)
-			) {
+			if (!(
+				initializerNode.range[0] <= nodeToCheck.range[0] &&
+				nodeToCheck.range[1] <= initializerNode.range[1]
+			)) {
 				return false;
 			}
 

--- a/lib/rules/prefer-object-has-own.js
+++ b/lib/rules/prefer-object-has-own.js
@@ -75,12 +75,10 @@ module.exports = {
 
 		return {
 			CallExpression(node) {
-				if (
-					!(
-						node.callee.type === "MemberExpression" &&
-						node.callee.object.type === "MemberExpression"
-					)
-				) {
+				if (!(
+					node.callee.type === "MemberExpression" &&
+					node.callee.object.type === "MemberExpression"
+				)) {
 					return;
 				}
 

--- a/lib/rules/preserve-caught-error.js
+++ b/lib/rules/preserve-caught-error.js
@@ -452,12 +452,10 @@ module.exports = {
 					const { value: thrownErrorCause } = errorCauseInfo;
 
 					// If there is an attached cause, verify that it matches the caught error
-					if (
-						!(
-							thrownErrorCause.type === "Identifier" &&
-							thrownErrorCause.name === caughtError.name
-						)
-					) {
+					if (!(
+						thrownErrorCause.type === "Identifier" &&
+						thrownErrorCause.name === caughtError.name
+					)) {
 						const suggest = errorCauseInfo.multipleDefinitions
 							? null // If there are multiple `cause` definitions, a suggestion could be confusing.
 							: [

--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -1344,7 +1344,7 @@ let needsPrecedingSemicolon;
 	 * @returns {boolean} Whether the node is inside a TypeScript type context.
 	 */
 	function isInType(node) {
-		for (let currNode = node; ; ) {
+		for (let currNode = node; ;) {
 			const { parent } = currNode;
 			if (!parent) {
 				break;

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -663,8 +663,7 @@ export namespace Rule {
 	interface NodeListener extends CustomRuleVisitorWithExit<
 		{
 			[Node in Rule.Node as Node["type"]]?:
-				| ((node: Node) => void)
-				| undefined;
+				((node: Node) => void) | undefined;
 		} & {
 			// A `Program` visitor's node type has no `parent` property.
 			Program?: ((node: AST.Program) => void) | undefined;
@@ -987,11 +986,9 @@ export namespace Linter {
 		filename?: string | undefined;
 		preprocess?: ((code: string) => string[]) | undefined;
 		postprocess?:
-			| ((problemLists: LintMessage[][]) => LintMessage[])
-			| undefined;
+			((problemLists: LintMessage[][]) => LintMessage[]) | undefined;
 		filterCodeBlock?:
-			| ((filename: string, text: string) => boolean)
-			| undefined;
+			((filename: string, text: string) => boolean) | undefined;
 		disableFixes?: boolean | undefined;
 		allowInlineConfig?: boolean | undefined;
 		reportUnusedDisableDirectives?: boolean | undefined;

--- a/lib/types/rules.d.ts
+++ b/lib/types/rules.d.ts
@@ -56,8 +56,7 @@ interface NoRestrictedImportPatternCommonOptions {
 
 // Base type for group or regex constraint, ensuring mutual exclusivity
 type EitherGroupOrRegEx =
-	| { group: string[]; regex?: never }
-	| { regex: string; group?: never };
+	{ group: string[]; regex?: never } | { regex: string; group?: never };
 
 // Base type for import name specifiers, ensuring mutual exclusivity
 type EitherNameSpecifiers =
@@ -2633,10 +2632,7 @@ export interface ESLintRules extends Linter.RulesRecord {
 						 * @default 'none'
 						 */
 						ignoreJSX:
-							| "none"
-							| "all"
-							| "multi-line"
-							| "single-line";
+							"none" | "all" | "multi-line" | "single-line";
 						/**
 						 * @default true
 						 */
@@ -5150,9 +5146,7 @@ export interface ESLintRules extends Linter.RulesRecord {
 						 * @default 'any'
 						 */
 						beforeStatementContinuationChars:
-							| "any"
-							| "always"
-							| "never";
+							"any" | "always" | "never";
 					}>,
 				]
 		  >;

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "mocha": "^11.7.1",
     "node-polyfill-webpack-plugin": "^1.0.3",
     "npm-license": "^0.3.3",
-    "prettier": "3.8.5",
+    "prettier": "3.9.0",
     "progress": "^2.0.3",
     "proxyquire": "^2.0.1",
     "regenerator-runtime": "^0.14.0",

--- a/tests/bench/large.js
+++ b/tests/bench/large.js
@@ -6948,7 +6948,7 @@ if (typeof window === "undefined") window = {};
 							if (this._events.removeListener)
 								this.emit("removeListener", type, listener);
 						} else if (isObject(list)) {
-							for (i = length; i-- > 0; ) {
+							for (i = length; i-- > 0;) {
 								if (
 									list[i] === listener ||
 									(list[i].listener &&
@@ -12187,14 +12187,12 @@ if (typeof window === "undefined") window = {};
 								delete funct["(nolet)"];
 							}
 							// Don't clear and let it propagate out if it is "break", "return", or "throw" in switch case
-							if (
-								!(
-									iscase &&
-									["break", "return", "throw"].indexOf(
-										funct["(verb)"],
-									) != -1
-								)
-							) {
+							if (!(
+								iscase &&
+								["break", "return", "throw"].indexOf(
+									funct["(verb)"],
+								) != -1
+							)) {
 								funct["(verb)"] = null;
 							}
 

--- a/tests/lib/types/types.test.mts
+++ b/tests/lib/types/types.test.mts
@@ -945,10 +945,7 @@ rule2 = {
 	meta: {},
 };
 type DeprecatedRuleContextKeys =
-	| "getAncestors"
-	| "getDeclaredVariables"
-	| "getScope"
-	| "markVariableAsUsed";
+	"getAncestors" | "getDeclaredVariables" | "getScope" | "markVariableAsUsed";
 (): RuleDefinition => ({
 	create(context) {
 		// Ensure that deprecated RuleContext methods are not defined when using RuleDefinition


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

- Bumped `prettier` from `3.8.5` to `3.9.0`. 
- Fixed formatting to align with the update.

Closes #21053

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
