### PR TITLE
chore: override `re2` dependency for `@metascraper/helpers`

### DIFF
--- a/package.json
+++ b/package.json
@@ -226,6 +226,9 @@
   "overrides": {
     "@arethetypeswrong/core": {
       "fflate": "0.8.2"
+    },
+    "@metascraper/helpers": {
+      "re2": "~1.24.1"
     }
   }
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Attempts to fix CI failure on v9.x-dev branch, noticed on https://github.com/eslint/eslint/pull/21065 (https://github.com/eslint/eslint/actions/runs/28933060888/job/85836629491?pr=21065). Reason for the failure is explained in https://github.com/eslint/eslint/pull/21065#issuecomment-4913240602.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Overrides `@metascraper/helpers` to use `"re2": "~1.24.1"`. I think this is a minimal safe change as we're not using `metascraper` much (only to fetch data locally when adding further reading links to rule docs) and the update of `re2` in `@metascraper/helpers` (https://github.com/microlinkhq/metascraper/commit/db863adb4b9d5752d04513d41feca015a67c47c1) didn't seem to use any new features.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
