### PR TITLE
test: add error locations to `no-proto`

### DIFF
--- a/tests/lib/rules/no-proto.js
+++ b/tests/lib/rules/no-proto.js
@@ -38,6 +38,10 @@ ruleTester.run("no-proto", rule, {
 			errors: [
 				{
 					messageId: "unexpectedProto",
+					line: 1,
+					column: 9,
+					endLine: 1,
+					endColumn: 23,
 				},
 			],
 		},
@@ -46,6 +50,10 @@ ruleTester.run("no-proto", rule, {
 			errors: [
 				{
 					messageId: "unexpectedProto",
+					line: 1,
+					column: 9,
+					endLine: 1,
+					endColumn: 26,
 				},
 			],
 		},
@@ -55,6 +63,10 @@ ruleTester.run("no-proto", rule, {
 			errors: [
 				{
 					messageId: "unexpectedProto",
+					line: 1,
+					column: 9,
+					endLine: 1,
+					endColumn: 26,
 				},
 			],
 		},
@@ -64,6 +76,10 @@ ruleTester.run("no-proto", rule, {
 			errors: [
 				{
 					messageId: "unexpectedProto",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 18,
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: 

Adds missing error location fields to the `no-proto` rule tests.

Followed the same approach as the already-merged https://github.com/eslint/eslint/pull/21109 and https://github.com/eslint/eslint/pull/21098. 

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

The `errors` objects in the `no-proto` rule tests were missing location information, so a regression where the message is correct but the reported location is wrong would not have been caught.

I added `line`, `column`, `endLine`, and `endColumn` to all four invalid cases.

The expected values were derived from the node the rule actually reports. Since `no-proto` reports the `MemberExpression` node, the expected range covers the entire `__proto__` property access.

Only tests were changed, so there is no impact on the rule's behavior, and all existing tests pass.

#### Is there anything you'd like reviewers to focus on?


<!-- markdownlint-disable-file MD004 -->
