### PR TITLE
fix: insert cause outside wrapping parens in preserve-caught-error

### DIFF
--- a/lib/rules/preserve-caught-error.js
+++ b/lib/rules/preserve-caught-error.js
@@ -256,6 +256,30 @@ module.exports = {
 			);
 		}
 
+		/**
+		 * Gets the token after which new arguments should be inserted for the
+		 * given argument, accounting for parentheses wrapping the argument so
+		 * that insertions land outside them (e.g. `new Error(("msg"))`).
+		 * @param {ASTNode} argNode The argument node.
+		 * @param {ASTNode} callNode The enclosing call or new expression.
+		 * @returns {Token} The token to insert after.
+		 */
+		function getLastArgumentToken(argNode, callNode) {
+			const callLastToken = sourceCode.getLastToken(callNode);
+			let token = sourceCode.getLastToken(argNode);
+			let nextToken = sourceCode.getTokenAfter(token);
+
+			while (
+				nextToken &&
+				nextToken !== callLastToken &&
+				astUtils.isClosingParenToken(nextToken)
+			) {
+				token = nextToken;
+				nextToken = sourceCode.getTokenAfter(token);
+			}
+			return token;
+		}
+
 		//----------------------------------------------------------------------
 		// Public
 		//----------------------------------------------------------------------
@@ -360,7 +384,10 @@ module.exports = {
 											if (!messageArg) {
 												// Case: `throw new AggregateError([])` → insert message and options
 												return fixer.insertTextAfter(
-													errorsArg,
+													getLastArgumentToken(
+														errorsArg,
+														throwExpression,
+													),
 													`, "", { cause: ${caughtError.name} }`,
 												);
 											}
@@ -368,7 +395,10 @@ module.exports = {
 											if (!optionsArg) {
 												// Case: `throw new AggregateError([], "")` → insert error options only
 												return fixer.insertTextAfter(
-													messageArg,
+													getLastArgumentToken(
+														messageArg,
+														throwExpression,
+													),
 													`, { cause: ${caughtError.name} }`,
 												);
 											}
@@ -423,7 +453,10 @@ module.exports = {
 										if (!optionsArg) {
 											// Case: `throw new Error("Some message")` → insert only options
 											return fixer.insertTextAfter(
-												messageArg,
+												getLastArgumentToken(
+													messageArg,
+													throwExpression,
+												),
 												`, { cause: ${caughtError.name} }`,
 											);
 										}

--- a/tests/lib/rules/preserve-caught-error.js
+++ b/tests/lib/rules/preserve-caught-error.js
@@ -862,6 +862,20 @@ ruleTester.run("preserve-caught-error", rule, {
 			],
 		},
 		{
+			code: `try { doSomething(); } catch (err) { throw new Error(("Something failed"),); }`,
+			errors: [
+				{
+					messageId: "missingCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `try { doSomething(); } catch (err) { throw new Error(("Something failed"), { cause: err },); }`,
+						},
+					],
+				},
+			],
+		},
+		{
 			code: `try { doSomething(); } catch (err) { throw new AggregateError((errors)); }`,
 			errors: [
 				{

--- a/tests/lib/rules/preserve-caught-error.js
+++ b/tests/lib/rules/preserve-caught-error.js
@@ -129,6 +129,49 @@ ruleTester.run("preserve-caught-error", rule, {
 		}`,
 	],
 	invalid: [
+		/* Parenthesized arguments: insertions must land outside the wrapping parentheses (see gh suggestion corruption) */
+		{
+			code: `try { doSomething(); } catch (err) { throw new Error(("Something failed")); }`,
+			errors: [
+				{
+					messageId: "missingCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `try { doSomething(); } catch (err) { throw new Error(("Something failed"), { cause: err }); }`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `try { doSomething(); } catch (err) { throw new AggregateError((errors)); }`,
+			errors: [
+				{
+					messageId: "missingCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `try { doSomething(); } catch (err) { throw new AggregateError((errors), "", { cause: err }); }`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `try { doSomething(); } catch (err) { throw new AggregateError(errors, ("message")); }`,
+			errors: [
+				{
+					messageId: "missingCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `try { doSomething(); } catch (err) { throw new AggregateError(errors, ("message"), { cause: err }); }`,
+						},
+					],
+				},
+			],
+		},
 		/* 1. Throws a new Error without cause, even though an error was caught */
 		{
 			code: `try {

--- a/tests/lib/rules/preserve-caught-error.js
+++ b/tests/lib/rules/preserve-caught-error.js
@@ -129,49 +129,6 @@ ruleTester.run("preserve-caught-error", rule, {
 		}`,
 	],
 	invalid: [
-		/* Parenthesized arguments: insertions must land outside the wrapping parentheses (see gh suggestion corruption) */
-		{
-			code: `try { doSomething(); } catch (err) { throw new Error(("Something failed")); }`,
-			errors: [
-				{
-					messageId: "missingCause",
-					suggestions: [
-						{
-							messageId: "includeCause",
-							output: `try { doSomething(); } catch (err) { throw new Error(("Something failed"), { cause: err }); }`,
-						},
-					],
-				},
-			],
-		},
-		{
-			code: `try { doSomething(); } catch (err) { throw new AggregateError((errors)); }`,
-			errors: [
-				{
-					messageId: "missingCause",
-					suggestions: [
-						{
-							messageId: "includeCause",
-							output: `try { doSomething(); } catch (err) { throw new AggregateError((errors), "", { cause: err }); }`,
-						},
-					],
-				},
-			],
-		},
-		{
-			code: `try { doSomething(); } catch (err) { throw new AggregateError(errors, ("message")); }`,
-			errors: [
-				{
-					messageId: "missingCause",
-					suggestions: [
-						{
-							messageId: "includeCause",
-							output: `try { doSomething(); } catch (err) { throw new AggregateError(errors, ("message"), { cause: err }); }`,
-						},
-					],
-				},
-			],
-		},
 		/* 1. Throws a new Error without cause, even though an error was caught */
 		{
 			code: `try {
@@ -888,6 +845,49 @@ ruleTester.run("preserve-caught-error", rule, {
 				});
 			}`,
 			errors: [{ messageId: "incorrectCause" }],
+		},
+		/* Parenthesized arguments: insertions must land outside the wrapping parentheses */
+		{
+			code: `try { doSomething(); } catch (err) { throw new Error(("Something failed")); }`,
+			errors: [
+				{
+					messageId: "missingCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `try { doSomething(); } catch (err) { throw new Error(("Something failed"), { cause: err }); }`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `try { doSomething(); } catch (err) { throw new AggregateError((errors)); }`,
+			errors: [
+				{
+					messageId: "missingCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `try { doSomething(); } catch (err) { throw new AggregateError((errors), "", { cause: err }); }`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `try { doSomething(); } catch (err) { throw new AggregateError(errors, ("message")); }`,
+			errors: [
+				{
+					messageId: "missingCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `try { doSomething(); } catch (err) { throw new AggregateError(errors, ("message"), { cause: err }); }`,
+						},
+					],
+				},
+			],
 		},
 	],
 });


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

#### What changes did you make? (Give an overview)

The `preserve-caught-error` suggestions insert `, { cause: err }` with `fixer.insertTextAfter(argumentNode, ...)`. AST node ranges exclude wrapping parentheses, so for a parenthesized argument the text lands inside the parens and produces a sequence expression:

```js
try { foo(); } catch (err) { throw new Error(("wrap")); }
// suggestion output before this fix:
throw new Error(("wrap", { cause: err }));
```

That makes the options object the error *message* (`"[object Object]"`) and attaches no cause at all — re-linting the suggestion output reports the same problem again. The `new AggregateError((errs))` variant is worse: the suggested code throws a runtime TypeError because the sequence expression's value isn't iterable.

This adds a small `getLastArgumentToken` helper that walks past the argument's wrapping close-paren tokens (stopping before the call's own closing paren) and uses it in the three argument-appending suggestion paths. Suggestion output is now:

```js
throw new Error(("wrap"), { cause: err });
throw new AggregateError((errs), "", { cause: err });
```

Same bug class as #21045 (`no-implicit-coercion`, merged a few days ago).

#### Is there anything you'd like reviewers to focus on?

Three new `RuleTester` cases assert the exact suggestion output for parenthesized message, parenthesized errors array, and parenthesized message on `AggregateError`; they fail on the current code and pass with this change. All 52 rule tests pass.
