### PR TITLE
fix: apply ignore configs to computed methods in class-methods-use-this

### DIFF
--- a/lib/rules/class-methods-use-this.js
+++ b/lib/rules/class-methods-use-this.js
@@ -141,10 +141,6 @@ module.exports = {
 		 */
 		function isIncludedInstanceMethod(node) {
 			if (isInstanceMethod(node)) {
-				if (node.computed) {
-					return true;
-				}
-
 				if (ignoreOverrideMethods && node.override) {
 					return false;
 				}
@@ -162,6 +158,10 @@ module.exports = {
 							return false;
 						}
 					}
+				}
+
+				if (node.computed) {
+					return true;
 				}
 
 				const hashIfNeeded =

--- a/tests/lib/rules/class-methods-use-this.js
+++ b/tests/lib/rules/class-methods-use-this.js
@@ -505,6 +505,10 @@ ruleTesterTypeScript.run("class-methods-use-this", rule, {
 			options: [{ ignoreOverrideMethods: true }],
 		},
 		{
+			code: 'class Foo { override ["method"]() {} }',
+			options: [{ ignoreOverrideMethods: true }],
+		},
+		{
 			code: "class Foo { private override method() {} }",
 			options: [{ ignoreOverrideMethods: true }],
 		},
@@ -665,6 +669,10 @@ ruleTesterTypeScript.run("class-methods-use-this", rule, {
 			options: [{ ignoreClassesWithImplements: "all" }],
 		},
 		{
+			code: 'class Foo implements Bar { ["method"]() {} }',
+			options: [{ ignoreClassesWithImplements: "all" }],
+		},
+		{
 			code: "class Foo implements Bar { accessor method = () => {} }",
 			options: [{ ignoreClassesWithImplements: "all" }],
 		},
@@ -690,6 +698,10 @@ ruleTesterTypeScript.run("class-methods-use-this", rule, {
 		},
 		{
 			code: "const Foo = class implements Bar { method() {} };",
+			options: [{ ignoreClassesWithImplements: "public-fields" }],
+		},
+		{
+			code: 'class Foo implements Bar { ["property"] = () => {} }',
 			options: [{ ignoreClassesWithImplements: "public-fields" }],
 		},
 	],


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:** v24.16.0
- **npm version:** v11.13.0
- **Local ESLint version:** v10.7.0
- **Global ESLint version:** no
- **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[ ] `Default (Espree)`
[x] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->

```js
export default [{}];
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```ts
/* eslint class-methods-use-this: ["error", { "ignoreOverrideMethods": true }] */

class Foo {
  override bar() {};
  override ["baz"]() {};
}
```

[Playground](https://eslint.org/play/#eyJ0ZXh0IjoiLyogZXNsaW50IGNsYXNzLW1ldGhvZHMtdXNlLXRoaXM6IFtcImVycm9yXCIsIHsgXCJpZ25vcmVPdmVycmlkZU1ldGhvZHNcIjogdHJ1ZSB9XSAqL1xuXG5jbGFzcyBGb28ge1xuICBvdmVycmlkZSBiYXIoKSB7fTtcbiAgb3ZlcnJpZGUgW1wiYmF6XCJdKCkge307XG59Iiwib3B0aW9ucyI6eyJydWxlcyI6e30sImxhbmd1YWdlT3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFGZWF0dXJlcyI6e319LCJwYXJzZXIiOiJAdHlwZXNjcmlwdC1lc2xpbnQvcGFyc2VyIn19fQ==)

**What did you expect to happen?**

No report. `["baz"]` is an override method, so with `ignoreOverrideMethods: true` the method should be ignored, exactly as it is for the non-computed `bar`.

**What actually happened? Please include the actual, raw output from ESLint.**

```
Expected 'this' to be used by class method 'baz'.
```

#### What changes did you make? (Give an overview)

Updated `isIncludedInstanceMethod` to check for `ignoreOverrideMethods` and `ignoreClassesWithImplements` before bailing out early for computed methods.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
