### PR TITLE
fix: handle static template literals in `eqeqeq` rule

### DIFF
--- a/lib/rules/eqeqeq.js
+++ b/lib/rules/eqeqeq.js
@@ -103,17 +103,33 @@ module.exports = {
 		}
 
 		/**
+		 * Gets the type of a literal node.
+		 * @param {ASTNode} node The node to check
+		 * @returns {string|null} The type of the literal
+		 * @private
+		 */
+		function getLiteralType(node) {
+			if (node.type === "Literal") {
+				return typeof node.value;
+			}
+
+			if (astUtils.isStaticTemplateLiteral(node)) {
+				return "string";
+			}
+
+			return null;
+		}
+
+		/**
 		 * Checks if operands are literals of the same type (via typeof)
 		 * @param {ASTNode} node The node to check
 		 * @returns {boolean} if operands are of same type
 		 * @private
 		 */
 		function areLiteralsAndSameType(node) {
-			return (
-				node.left.type === "Literal" &&
-				node.right.type === "Literal" &&
-				typeof node.left.value === typeof node.right.value
-			);
+			const leftType = getLiteralType(node.left);
+
+			return leftType !== null && leftType === getLiteralType(node.right);
 		}
 
 		/**

--- a/tests/lib/rules/eqeqeq.js
+++ b/tests/lib/rules/eqeqeq.js
@@ -31,6 +31,8 @@ ruleTester.run("eqeqeq", rule, {
 		{ code: "typeof a == 'number'", options: ["smart"] },
 		{ code: "'string' != typeof a", options: ["smart"] },
 		{ code: "'hello' != 'world'", options: ["smart"] },
+		{ code: "`hello` != `world`", options: ["smart"] },
+		{ code: "`hello` == 'hello'", options: ["smart"] },
 		{ code: "2 == 3", options: ["smart"] },
 		{ code: "true == true", options: ["smart"] },
 		{ code: "null == a", options: ["smart"] },
@@ -184,6 +186,26 @@ ruleTester.run("eqeqeq", rule, {
 			],
 		},
 		{
+			code: "`hello` == `world`",
+			output: "`hello` === `world`",
+			errors: [
+				{
+					messageId: "unexpected",
+					data: wantedEqEqEq,
+				},
+			],
+		},
+		{
+			code: "`hello` != 'world'",
+			output: "`hello` !== 'world'",
+			errors: [
+				{
+					messageId: "unexpected",
+					data: wantedNotEqEq,
+				},
+			],
+		},
+		{
 			code: "a == null",
 			errors: [
 				{
@@ -278,6 +300,23 @@ ruleTester.run("eqeqeq", rule, {
 							messageId: "replaceOperator",
 							data: wantedEqEqEq,
 							output: "'wee' === /wee/",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "`hello${world}` == `hello`",
+			options: ["smart"],
+			errors: [
+				{
+					messageId: "unexpected",
+					data: wantedEqEqEq,
+					suggestions: [
+						{
+							messageId: "replaceOperator",
+							data: wantedEqEqEq,
+							output: "`hello${world}` === `hello`",
 						},
 					],
 				},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:** v24.16.0
- **npm version:** v11.13.0
- **Local ESLint version:** v10.6.0
- **Global ESLint version:** no
- **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->

```js
export default [{}];
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint eqeqeq: ["error", "smart"] */

`hello` != `world`
`hello` == "hello"
```

[Playground](https://eslint.org/play/#eyJ0ZXh0IjoiLyogZXNsaW50IGVxZXFlcTogW1wiZXJyb3JcIiwgXCJzbWFydFwiXSAqL1xuXG5gaGVsbG9gICE9IGB3b3JsZGBcbmBoZWxsb2AgPT0gXCJoZWxsb1wiIiwib3B0aW9ucyI6eyJydWxlcyI6e30sImxhbmd1YWdlT3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFGZWF0dXJlcyI6e319fX19)

**What did you expect to happen?**

The `smart` option should treat static template literals as literal string values, so these comparisons should be allowed like other same-type literal comparisons.

**What actually happened? Please include the actual, raw output from ESLint.**

The rule reported these comparisons:
```
Expected '!==' and instead saw '!='.
Expected '===' and instead saw '=='.
```

#### What changes did you make? (Give an overview)

Updated `eqeqeq` so static template literals are treated as string literals in the same-type literal check.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
