### PR TITLE
chore: add missing backticks to `translate-cli-options.js`

### DIFF
--- a/lib/shared/translate-cli-options.js
+++ b/lib/shared/translate-cli-options.js
@@ -60,8 +60,8 @@ async function loadPlugins(importer, pluginNames) {
  * Predicate function for whether or not to apply fixes in quiet mode.
  * If a message is a warning, do not apply a fix.
  * @param {LintMessage} message The lint result.
- * @returns {boolean} True if the lint message is an error (and thus should be
- * autofixed), false otherwise.
+ * @returns {boolean} `true` if the lint message is an error (and thus should be
+ * autofixed), `false` otherwise.
  */
 function quietFixPredicate(message) {
 	return message.severity === 2;
@@ -71,7 +71,7 @@ function quietFixPredicate(message) {
  * Predicate function for whether or not to run a rule in quiet mode.
  * If a rule is set to warning, do not run it.
  * @param {{ ruleId: string; severity: number; }} rule The rule id and severity.
- * @returns {boolean} True if the lint rule should run, false otherwise.
+ * @returns {boolean} `true` if the lint rule should run, `false` otherwise.
  */
 function quietRuleFilter(rule) {
 	return rule.severity === 2;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

added missing backticks around the `true` and `false` values in the JSDoc return
descriptions in `lib/shared/translate-cli-options.js`, for consistency with similar changes in #21091, #19226, and #19313.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
