### PR TITLE
fix: apply `ignoreClassesWithImplements` to class expressions

### DIFF
--- a/lib/rules/class-methods-use-this.js
+++ b/lib/rules/class-methods-use-this.js
@@ -127,7 +127,8 @@ module.exports = {
 		function hasImplements(node) {
 			const classNode = node.parent.parent;
 			return (
-				classNode?.type === "ClassDeclaration" &&
+				(classNode?.type === "ClassDeclaration" ||
+					classNode?.type === "ClassExpression") &&
 				classNode.implements?.length > 0
 			);
 		}

--- a/tests/lib/rules/class-methods-use-this.js
+++ b/tests/lib/rules/class-methods-use-this.js
@@ -680,6 +680,18 @@ ruleTesterTypeScript.run("class-methods-use-this", rule, {
 			code: "class Foo implements Bar { property = () => {} }",
 			options: [{ ignoreClassesWithImplements: "all" }],
 		},
+		{
+			code: "const Foo = class implements Bar { method() {} };",
+			options: [{ ignoreClassesWithImplements: "all" }],
+		},
+		{
+			code: "const Foo = class implements Bar { property = () => {} };",
+			options: [{ ignoreClassesWithImplements: "all" }],
+		},
+		{
+			code: "const Foo = class implements Bar { method() {} };",
+			options: [{ ignoreClassesWithImplements: "public-fields" }],
+		},
 	],
 	invalid: [
 		{
@@ -1338,6 +1350,15 @@ ruleTesterTypeScript.run("class-methods-use-this", rule, {
 					messageId: "missingThis",
 				},
 			],
+		},
+		{
+			code: "const Foo = class implements Bar { method() {} };",
+			errors: [{ messageId: "missingThis" }],
+		},
+		{
+			code: "const Foo = class implements Bar { private method() {} };",
+			options: [{ ignoreClassesWithImplements: "public-fields" }],
+			errors: [{ messageId: "missingThis" }],
 		},
 	],
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:** v24.16.0
- **npm version:** v11.13.0
- **Local ESLint version:** v10.6.0
- **Global ESLint version:** no
- **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->

```js
export default [{}];
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```ts
/* eslint class-methods-use-this: ["error", { "ignoreClassesWithImplements": "all" }] */

interface Base { method(): void; };

const Foo = class implements Base { method() {} };
class Bar implements Base { method() {} };
```

[Playground](https://eslint.org/play/#eyJ0ZXh0IjoiLyogZXNsaW50IGNsYXNzLW1ldGhvZHMtdXNlLXRoaXM6IFtcImVycm9yXCIsIHsgXCJpZ25vcmVDbGFzc2VzV2l0aEltcGxlbWVudHNcIjogXCJhbGxcIiB9XSAqL1xuXG5pbnRlcmZhY2UgQmFzZSB7IG1ldGhvZCgpOiB2b2lkOyB9O1xuXG5jb25zdCBGb28gPSBjbGFzcyBpbXBsZW1lbnRzIEJhc2UgeyBtZXRob2QoKSB7fSB9O1xuY2xhc3MgQmFyIGltcGxlbWVudHMgQmFzZSB7IG1ldGhvZCgpIHt9IH07Iiwib3B0aW9ucyI6eyJydWxlcyI6e30sImxhbmd1YWdlT3B0aW9ucyI6eyJwYXJzZXIiOiJAdHlwZXNjcmlwdC1lc2xpbnQvcGFyc2VyIiwicGFyc2VyT3B0aW9ucyI6eyJlY21hRmVhdHVyZXMiOnsianN4Ijp0cnVlfX19fX0=)

**What did you expect to happen?**

No report. `Foo` implements `Base`, so with `ignoreClassesWithImplements: "all"` the `method` should be ignored, exactly as it is for the equivalent class declaration.

**What actually happened? Please include the actual, raw output from ESLint.**

```
Expected 'this' to be used by class method 'method'.
```

#### What changes did you make? (Give an overview)

Updated the `hasImplements` helper in `class-methods-use-this` to also recognize `ClassExpression`, so the `ignoreClassesWithImplements` option applies to class expressions with an `implements` clause, matching class declarations.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
