### PR TITLE
fix: prefer-object-spread add semicolon when adding parenthesis

### DIFF
--- a/lib/rules/prefer-object-spread.js
+++ b/lib/rules/prefer-object-spread.js
@@ -11,6 +11,8 @@ const {
 	isOpeningParenToken,
 	isClosingParenToken,
 	isParenthesised,
+	isStartOfExpressionStatement,
+	needsPrecedingSemicolon,
 } = require("./utils/ast-utils");
 
 const ANY_SPACE = /\s/u;
@@ -194,7 +196,13 @@ function defineFixer(node, sourceCode) {
 
 		// Replace the parens of argument list to braces.
 		if (needsParens(node, sourceCode)) {
-			yield fixer.replaceText(leftParen, "({");
+			const prefix =
+				isStartOfExpressionStatement(node) &&
+				needsPrecedingSemicolon(sourceCode, node)
+					? ";({"
+					: "({";
+
+			yield fixer.replaceText(leftParen, prefix);
 			yield fixer.replaceText(rightParen, "})");
 		} else {
 			yield fixer.replaceText(leftParen, "{");

--- a/tests/lib/rules/prefer-object-spread.js
+++ b/tests/lib/rules/prefer-object-spread.js
@@ -102,60 +102,6 @@ ruleTester.run("prefer-object-spread", rule, {
 
 	invalid: [
 		{
-			code: "const result = doSomething()\nObject.assign({}, myData)",
-			output: "const result = doSomething()\n;({ ...myData})",
-			errors: [
-				{
-					messageId: "useSpreadMessage",
-				},
-			],
-		},
-		{
-			code: "let a = foo + Object.assign({}, bar)",
-			output: "let a = foo + ({ ...bar})",
-			errors: [
-				{
-					messageId: "useSpreadMessage",
-				},
-			],
-		},
-		{
-			code: "let foo = function() {};\nfoo\nObject.assign({}, bar)",
-			output: "let foo = function() {};\nfoo\n;({ ...bar})",
-			errors: [
-				{
-					messageId: "useSpreadMessage",
-				},
-			],
-		},
-		{
-			code: "foo\nObject.assign({ foo: bar })",
-			output: "foo\n;({foo: bar})",
-			errors: [
-				{
-					messageId: "useLiteralMessage",
-				},
-			],
-		},
-		{
-			code: "foo();\nObject.assign({}, bar)",
-			output: "foo();\n({ ...bar})",
-			errors: [
-				{
-					messageId: "useSpreadMessage",
-				},
-			],
-		},
-		{
-			code: "const x = [1]\nObject.assign({}, bar)",
-			output: "const x = [1]\n;({ ...bar})",
-			errors: [
-				{
-					messageId: "useSpreadMessage",
-				},
-			],
-		},
-		{
 			code: "Object.assign({}, foo)",
 			output: "({ ...foo})",
 			errors: [
@@ -431,6 +377,60 @@ ruleTester.run("prefer-object-spread", rule, {
 			],
 		},
 
+		{
+			code: "const result = doSomething()\nObject.assign({}, myData)",
+			output: "const result = doSomething()\n;({ ...myData})",
+			errors: [
+				{
+					messageId: "useSpreadMessage",
+				},
+			],
+		},
+		{
+			code: "let a = foo + Object.assign({}, bar)",
+			output: "let a = foo + ({ ...bar})",
+			errors: [
+				{
+					messageId: "useSpreadMessage",
+				},
+			],
+		},
+		{
+			code: "let foo = function() {};\nfoo\nObject.assign({}, bar)",
+			output: "let foo = function() {};\nfoo\n;({ ...bar})",
+			errors: [
+				{
+					messageId: "useSpreadMessage",
+				},
+			],
+		},
+		{
+			code: "foo\nObject.assign({ foo: bar })",
+			output: "foo\n;({foo: bar})",
+			errors: [
+				{
+					messageId: "useLiteralMessage",
+				},
+			],
+		},
+		{
+			code: "foo();\nObject.assign({}, bar)",
+			output: "foo();\n({ ...bar})",
+			errors: [
+				{
+					messageId: "useSpreadMessage",
+				},
+			],
+		},
+		{
+			code: "const x = [1]\nObject.assign({}, bar)",
+			output: "const x = [1]\n;({ ...bar})",
+			errors: [
+				{
+					messageId: "useSpreadMessage",
+				},
+			],
+		},
 		/*
 		 * This is a special case where Object.assign is called with a single argument
 		 * and that argument is an object expression. In this case we warn and display

--- a/tests/lib/rules/prefer-object-spread.js
+++ b/tests/lib/rules/prefer-object-spread.js
@@ -431,6 +431,24 @@ ruleTester.run("prefer-object-spread", rule, {
 				},
 			],
 		},
+		{
+			code: "foo\nObject.assign({}, bar).doSomething()",
+			output: "foo\n;({ ...bar}).doSomething()",
+			errors: [
+				{
+					messageId: "useSpreadMessage",
+				},
+			],
+		},
+		{
+			code: "foo\nObject.assign({}, bar), 2",
+			output: "foo\n;({ ...bar}), 2",
+			errors: [
+				{
+					messageId: "useSpreadMessage",
+				},
+			],
+		},
 		/*
 		 * This is a special case where Object.assign is called with a single argument
 		 * and that argument is an object expression. In this case we warn and display

--- a/tests/lib/rules/prefer-object-spread.js
+++ b/tests/lib/rules/prefer-object-spread.js
@@ -102,6 +102,60 @@ ruleTester.run("prefer-object-spread", rule, {
 
 	invalid: [
 		{
+			code: "const result = doSomething()\nObject.assign({}, myData)",
+			output: "const result = doSomething()\n;({ ...myData})",
+			errors: [
+				{
+					messageId: "useSpreadMessage",
+				},
+			],
+		},
+		{
+			code: "let a = foo + Object.assign({}, bar)",
+			output: "let a = foo + ({ ...bar})",
+			errors: [
+				{
+					messageId: "useSpreadMessage",
+				},
+			],
+		},
+		{
+			code: "let foo = function() {};\nfoo\nObject.assign({}, bar)",
+			output: "let foo = function() {};\nfoo\n;({ ...bar})",
+			errors: [
+				{
+					messageId: "useSpreadMessage",
+				},
+			],
+		},
+		{
+			code: "foo\nObject.assign({ foo: bar })",
+			output: "foo\n;({foo: bar})",
+			errors: [
+				{
+					messageId: "useLiteralMessage",
+				},
+			],
+		},
+		{
+			code: "foo();\nObject.assign({}, bar)",
+			output: "foo();\n({ ...bar})",
+			errors: [
+				{
+					messageId: "useSpreadMessage",
+				},
+			],
+		},
+		{
+			code: "const x = [1]\nObject.assign({}, bar)",
+			output: "const x = [1]\n;({ ...bar})",
+			errors: [
+				{
+					messageId: "useSpreadMessage",
+				},
+			],
+		},
+		{
 			code: "Object.assign({}, foo)",
 			output: "({ ...foo})",
 			errors: [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #21078

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

When replacing an Object.assign() expression statement with an object spread wrapped in parentheses `({ ... })`, the fixer now uses `astUtils.needsPrecedingSemicolon()` to safely prepend a semicolon guard if an ASI hazard exists. The check is gated by `isStartOfExpressionStatement(node)` to avoid injecting invalid semicolons into nested expressions.

#### Is there anything you'd like reviewers to focus on?


<!-- markdownlint-disable-file MD004 -->
