### PR TITLE
fix: handle unavailable require cache (backport of #20812 to v9.x)

### DIFF
--- a/lib/config/config-loader.js
+++ b/lib/config/config-loader.js
@@ -231,7 +231,7 @@ async function loadConfigFile(filePath, hasUnstableNativeNodeJsTSConfigFlag) {
 	 * the require cache only if the file has been changed.
 	 */
 	if (importedConfigFileModificationTime.get(filePath) !== mtime) {
-		delete require.cache[filePath];
+		delete require.cache?.[filePath];
 	}
 
 	const isTS = isFileTS(filePath);

--- a/tests/lib/config/config-loader.js
+++ b/tests/lib/config/config-loader.js
@@ -10,7 +10,11 @@
 //------------------------------------------------------------------------------
 
 const assert = require("node:assert");
+const fs = require("node:fs");
+const Module = require("node:module");
+const os = require("node:os");
 const path = require("node:path");
+const vm = require("node:vm");
 const sinon = require("sinon");
 const {
 	ConfigLoader,
@@ -75,6 +79,75 @@ describe("Config loaders", () => {
 			});
 
 			describe("loadConfigArrayForFile()", () => {
+				const useMainContextDefaultLoader =
+					// eslint-disable-next-line n/no-unsupported-features/node-builtins -- unavailable before Node.js 20.12/21.7.
+					vm.constants?.USE_MAIN_CONTEXT_DEFAULT_LOADER;
+
+				(useMainContextDefaultLoader ? it : it.skip)(
+					"should not error when require.cache is unavailable",
+					async () => {
+						const cwd = path.resolve(
+							fixtureDir,
+							"simple-valid-project-2",
+						);
+						const configLoaderPath = path.resolve(
+							__dirname,
+							"../../../lib/config/config-loader.js",
+						);
+						const configLoaderSource = fs.readFileSync(
+							configLoaderPath,
+							"utf8",
+						);
+						const moduleExports = { exports: {} };
+						const requireWithoutCache =
+							Module.createRequire(configLoaderPath);
+
+						requireWithoutCache.cache = void 0;
+
+						const compiledWrapper = vm.runInThisContext(
+							Module.wrap(configLoaderSource),
+							{
+								filename: path.join(
+									os.tmpdir(),
+									"eslint-config-loader-without-require-cache.js",
+								),
+								importModuleDynamically:
+									useMainContextDefaultLoader,
+							},
+						);
+
+						compiledWrapper.call(
+							moduleExports.exports,
+							moduleExports.exports,
+							requireWithoutCache,
+							moduleExports,
+							configLoaderPath,
+							path.dirname(configLoaderPath),
+						);
+
+						const {
+							[ConfigLoaderClass.name]:
+								ConfigLoaderClassWithoutRequireCache,
+						} = moduleExports.exports;
+
+						const configArray =
+							await ConfigLoaderClassWithoutRequireCache.calculateConfigArray(
+								path.resolve(cwd, "eslint.config.js"),
+								cwd,
+								{
+									cwd,
+									ignoreEnabled: true,
+									warningService: new WarningService(),
+								},
+							);
+
+						assert(
+							Array.isArray(configArray),
+							"Expected `calculateConfigArray()` to return a config array",
+						);
+					},
+				);
+
 				// https://github.com/eslint/eslint/issues/19025
 				it("should lookup config file only once and create config array only once for multiple files in same directory", async () => {
 					const cwd = path.resolve(


### PR DESCRIPTION
## Summary

Backports the fix from #20812 (fixing #20813) to the `v9.x-dev` branch, guarding `require.cache` access while reloading config files so ESLint 9.x does not crash when the CommonJS `require` object has no `cache` (e.g. Yarn Berry PnP with the ESM loader enabled on recent Node.js versions).

This is a clean cherry-pick of the upstream fix commit `b6ae5cf07b9b51802367539cb24b245b61eaa37c`. The regression test was adapted to the `v9.x-dev` test structure, which still parameterizes over both `ConfigLoader` and `LegacyConfigLoader` (removed on `main`/v10), so the new test now runs for both classes since they share the same `loadConfigFile()` helper.

## Why backport this

v9.x is currently in *Maintenance* status until 2026-08-06 (see https://eslint.org/version-support/), which explicitly covers compatibility fixes for interoperability between major release lines. This crash is exactly that: a Yarn Berry PnP + Node.js compatibility issue affecting projects that cannot yet upgrade to ESLint 10.x. Discussed and requested in #21060, where @lumirlumir and @fasttime indicated support for a backport against `v9.x-dev` pending final TSC confirmation.

Closes #21060
