### PR TITLE
fix: prevent `eqeqeq` null option from reporting non-equality operators

### DIFF
--- a/lib/rules/eqeqeq.js
+++ b/lib/rules/eqeqeq.js
@@ -186,7 +186,11 @@ module.exports = {
 				const isNull = isNullCheck(node);
 
 				if (node.operator !== "==" && node.operator !== "!=") {
-					if (enforceInverseRuleForNull && isNull) {
+					if (
+						enforceInverseRuleForNull &&
+						isNull &&
+						(node.operator === "===" || node.operator === "!==")
+					) {
 						report(node, node.operator.slice(0, -1));
 					}
 					return;

--- a/tests/lib/rules/eqeqeq.js
+++ b/tests/lib/rules/eqeqeq.js
@@ -48,6 +48,10 @@ ruleTester.run("eqeqeq", rule, {
 		{ code: "a != null", options: ["always", { null: "never" }] },
 		{ code: "null == null", options: ["always", { null: "never" }] },
 		{ code: "null != null", options: ["always", { null: "never" }] },
+		{ code: "a >= null", options: ["always", { null: "never" }] },
+		{ code: "a + null", options: ["always", { null: "never" }] },
+		{ code: "null + null", options: ["always", { null: "never" }] },
+		{ code: "null instanceof Foo", options: ["always", { null: "never" }] },
 
 		// https://github.com/eslint/eslint/issues/8020
 		{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:** v24.16.0
- **npm version:** v11.13.0
- **Local ESLint version:** v10.6.0
- **Global ESLint version:** no
- **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->

```js
export default [{}];
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint eqeqeq: ["error", "always", { null: "never" }] */

a + null;
null instanceof Foo;
```

**What did you expect to happen?**

The rule should only enforce `==`/`!=` instead of `===`/`!==` for comparisons with `null`. Other binary operators should not be reported or fixed.

**What actually happened? Please include the actual, raw output from ESLint.**

The rule reported non-equality operators and derived invalid expected operators by slicing the final character.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated `eqeqeq` so the `{ null: "never" }` inverse check only reports `===` and `!==` with `null`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
