### PR TITLE
fix: quadratic-time regex in `prefer-template`

### DIFF
--- a/lib/rules/prefer-template.js
+++ b/lib/rules/prefer-template.js
@@ -204,7 +204,7 @@ module.exports = {
 				 */
 				return `\`${currentNode.raw
 					.slice(1, -1)
-					.replace(/\\*(\$\{|`)/gu, matched => {
+					.replace(/(?<!\\)\\*(\$\{|`)/gu, matched => {
 						if (matched.lastIndexOf("\\") % 2) {
 							return `\\${matched}`;
 						}

--- a/tests/lib/rules/prefer-template.js
+++ b/tests/lib/rules/prefer-template.js
@@ -408,5 +408,16 @@ ruleTester.run("prefer-template", rule, {
 			output: "`Hello ` + `'world' ${  test}`",
 			errors,
 		},
+
+		/*
+		 * Performance test for handling escape characters.
+		 * A quadratic-time regex would need several minutes,
+		 * thus exceeding the timeout for tests.
+		 */
+		{
+			code: `"${"\\".repeat(1_000_000)}" + test`,
+			output: `\`${"\\".repeat(1_000_000)}\${  test}\``,
+			errors,
+		},
 	],
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:** 24.16.0
- **npm version:** 11.13.0
- **Local ESLint version:** 10.7.0
- **Global ESLint version:** no
- **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

N/A, running tests.

**What did you do? Please include the actual source code causing the issue.**

Added a test case for the `prefer-template` rule:

```js
{
    code: `"${"\\".repeat(1_000_000)}" + test`,
    output: `\`${"\\".repeat(1_000_000)}\${  test}\``,
    errors,
},
```

**What did you expect to happen?**

The test to pass in a reasonable time.

**What actually happened? Please include the actual, raw output from ESLint.**

It takes 7-8 minutes, thus exceeding the timeout.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed a regex in the `prefer-template` rule by adding a negative lookbehind to avoid quadratic time complexity when processing a sequence of backslash characters.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
