### PR TITLE
docs: fix broken Specify Parser Options anchor link

### DIFF
--- a/docs/src/rules/rest-spread-spacing.md
+++ b/docs/src/rules/rest-spread-spacing.md
@@ -55,7 +55,7 @@ This rule aims to enforce consistent spacing between rest and spread operators a
 }
 ```
 
-Please read the user guide's section on [configure parser options](../use/configure/language-options#specify-parser-options) to learn more.
+Please read the user guide's section on [configure language options](../use/configure/language-options#specify-javascript-options) to learn more
 
 ## Options
 

--- a/docs/src/rules/rest-spread-spacing.md
+++ b/docs/src/rules/rest-spread-spacing.md
@@ -55,7 +55,7 @@ This rule aims to enforce consistent spacing between rest and spread operators a
 }
 ```
 
-Please read the user guide's section on [configure parser options](../use/configure#specify-parser-options) to learn more.
+Please read the user guide's section on [configure parser options](../use/configure/language-options#specify-parser-options) to learn more.
 
 ## Options
 

--- a/docs/src/rules/rest-spread-spacing.md
+++ b/docs/src/rules/rest-spread-spacing.md
@@ -55,7 +55,7 @@ This rule aims to enforce consistent spacing between rest and spread operators a
 }
 ```
 
-Please read the user guide's section on [configure language options](../use/configure/language-options#specify-javascript-options) to learn more
+Please read the user guide's section on [configure language options](../use/configure/language-options#specify-javascript-options) to learn more.
 
 ## Options
 


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

The `configure parser options` link should navigate to the `Specify Parser Options` section, which explains how to configure parser options. However, the current link points to `/use/configure#specify-parser-options`, and because the `specify-parser-options` anchor does not exist on that page, users remain at the beginning of the configuration documentation.

The actual `Specify Parser Options` section is located at `/use/configure/language-options#specify-parser-options`, so this change updates the link path to ensure that users are taken directly to the correct section when they click the link.

#### Is there anything you'd like reviewers to focus on?

Please verify that the updated link navigates directly to the `Specify Parser Options` section.
