### PR TITLE
chore: add allowScripts field to package.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
               with:
                   node-version: "24" # Should be the same as the version used on Netlify to build the ESLint Playground
 
-            # Node 24 bundles npm 11.16.0, which has a bug where denying a package's
+            # Node 24.18.0 bundles npm 11.16.0, which has a bug where denying a package's
             # install scripts via `allowScripts` also drops its `.bin` links.
             # Fixed in npm 11.18.0. See https://github.com/npm/cli/issues/9681
             - name: Update npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,12 @@ jobs:
             - uses: actions/setup-node@v6
               with:
                   node-version: "24" # Should be the same as the version used on Netlify to build the ESLint Playground
+
+            # Node 24 bundles npm 11.16.0, which has a bug where denying a package's
+            # install scripts via `allowScripts` also drops its `.bin` links.
+            # Fixed in npm 11.18.0. See https://github.com/npm/cli/issues/9681
+            - name: Update npm
+              run: npm install -g npm@latest
             - name: Install Packages
               run: npm install
             - name: Test

--- a/Makefile.js
+++ b/Makefile.js
@@ -657,6 +657,13 @@ target.mocha = () => {
 target.cypress = () => {
 	echo("Running unit tests on browsers");
 	target.webpack("production");
+
+	const installReturn = exec(`${getBinFile("cypress")} install`);
+
+	if (installReturn.code !== 0) {
+		exit(1);
+	}
+
 	const lastReturn = exec(`${getBinFile("cypress")} run --no-runner-ui`);
 
 	if (lastReturn.code !== 0) {

--- a/package.json
+++ b/package.json
@@ -241,12 +241,5 @@
   "license": "MIT",
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "npm",
-      "version": "<11.16.0 || >=11.18.0",
-      "onFail": "warn"
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -241,5 +241,12 @@
   "license": "MIT",
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": "<11.16.0 || >=11.18.0",
+      "onFail": "warn"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -84,6 +84,12 @@
     "test:types:7.x": "npx -p @typescript/native-preview@latest -y -- tsgo -p tsconfig.types.json",
     "test:types:all": "npm run test:types && npm run test:types:5.3 && npm run test:types:5.x && npm run test:types:7.x"
   },
+  "allowScripts": {
+    "core-js@3.49.0": true,
+    "cypress@14.5.4": true,
+    "re2@1.25.2": true,
+    "yorkie@2.0.0": true
+  },
   "workspaces": [
     "packages/*"
   ],

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   },
   "allowScripts": {
     "core-js": false,
-    "cypress": true,
+    "cypress": false,
     "re2": true,
     "yorkie": true
   },

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "test:types:all": "npm run test:types && npm run test:types:5.3 && npm run test:types:5.x && npm run test:types:7.x"
   },
   "allowScripts": {
-    "core-js": true,
+    "core-js": false,
     "cypress": true,
     "re2": true,
     "yorkie": true

--- a/package.json
+++ b/package.json
@@ -85,10 +85,10 @@
     "test:types:all": "npm run test:types && npm run test:types:5.3 && npm run test:types:5.x && npm run test:types:7.x"
   },
   "allowScripts": {
-    "core-js@3.49.0": true,
-    "cypress@14.5.4": true,
-    "re2@1.25.2": true,
-    "yorkie@2.0.0": true
+    "core-js": true,
+    "cypress": true,
+    "re2": true,
+    "yorkie": true
   },
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: add the `allowScripts` field to `package.json` for the npm install scripts policy.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR adds the `allowScripts` field to `package.json` to explicitly allow the install scripts of the four dependencies that use them.

npm 11.16.0 introduced phase 1 of the `allowScripts` policy ([npm/cli#9415](https://github.com/npm/cli/pull/9415), [v11.16.0 release](https://github.com/npm/cli/releases/tag/v11.16.0)). Install scripts still run in this phase, but a warning is shown after `npm install` when a package has an install script that isn't covered by `allowScripts`. Starting with npm 12, unapproved install scripts will no longer run by default ([official announcement](https://github.blog/changelog/2026-07-08-npm-install-time-security-and-gat-bypass2fa-deprecation/)).

On a fresh install with npm 11.16.0, the following warning appears:

```
npm warn allow-scripts 4 packages have install scripts not yet covered by allowScripts:
npm warn allow-scripts   core-js@3.49.0 (postinstall: node -e "try{require('./postinstall')}catch(e){}")
npm warn allow-scripts   cypress@14.5.4 (postinstall: node index.js --exec install)
npm warn allow-scripts   yorkie@2.0.0 (install: node bin/install.js)
npm warn allow-scripts   re2@1.25.2 (install: install-from-cache --artifact build/Release/re2.node ... || node-gyp -j max rebuild)
```

Under npm 12, these scripts would be blocked, so the git hooks setup, the Cypress binary download, and the `re2` native build would stop working.

I reviewed each install script before allowing it: `yorkie` installs the git hooks, `cypress` downloads its binary, `re2` (a transitive dependency) builds its native module, and `core-js` only prints a funding message.

Verification with npm 11.16.0 (Node.js v24.14.1), after running `rm -rf node_modules && npm install`:

- The `allow-scripts` warning no longer appears.
- `.git/hooks/pre-commit` is correctly created by yorkie, and the hook runs `lint-staged` on commit as before.
- `npx cypress verify` → `✔ Verified Cypress!`
- `node_modules/re2/build/Release/re2.node` is built, and the module loads correctly.
- `npm test` passes.
- `npx prettier --check package.json` passes.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
