### PR TITLE
feat: link rule IDs to docs URLs in stylish formatter

### DIFF
--- a/lib/cli-engine/formatters/stylish.js
+++ b/lib/cli-engine/formatters/stylish.js
@@ -38,12 +38,37 @@ function pluralize(word, count) {
 	return count === 1 ? word : `${word}s`;
 }
 
+/**
+ * Wraps text in an OSC 8 escape sequence so that supporting terminals render it
+ * as a clickable hyperlink. Terminals that don't support it will just render it
+ * as a normal text.
+ * @param {string} url The URL to link to.
+ * @param {string} text The visible text of the link.
+ * @returns {string} The text wrapped in an OSC 8 hyperlink escape sequence.
+ */
+function hyperlink(url, text) {
+	return `]8;;${url}${text}]8;;`;
+}
+
+/**
+ * Determines whether terminal hyperlinks should be emitted.
+ * @param {boolean|undefined} color Indicates whether to use colors.
+ * @returns {boolean} `true` if hyperlinks should be emitted.
+ */
+function shouldUseHyperlinks(color) {
+	if (typeof color === "boolean") {
+		return color;
+	}
+	return Boolean(process.stdout?.isTTY);
+}
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
 
 module.exports = function (results, data) {
 	const styleText = getStyleText(data?.color);
+	const rulesMeta = shouldUseHyperlinks(data?.color) ? data?.rulesMeta : null;
 
 	let output = "\n",
 		errorCount = 0,
@@ -77,13 +102,24 @@ module.exports = function (results, data) {
 					messageType = styleText("yellow", "warning");
 				}
 
+				let ruleCell = "";
+
+				if (message.ruleId) {
+					ruleCell = styleText("dim", message.ruleId);
+					const url = rulesMeta?.[message.ruleId]?.docs?.url;
+
+					if (url) {
+						ruleCell = hyperlink(url, ruleCell);
+					}
+				}
+
 				return [
 					"",
 					String(message.line || 0),
 					String(message.column || 0),
 					messageType,
 					message.message.replace(/([^ ])\.$/u, "$1"),
-					message.ruleId ? styleText("dim", message.ruleId) : "",
+					ruleCell,
 				];
 			}),
 			{

--- a/tests/lib/cli-engine/formatters/stylish.js
+++ b/tests/lib/cli-engine/formatters/stylish.js
@@ -680,4 +680,62 @@ describe("formatter:stylish", () => {
 			);
 		});
 	});
+
+	describe("when rule documentation URLs are available", () => {
+		const code = [
+			{
+				filePath: "foo.js",
+				errorCount: 1,
+				warningCount: 0,
+				fixableErrorCount: 0,
+				fixableWarningCount: 0,
+				messages: [
+					{
+						message: "Unexpected foo.",
+						severity: 2,
+						line: 5,
+						column: 10,
+						ruleId: "foo",
+					},
+				],
+			},
+		];
+
+		const osc8 = "\u001b]8;;";
+		const hyperlinkStart = `${osc8}https://example.com/foo\u0007`;
+		const hyperlinkEnd = `${osc8}\u0007`;
+
+		const rulesMeta = {
+			foo: { docs: { url: "https://example.com/foo" } },
+		};
+
+		it("`color: true` should wrap the rule ID in an OSC 8 hyperlink to the docs URL", () => {
+			const result = formatter(code, { color: true, rulesMeta });
+
+			assert.include(result, hyperlinkStart);
+			assert.include(result, hyperlinkEnd);
+
+			// the hyperlink escape sequences are not part of the visible text
+			assert.strictEqual(
+				util.stripVTControlCharacters(result),
+				"\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n✖ 1 problem (1 error, 0 warnings)\n",
+			);
+		});
+
+		it("`color: false` should not emit hyperlinks", () => {
+			const result = formatter(code, { color: false, rulesMeta });
+
+			assert.notInclude(result, osc8);
+			assert.notMatch(result, ansiEscapePattern);
+		});
+
+		it("should not emit a hyperlink for a rule without a docs URL", () => {
+			const result = formatter(code, {
+				color: true,
+				rulesMeta: { foo: { docs: {} } },
+			});
+
+			assert.notInclude(result, osc8);
+		});
+	});
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

**Background**
Most popular ESLint plugins have great documentation, either as Markdown files or as dedicated websites. However, these docs are often hard to find. You either need to use the JSON formatter, which displays a lot of unnecessary information, or search for the rule manually online. Other popular linters solve it just by displaying link to the rule docs, so I thought ESLint should to the same.

I extended the default `stylish` with support for displaying documentation hyperlinks for rules that provide them (example below).

<img width="1626" height="766" alt="image" src="https://github.com/user-attachments/assets/20d7e036-aee6-45da-a323-c40abded6e49" />

This should only work in TTY terminals, so most coding agents (eg. Claude Code), should not receive these links. This avoids increasing the risk of issues such as prompt injection.

#### Is there anything you'd like reviewers to focus on?

I think there is no built-in Node utility for formatting links, so I had to add a manual util for that, but if there is a better way, please let me know.

<!-- markdownlint-disable-file MD004 -->
