### PR TITLE
chore: restrict `markdownlint-cli2` updates in renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,9 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["github>eslint/workflows//.github/renovate/base.json5"],
-  ignoreDeps: ["markdownlint-cli2"],
+  ignoreDeps: [
+    "markdownlint-cli2", // markdownlint-cli2 currently requires Node.js 22 or later, so it cannot be updated yet.
+  ],
   packageRules: [
     {
       description: "Group Babel packages into a single PR.",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,7 +2,7 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["github>eslint/workflows//.github/renovate/base.json5"],
   ignoreDeps: [
-    // markdownlint-cli2 currently requires Node.js 22 or later, so it cannot be updated yet.
+    // markdownlint-cli2 v0.23.0 and later require Node.js 22 or later, so updates are blocked for now.
     "markdownlint-cli2",
   ],
   packageRules: [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,7 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["github>eslint/workflows//.github/renovate/base.json5"],
+  ignoreDeps: ["markdownlint-cli2"],
   packageRules: [
     {
       description: "Group Babel packages into a single PR.",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,7 +2,8 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["github>eslint/workflows//.github/renovate/base.json5"],
   ignoreDeps: [
-    "markdownlint-cli2", // markdownlint-cli2 currently requires Node.js 22 or later, so it cannot be updated yet.
+    // markdownlint-cli2 currently requires Node.js 22 or later, so it cannot be updated yet.
+    "markdownlint-cli2",
   ],
   packageRules: [
     {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR comes from https://github.com/eslint/eslint/pull/21066.

`markdownlint-cli2` 0.23.0 and above now requires Node.js 22 or higher, so this update can’t be applied to our current Node.js range, which still includes Node.js 20.19.0 and above.

I added `markdownlint-cli2` to Renovate’s ignore dependency list to prevent updates until the next major ESLint release.

Changelog: https://github.com/DavidAnson/markdownlint-cli2/blob/HEAD/CHANGELOG.md#0230

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
