### PR TITLE
feat: add checkTernaryOperands option to no-unmodified-loop-condition

### DIFF
--- a/docs/src/rules/no-unmodified-loop-condition.md
+++ b/docs/src/rules/no-unmodified-loop-condition.md
@@ -99,7 +99,50 @@ while (check(obj)) {
 
 ## Options
 
-This rule has no options.
+This rule has an object option:
+
+* `"checkTernaryOperands"` (default `false`) check each variable of a ternary expression in a loop condition individually, instead of skipping the whole ternary expression when any of its variables is modified
+
+### checkTernaryOperands
+
+By default, a ternary expression in a loop condition is not reported if any of its variables is modified in the loop. With `"checkTernaryOperands"` set to `true`, each variable of a ternary expression is checked individually, so unmodified variables are reported even if another variable of the ternary expression is modified.
+
+Examples of **incorrect** code for this rule with the `{ "checkTernaryOperands": true }` option:
+
+::: incorrect
+
+```js
+/*eslint no-unmodified-loop-condition: ["error", { "checkTernaryOperands": true }]*/
+
+let node = getNode();
+let done = false;
+
+// "done" is not modified in this loop.
+while (node ? !done : false) {
+    node = node.next;
+}
+```
+
+:::
+
+Examples of **correct** code for this rule with the `{ "checkTernaryOperands": true }` option:
+
+::: correct
+
+```js
+/*eslint no-unmodified-loop-condition: ["error", { "checkTernaryOperands": true }]*/
+
+let node = getNode();
+let done = false;
+
+// OK, all variables of the ternary expression are modified in this loop.
+while (node ? !done : false) {
+    node = node.next;
+    done = isDone(node);
+}
+```
+
+:::
 
 ## When Not To Use It
 

--- a/lib/rules/no-unmodified-loop-condition.js
+++ b/lib/rules/no-unmodified-loop-condition.js
@@ -26,7 +26,6 @@ const Traverser = require("../shared/traverser"),
 const SENTINEL_PATTERN =
 	/(?:(?:Call|Class|Function|Member|New|Yield)Expression|Statement|Declaration)$/u;
 const LOOP_PATTERN = /^(?:DoWhile|For|While)Statement$/u; // for-in/of statements don't have `test` property.
-const GROUP_PATTERN = /^(?:BinaryExpression|ConditionalExpression)$/u;
 const SKIP_PATTERN = /^(?:ArrowFunction|Class|Function)Expression$/u;
 const DYNAMIC_PATTERN = /^(?:Call|Member|New|TaggedTemplate|Yield)Expression$/u;
 
@@ -190,7 +189,23 @@ module.exports = {
 			url: "https://eslint.org/docs/latest/rules/no-unmodified-loop-condition",
 		},
 
-		schema: [],
+		schema: [
+			{
+				type: "object",
+				properties: {
+					checkTernaryOperands: {
+						type: "boolean",
+					},
+				},
+				additionalProperties: false,
+			},
+		],
+
+		defaultOptions: [
+			{
+				checkTernaryOperands: false,
+			},
+		],
 
 		messages: {
 			loopConditionNotModified:
@@ -200,7 +215,22 @@ module.exports = {
 
 	create(context) {
 		const sourceCode = context.sourceCode;
+		const [{ checkTernaryOperands }] = context.options;
 		let groupMap = null;
+
+		/**
+		 * Checks whether or not a given node makes a group.
+		 * References inside of a group are not reported if any element of the
+		 * group is modified.
+		 * @param {ASTNode} node A node to check.
+		 * @returns {boolean} `true` if the node makes a group.
+		 */
+		function isGroup(node) {
+			return (
+				node.type === "BinaryExpression" ||
+				(!checkTernaryOperands && node.type === "ConditionalExpression")
+			);
+		}
 
 		/**
 		 * Reports a given condition info.
@@ -308,7 +338,7 @@ module.exports = {
 				 * If it's inside of a group, OK if either operand is modified.
 				 * So stores the group this reference belongs to.
 				 */
-				if (GROUP_PATTERN.test(node.type)) {
+				if (isGroup(node)) {
 					// If this expression is dynamic, no need to check.
 					if (hasDynamicExpressions(node)) {
 						break;

--- a/lib/types/rules.d.ts
+++ b/lib/types/rules.d.ts
@@ -4040,7 +4040,16 @@ export interface ESLintRules extends Linter.RulesRecord {
 	 * @since 2.0.0-alpha-2
 	 * @see https://eslint.org/docs/latest/rules/no-unmodified-loop-condition
 	 */
-	"no-unmodified-loop-condition": Linter.RuleEntry<[]>;
+	"no-unmodified-loop-condition": Linter.RuleEntry<
+		[
+			Partial<{
+				/**
+				 * @default false
+				 */
+				checkTernaryOperands: boolean;
+			}>,
+		]
+	>;
 
 	/**
 	 * Rule to disallow ternary operators when simpler alternatives exist.

--- a/tests/lib/rules/no-unmodified-loop-condition.js
+++ b/tests/lib/rules/no-unmodified-loop-condition.js
@@ -58,6 +58,18 @@ ruleTester.run("no-unmodified-loop-condition", rule, {
 		"var foo = 0, bar = 0; for (bar; foo;) { ++foo }",
 		"var foo; if (foo) { }",
 		"var a = [1, 2, 3]; var len = a.length; for (var i = 0; i < len - 1; i++) {}",
+		{
+			code: "var foo = 0, bar = 1, baz = 2; while (foo ? bar : baz) { foo += 1; }",
+			options: [{ checkTernaryOperands: false }],
+		},
+		{
+			code: "var foo = 0, bar = 1, baz = 2; while (foo ? bar : baz) { foo += 1; bar += 1; baz += 1; }",
+			options: [{ checkTernaryOperands: true }],
+		},
+		{
+			code: "var a = 0, b = 1, c = 2; while (a ? b < c : false) { a += 1; b += 1; }",
+			options: [{ checkTernaryOperands: true }],
+		},
 	],
 	invalid: [
 		{
@@ -131,6 +143,41 @@ ruleTester.run("no-unmodified-loop-condition", rule, {
 				{
 					messageId: "loopConditionNotModified",
 					data: { name: "foo" },
+				},
+			],
+		},
+		{
+			code: "var foo = 0, bar = 1, baz = 2; while (foo ? bar : baz) { foo += 1; }",
+			options: [{ checkTernaryOperands: true }],
+			errors: [
+				{
+					messageId: "loopConditionNotModified",
+					data: { name: "bar" },
+				},
+				{
+					messageId: "loopConditionNotModified",
+					data: { name: "baz" },
+				},
+			],
+		},
+		{
+			code: "let chunk = next(); let done = false; while (chunk ? !done : false) { chunk = next(); }",
+			options: [{ checkTernaryOperands: true }],
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "loopConditionNotModified",
+					data: { name: "done" },
+				},
+			],
+		},
+		{
+			code: "var a = 0, b = 1, c = 2; while (a ? b < c : false) { b += 1; }",
+			options: [{ checkTernaryOperands: true }],
+			errors: [
+				{
+					messageId: "loopConditionNotModified",
+					data: { name: "a" },
 				},
 			],
 		},


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Follows up on the discussion in #20844: DMartens identified a `ConditionalExpression` false negative and invited a PR; the review of the previous attempt (#20864, auto-closed for inactivity) concluded the new reports should be behind an option (DMartens: "The safe thing to do would be to introduce an option for this new behavior"; fasttime agreed). This PR implements exactly that. @Kuldeep2822k, since #20864 was auto-closed I picked this up where that review left off — if you'd rather resubmit your PR, happy to close mine.

#### What changes did you make? (Give an overview)

Added a `checkTernaryOperands` option (default `false`) to `no-unmodified-loop-condition`:

- **Default (`false`): behavior is completely unchanged.** A ternary in a loop condition is still treated as a single group — if any of its variables is modified, none are reported. No existing test was modified.
- **`checkTernaryOperands: true`:** each variable of a ternary loop condition is checked individually, mirroring how `LogicalExpression` operands are already handled. This catches the false negative from the issue: in `while (chunk ? !done : false) { chunk = next(); }`, `done` is now reported.
- Replaced the `GROUP_PATTERN` regex with a direct type check (`isGroup`), per the review feedback on #20864 that the regex was no longer needed.
- Nested `BinaryExpression`s inside a ternary still group their own operands when the option is enabled (`while (a ? b < c : false) { b += 1; }` does not report `b`/`c`, but reports the unmodified `a`).
- Updated `lib/types/rules.d.ts` and the rule docs (new Options section with correct/incorrect examples; the existing "Rule Details" wording about ternaries is kept, since default behavior is unchanged — addressing the docs feedback on #20864).
- Tests: 3 new valid + 3 new invalid cases covering the option on/off, the issue's exact false-negative shape, and the nested-binary case. The rule's suite: 43 passing after the change; the 6 new tests fail without the rule change.

#### Is there anything you'd like reviewers to focus on?

- Option name: `checkTernaryOperands` follows the `check*` naming of recent rule options (e.g. `checkConstructorCallCallbacks` in max-nested-callbacks); happy to rename (e.g. `enforceForTernaryOperands`) if preferred.
- With the option enabled, ternary operands are treated like logical-expression operands, which also means the ternary no longer gets the group-level dynamic-expression skip; e.g. `while (foo ? bar() : baz)` reports `foo` and `baz` when they are unmodified, symmetric with `while (foo && bar())`. Flagging in case you want different semantics there.
