### PR TITLE
test: add error locations to `no-label-var`

### DIFF
--- a/tests/lib/rules/no-label-var.js
+++ b/tests/lib/rules/no-label-var.js
@@ -29,6 +29,10 @@ ruleTester.run("no-label-var", rule, {
 			errors: [
 				{
 					messageId: "identifierClashWithLabel",
+					line: 1,
+					column: 31,
+					endLine: 1,
+					endColumn: 54,
 				},
 			],
 		},
@@ -37,6 +41,10 @@ ruleTester.run("no-label-var", rule, {
 			errors: [
 				{
 					messageId: "identifierClashWithLabel",
+					line: 1,
+					column: 31,
+					endLine: 1,
+					endColumn: 54,
 				},
 			],
 		},
@@ -45,6 +53,10 @@ ruleTester.run("no-label-var", rule, {
 			errors: [
 				{
 					messageId: "identifierClashWithLabel",
+					line: 1,
+					column: 19,
+					endLine: 1,
+					endColumn: 42,
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: 

Adds missing error location fields to the `no-label-var` rule tests.

Followed the same approach as https://github.com/eslint/eslint/pull/21039.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

The `errors` objects in the `no-label-var` rule tests were missing location information, so a regression where the message is correct but the reported location is wrong would not have been caught.

I added `line`, `column`, `endLine`, and `endColumn` to all three invalid cases.

The expected values were derived from the node the rule actually reports. Since `no-label-var` reports the `LabeledStatement` node itself rather than the label identifier, the expected range covers the entire labeled statement.

Only tests were changed, so there is no impact on the rule's behavior, and all existing tests pass.

#### Is there anything you'd like reviewers to focus on?


<!-- markdownlint-disable-file MD004 -->
