### PR TITLE
fix: prevent `no-unreachable-loop` crash when all loop types are ignored

### DIFF
--- a/lib/rules/no-unreachable-loop.js
+++ b/lib/rules/no-unreachable-loop.js
@@ -98,11 +98,15 @@ module.exports = {
 
 	create(context) {
 		const [{ ignore: ignoredLoopTypes }] = context.options;
-		const loopTypesToCheck = getDifference(allLoopTypes, ignoredLoopTypes),
-			loopSelector = loopTypesToCheck.join(","),
-			loopsByTargetSegments = new Map(),
-			loopsToReport = new Set();
+		const loopTypesToCheck = getDifference(allLoopTypes, ignoredLoopTypes);
+		const loopSelector = loopTypesToCheck.join(",");
 
+		if (!loopSelector) {
+			return {};
+		}
+
+		const loopsByTargetSegments = new Map();
+		const loopsToReport = new Set();
 		const codePathSegments = [];
 		let currentCodePathSegments = new Set();
 

--- a/tests/lib/rules/no-unreachable-loop.js
+++ b/tests/lib/rules/no-unreachable-loop.js
@@ -223,6 +223,20 @@ ruleTester.run("no-unreachable-loop", rule, {
 			code: "for (var key in obj) { hasEnumerableProperties = true; break; } for (const a of b) break;",
 			options: [{ ignore: ["ForInStatement", "ForOfStatement"] }],
 		},
+		{
+			code: "while (a) break;",
+			options: [
+				{
+					ignore: [
+						"WhileStatement",
+						"DoWhileStatement",
+						"ForStatement",
+						"ForInStatement",
+						"ForOfStatement",
+					],
+				},
+			],
+		},
 	],
 
 	invalid: [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:** v24.16.0
- **npm version:** v11.13.0
- **Local ESLint version:** v10.7.0
- **Global ESLint version:** no
- **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->

```js
export default [{}];
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint no-unreachable-loop: ["error", { "ignore": ["WhileStatement", "DoWhileStatement", "ForStatement", "ForInStatement", "ForOfStatement"] }] */

while (a) break;
```

[Playground](https://eslint.org/play/#eyJ0ZXh0IjoiLyogZXNsaW50IG5vLXVucmVhY2hhYmxlLWxvb3A6IFtcImVycm9yXCIsIHsgXCJpZ25vcmVcIjogW1wiV2hpbGVTdGF0ZW1lbnRcIiwgXCJEb1doaWxlU3RhdGVtZW50XCIsIFwiRm9yU3RhdGVtZW50XCIsIFwiRm9ySW5TdGF0ZW1lbnRcIiwgXCJGb3JPZlN0YXRlbWVudFwiXSB9XSAqL1xuXG53aGlsZSAoYSkgYnJlYWs7Iiwib3B0aW9ucyI6eyJydWxlcyI6e30sImxhbmd1YWdlT3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFGZWF0dXJlcyI6e319fX19)

**What did you expect to happen?**

The rule should ignore every loop type and produce no errors.

**What actually happened? Please include the actual, raw output from ESLint.**

ESLint crashed:
```
Error: Cannot read properties of undefined (reading 'type')
```

#### What changes did you make? (Give an overview)

Added an early return when all supported loop types are listed in `ignore`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
