### PR TITLE
docs: fix broken Specify Globals anchor links in rule pages

### DIFF
--- a/docs/src/rules/no-global-assign.md
+++ b/docs/src/rules/no-global-assign.md
@@ -23,7 +23,7 @@ This rule disallows modifications to read-only global variables.
 
 ESLint has the capability to configure global variables as read-only.
 
-See also: [Specify Globals](../use/configure#specify-globals)
+See also: [Specify Globals](../use/configure/language-options#specify-globals)
 
 Examples of **incorrect** code for this rule:
 

--- a/docs/src/rules/no-implicit-globals.md
+++ b/docs/src/rules/no-implicit-globals.md
@@ -116,7 +116,7 @@ This rule also disallows redeclarations of read-only global variables and assign
 
 A read-only global variable can be a built-in ES global (e.g. `Array`), or a global variable defined as `readonly` in the configuration file or in a `/*global */` comment.
 
-See also: [Specify Globals](../use/configure#specify-globals)
+See also: [Specify Globals](../use/configure/language-options#specify-globals)
 
 Examples of **incorrect** code for this rule:
 

--- a/docs/src/rules/no-native-reassign.md
+++ b/docs/src/rules/no-native-reassign.md
@@ -21,7 +21,7 @@ This rule disallows modifications to read-only global variables.
 
 ESLint has the capability to configure global variables as read-only.
 
-See also: [Specify Globals](../use/configure#specify-globals)
+See also: [Specify Globals](../use/configure/language-options#specify-globals)
 
 Examples of **incorrect** code for this rule:
 


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

The `Specify Globals` link should navigate to the section that explains how to specify global variables. However, the current link points to `/use/configure#specify-globals`, and because the `specify-globals` anchor does not exist on that page, it remains at the beginning of the configuration documentation.

The actual `Specify Globals` section is located at `/use/configure/language-options#specify-globals`, so this change updates the link path to ensure that users are taken directly to the correct section when they click the link.

#### Is there anything you'd like reviewers to focus on?

Please verify that the updated links navigate directly to the Specify Globals section.
