### PR TITLE
ci: Add explicit permissions to rebuild-docs-sites workflow

### DIFF
--- a/.github/workflows/rebuild-docs-sites.yml
+++ b/.github/workflows/rebuild-docs-sites.yml
@@ -6,6 +6,9 @@ on:
         paths:
             - "docs/src/_data/versions.json"
 
+permissions:
+    contents: read
+
 jobs:
     rebuild:
         name: "Trigger rebuild on Netlify"


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: CI hardening - declare least-privilege `GITHUB_TOKEN` permissions in a workflow.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added a workflow-level `permissions: contents: read` declaration to `rebuild-docs-sites.yml`.

Without an explicit `permissions` key, the workflow inherits the repository’s default `GITHUB_TOKEN` permissions, which may grant unnecessary write access.

This workflow only checks out the repository and sends a `curl` request to a Netlify build hook using `secrets.NETLIFY_DOCS_BUILD_HOOK`. Since it does not perform any GitHub API write operations, restricting the token to `contents: read` does not affect the workflow’s behavior. It only reduces the potential impact if a workflow step is ever compromised.

This is consistent with the approach used in [`eslint/.github#20`](https://github.com/eslint/.github/pull/20), where read-only workflows were also granted workflow-level `contents: read` permissions.


#### Is there anything you'd like reviewers to focus on?


<!-- markdownlint-disable-file MD004 -->
