### PR TITLE
docs: replace quake link

### DIFF
--- a/docs/src/extend/custom-formatters.md
+++ b/docs/src/extend/custom-formatters.md
@@ -220,7 +220,7 @@ In this example, the `your-program-that-reads-json` program can accept the raw J
 
 ### Formatting for Terminals
 
-Modern terminals like [iTerm2](https://www.iterm2.com/) or [Guake](http://guake-project.org/) expect a specific results format to automatically open filenames when they are clicked. Most terminals support this format for that purpose:
+Modern terminals like [iTerm2](https://www.iterm2.com/) or [Guake](http://guake.org/) expect a specific results format to automatically open filenames when they are clicked. Most terminals support this format for that purpose:
 
 ```bash
 file:line:column


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated the broken Guake website link. The previous URL returned a 404 "Vhost unknown" error (see the screenshot below), so I replaced it with `http://guake.org/`.

<img width="482" height="189" alt="image" src="https://github.com/user-attachments/assets/9c662c1c-1024-44ba-b225-8c48e7c4ecda" />


#### Is there anything you'd like reviewers to focus on?

I noticed that both [http://guake.org/](http://guake.org/) and [https://guake.github.io/](https://guake.github.io/) are available. I updated the link to `http://guake.org/`, but I'd appreciate your guidance on which URL should be preferred for the documentation

<!-- markdownlint-disable-file MD004 -->
