### PR TITLE
fix: NewExpression with parenthesized callee in `preserve-caught-error`

### DIFF
--- a/lib/rules/preserve-caught-error.js
+++ b/lib/rules/preserve-caught-error.js
@@ -15,6 +15,8 @@ const astUtils = require("./utils/ast-utils");
 //------------------------------------------------------------------------------
 
 /** @typedef {import("estree").Node} ASTNode */
+/** @typedef {import("eslint").Rule.Fix} Fix */
+/** @typedef {import("eslint").Rule.RuleFixer} RuleFixer */
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -309,27 +311,80 @@ module.exports = {
 		}
 
 		/**
-		 * Gets the token after which new arguments should be inserted for the
-		 * given argument, accounting for parentheses wrapping the argument so
-		 * that insertions land outside them (e.g. `new Error(("msg"))`).
-		 * @param {ASTNode} argNode The argument node.
-		 * @param {ASTNode} callNode The enclosing call or new expression.
-		 * @returns {Token} The token to insert after.
+		 * Finds the first token that isn't followed by a closing parenthesis in a specified range.
+		 * This is the token after which new arguments should be inserted.
+		 * @param {Token} firstToken The first token to start searching from.
+		 * @param {Token} lastToken The last token to scan up to (inclusive).
+		 * @returns {Token} The first token that isn't followed by a closing parenthesis, or `lastToken` if none is found.
 		 */
-		function getLastArgumentToken(argNode, callNode) {
-			const callLastToken = sourceCode.getLastToken(callNode);
-			let token = sourceCode.getLastToken(argNode);
+		function findInsertionTokenAfterParens(firstToken, lastToken) {
+			const lastIndex = lastToken.range[1];
+			let token = firstToken;
 			let nextToken = sourceCode.getTokenAfter(token);
 
 			while (
-				nextToken &&
-				nextToken !== callLastToken &&
+				nextToken.range[1] <= lastIndex &&
 				astUtils.isClosingParenToken(nextToken)
 			) {
 				token = nextToken;
 				nextToken = sourceCode.getTokenAfter(token);
 			}
 			return token;
+		}
+
+		/**
+		 * Adds arguments for a call/new expression with no arguments.
+		 * Works for `new Error`, `new (Error)`, and forms that already include empty argument parentheses.
+		 * @param {RuleFixer} fixer The fixer instance.
+		 * @param {ASTNode & { callee: ASTNode }} throwExpression The thrown CallExpression or NewExpression node.
+		 * @param {string} text The arguments to insert.
+		 * @returns {Fix} The fixer operation.
+		 */
+		function addArgumentsToEmptyCall(fixer, throwExpression, text) {
+			const callClosingParenToken =
+				sourceCode.getLastToken(throwExpression);
+			const lastCalleeToken = sourceCode.getLastToken(
+				throwExpression.callee,
+			);
+			const parenToken = sourceCode.getFirstTokenBetween(
+				lastCalleeToken,
+				callClosingParenToken,
+				astUtils.isOpeningParenToken,
+			);
+
+			if (parenToken) {
+				return fixer.insertTextAfter(parenToken, text);
+			}
+
+			const insertionToken = findInsertionTokenAfterParens(
+				lastCalleeToken,
+				callClosingParenToken,
+			);
+
+			return fixer.insertTextAfter(insertionToken, `(${text})`);
+		}
+
+		/**
+		 * Appends additional arguments after the last argument of a call/new expression,
+		 * accounting for any wrapping parentheses around that argument.
+		 * @param {RuleFixer} fixer The fixer instance.
+		 * @param {ASTNode & { arguments: ASTNode[] }} throwExpression The thrown CallExpression or NewExpression node.
+		 * @param {string} text The additional arguments to insert, including the leading comma.
+		 * @returns {Fix} The fixer operation.
+		 */
+		function appendArguments(fixer, throwExpression, text) {
+			const lastArgument = throwExpression.arguments.at(-1);
+			const lastArgumentToken = sourceCode.getLastToken(lastArgument);
+			const lastTokenBeforeArgListParen = sourceCode.getLastToken(
+				throwExpression,
+				{ skip: 1 },
+			);
+			const insertionToken = findInsertionTokenAfterParens(
+				lastArgumentToken,
+				lastTokenBeforeArgListParen,
+			);
+
+			return fixer.insertTextAfter(insertionToken, text);
 		}
 
 		//----------------------------------------------------------------------
@@ -450,51 +505,27 @@ module.exports = {
 
 											if (!errorsArg) {
 												// Case: `throw new AggregateError()` → insert all arguments
-												const lastToken =
-													sourceCode.getLastToken(
-														throwExpression,
-													);
-												const lastCalleeToken =
-													sourceCode.getLastToken(
-														throwExpression.callee,
-													);
-												const parenToken =
-													sourceCode.getFirstTokenBetween(
-														lastCalleeToken,
-														lastToken,
-														astUtils.isOpeningParenToken,
-													);
-
-												if (parenToken) {
-													return fixer.insertTextAfter(
-														parenToken,
-														`[], "", { cause: ${caughtError.name} }`,
-													);
-												}
-												return fixer.insertTextAfter(
-													throwExpression.callee,
-													`([], "", { cause: ${caughtError.name} })`,
+												return addArgumentsToEmptyCall(
+													fixer,
+													throwExpression,
+													`[], "", { cause: ${caughtError.name} }`,
 												);
 											}
 
 											if (!messageArg) {
 												// Case: `throw new AggregateError([])` → insert message and options
-												return fixer.insertTextAfter(
-													getLastArgumentToken(
-														errorsArg,
-														throwExpression,
-													),
+												return appendArguments(
+													fixer,
+													throwExpression,
 													`, "", { cause: ${caughtError.name} }`,
 												);
 											}
 
 											if (!optionsArg) {
 												// Case: `throw new AggregateError([], "")` → insert error options only
-												return fixer.insertTextAfter(
-													getLastArgumentToken(
-														messageArg,
-														throwExpression,
-													),
+												return appendArguments(
+													fixer,
+													throwExpression,
 													`, { cause: ${caughtError.name} }`,
 												);
 											}
@@ -511,39 +542,17 @@ module.exports = {
 
 											if (!messageArg) {
 												// Case: `throw new Error()` → insert both message and options
-												const lastToken =
-													sourceCode.getLastToken(
-														throwExpression,
-													);
-												const lastCalleeToken =
-													sourceCode.getLastToken(
-														throwExpression.callee,
-													);
-												const parenToken =
-													sourceCode.getFirstTokenBetween(
-														lastCalleeToken,
-														lastToken,
-														astUtils.isOpeningParenToken,
-													);
-
-												if (parenToken) {
-													return fixer.insertTextAfter(
-														parenToken,
-														`"", { cause: ${caughtError.name} }`,
-													);
-												}
-												return fixer.insertTextAfter(
-													throwExpression.callee,
-													`("", { cause: ${caughtError.name} })`,
+												return addArgumentsToEmptyCall(
+													fixer,
+													throwExpression,
+													`"", { cause: ${caughtError.name} }`,
 												);
 											}
 											if (!optionsArg) {
 												// Case: `throw new Error("Some message")` → insert only options
-												return fixer.insertTextAfter(
-													getLastArgumentToken(
-														messageArg,
-														throwExpression,
-													),
+												return appendArguments(
+													fixer,
+													throwExpression,
 													`, { cause: ${caughtError.name} }`,
 												);
 											}
@@ -569,40 +578,18 @@ module.exports = {
 
 											if (lastProvidedArg) {
 												// Options slot missing, all prior args provided → append options
-												return fixer.insertTextAfter(
-													getLastArgumentToken(
-														lastProvidedArg,
-														throwExpression,
-													),
+												return appendArguments(
+													fixer,
+													throwExpression,
 													`, { cause: ${caughtError.name} }`,
 												);
 											}
 
-											// argumentPosition: 1 and no args → insert `{ cause: err }` inside parens
-											const lastToken =
-												sourceCode.getLastToken(
-													throwExpression,
-												);
-											const lastCalleeToken =
-												sourceCode.getLastToken(
-													throwExpression.callee,
-												);
-											const parenToken =
-												sourceCode.getFirstTokenBetween(
-													lastCalleeToken,
-													lastToken,
-													astUtils.isOpeningParenToken,
-												);
-
-											if (parenToken) {
-												return fixer.insertTextAfter(
-													parenToken,
-													`{ cause: ${caughtError.name} }`,
-												);
-											}
-											return fixer.insertTextAfter(
-												throwExpression.callee,
-												`({ cause: ${caughtError.name} })`,
+											// argumentPosition: 1 and no args → insert options inside parens
+											return addArgumentsToEmptyCall(
+												fixer,
+												throwExpression,
+												`{ cause: ${caughtError.name} }`,
 											);
 										}
 

--- a/tests/lib/rules/preserve-caught-error.js
+++ b/tests/lib/rules/preserve-caught-error.js
@@ -1404,5 +1404,76 @@ ruleTester.run("preserve-caught-error", rule, {
 				},
 			],
 		},
+
+		/* Built-in error constructor without argument list */
+		{
+			code: `try {} catch (err) { throw new Error; }`,
+			errors: [
+				{
+					messageId: "missingCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `try {} catch (err) { throw new Error("", { cause: err }); }`,
+						},
+					],
+				},
+			],
+		},
+
+		/* AggregateError without argument list */
+		{
+			code: `try {} catch (err) { throw new AggregateError; }`,
+			errors: [
+				{
+					messageId: "missingCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `try {} catch (err) { throw new AggregateError([], "", { cause: err }); }`,
+						},
+					],
+				},
+			],
+		},
+
+		/* Custom error type without argument list */
+		{
+			code: `try {} catch (err) { throw new CustomError; }`,
+			options: [
+				{
+					errorClassNames: [
+						{ name: "CustomError", argumentPosition: 1 },
+					],
+				},
+			],
+			errors: [
+				{
+					messageId: "missingCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `try {} catch (err) { throw new CustomError({ cause: err }); }`,
+						},
+					],
+				},
+			],
+		},
+
+		/* Parenthesized error constructor without argument list */
+		{
+			code: `try {} catch (err) { throw new (Error); }`,
+			errors: [
+				{
+					messageId: "missingCause",
+					suggestions: [
+						{
+							messageId: "includeCause",
+							output: `try {} catch (err) { throw new (Error)("", { cause: err }); }`,
+						},
+					],
+				},
+			],
+		},
 	],
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

Node version: v26.5.0
npm version: v11.17.0
Local ESLint version: v10.7.0 (Currently used)
Global ESLint version: v10.7.0
Operating System: darwin 25.5.0

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

No config file.

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint preserve-caught-error: "error" */

try {
    // ...
} catch (error) {
    throw new (Error);
}
```

[**Playground link**](https://eslint.org/play/#eyJ0ZXh0IjoiLyogZXNsaW50IHByZXNlcnZlLWNhdWdodC1lcnJvcjogXCJlcnJvclwiICovXG5cbnRyeSB7XG4gICAgLy8gLi4uXG59IGNhdGNoIChlcnJvcikge1xuICAgIHRocm93IG5ldyAoRXJyb3IpO1xufVxuIiwib3B0aW9ucyI6eyJydWxlcyI6e30sImxhbmd1YWdlT3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFGZWF0dXJlcyI6e319fX19)

**What did you expect to happen?**

The suggested fix should invoke `new` on the `Error` constructor.

```js
/* eslint preserve-caught-error: "error" */

try {
    // ...
} catch (error) {
    throw new (Error)("", { cause: error });
}
```

**What actually happened? Please include the actual, raw output from ESLint.**

The fix invokes `new` on a non-constructible `Error` object. That results in an unrelated `TypeError` at runtime:

```js
/* eslint preserve-caught-error: "error" */

try {
    // ...
} catch (error) {
    throw new (Error("", { cause: error }));
}

```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR corrects the fix logic for parenthesized error constructors, to ensure that new arguments are added outside the existing parentheses. I also refactored the logic for appending new arguments to existing ones to eliminate duplications.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
