### PR TITLE
fix: do not clutter output with "0 errors"

### DIFF
--- a/docs/src/extend/custom-rule-tutorial.md
+++ b/docs/src/extend/custom-rule-tutorial.md
@@ -374,7 +374,7 @@ This produces the following output in the terminal:
 /<path-to-directory>/eslint-custom-rule-example/example.js
   8:11  error  Value other than "bar" assigned to `const foo`. Unexpected value: baz  example/enforce-foo-bar
 
-✖ 1 problem (1 error, 0 warnings)
+✖ 1 problem (1 error)
   1 error and 0 warnings potentially fixable with the `--fix` option.
 ```
 
@@ -464,7 +464,7 @@ This produces the following output in the terminal:
 /<path-to-directory>/eslint-custom-rule-example/example.js
   8:11  error  Value other than "bar" assigned to `const foo`. Unexpected value: baz  example/enforce-foo-bar
 
-✖ 1 problem (1 error, 0 warnings)
+✖ 1 problem (1 error)
   1 error and 0 warnings potentially fixable with the `--fix` option.
 ```
 

--- a/docs/src/use/configure/ignore.md
+++ b/docs/src/use/configure/ignore.md
@@ -210,7 +210,7 @@ You'll see this warning:
 foo.js
   0:0  warning  File ignored because of a matching ignore pattern. Use "--no-ignore" to disable file ignore settings or use "--no-warn-ignored" to suppress this warning.
 
-✖ 1 problem (0 errors, 1 warning)
+✖ 1 problem (1 warning)
 ```
 
 This message occurs because ESLint is unsure if you wanted to actually lint the file or not. As the message indicates, you can use `--no-ignore` to omit using the ignore rules.

--- a/lib/cli-engine/formatters/html.js
+++ b/lib/cli-engine/formatters/html.js
@@ -199,9 +199,17 @@ function renderSummary(totalErrors, totalWarnings) {
 	const totalProblems = totalErrors + totalWarnings;
 	let renderedText = `${totalProblems} ${pluralize("problem", totalProblems)}`;
 
-	if (totalProblems !== 0) {
-		renderedText += ` (${totalErrors} ${pluralize("error", totalErrors)}, ${totalWarnings} ${pluralize("warning", totalWarnings)})`;
+	const parts = [];
+	if (totalErrors !== 0) {
+		parts.push(`${totalErrors} ${pluralize("error", totalErrors)}`);
 	}
+	if (totalWarnings !== 0) {
+		parts.push(`${totalWarnings} ${pluralize("warning", totalWarnings)}`);
+	}
+	if (parts.length > 0) {
+		renderedText += ` (${parts.join(", ")})`;
+	}
+
 	return renderedText;
 }
 

--- a/lib/cli-engine/formatters/stylish.js
+++ b/lib/cli-engine/formatters/stylish.js
@@ -38,6 +38,32 @@ function pluralize(word, count) {
 	return count === 1 ? word : `${word}s`;
 }
 
+/**
+ * Format the " (1 error, 3 warnings)" summary, including leading space
+ * @param {number} errorCount Total errors
+ * @param {number} warningCount Total warnings
+ * @returns {Array} The parts of the formatted strings, pluralized where necessary
+ */
+function summaryParts(errorCount, warningCount) {
+	const result = [];
+	if (errorCount || warningCount) {
+		result.push(" (");
+	}
+	if (errorCount) {
+		result.push(errorCount, pluralize(" error", errorCount));
+	}
+	if (errorCount && warningCount) {
+		result.push(", ");
+	}
+	if (warningCount) {
+		result.push(warningCount, pluralize(" warning", warningCount));
+	}
+	if (errorCount || warningCount) {
+		result.push(")");
+	}
+	return result;
+}
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -118,13 +144,7 @@ module.exports = function (results, data) {
 					"\u2716 ",
 					total,
 					pluralize(" problem", total),
-					" (",
-					errorCount,
-					pluralize(" error", errorCount),
-					", ",
-					warningCount,
-					pluralize(" warning", warningCount),
-					")",
+					...summaryParts(errorCount, warningCount),
 				].join(""),
 			),
 		)}\n`;

--- a/tests/lib/cli-engine/formatters/html.js
+++ b/tests/lib/cli-engine/formatters/html.js
@@ -151,7 +151,7 @@ describe("formatter:html", () => {
 			// Check overview
 			checkOverview($, {
 				bgColor: "bg-2",
-				problems: "1 problem (1 error, 0 warnings)",
+				problems: "1 problem (1 error)",
 			});
 
 			// Check rows
@@ -169,7 +169,7 @@ describe("formatter:html", () => {
 				bgColor: "bg-2",
 				group: "f-0",
 				file: "foo.js",
-				problems: "1 problem (1 error, 0 warnings)",
+				problems: "1 problem (1 error)",
 			});
 			checkContentRow($, $("tr")[1], {
 				group: "f-0",
@@ -188,7 +188,7 @@ describe("formatter:html", () => {
 			// Check overview
 			checkOverview($, {
 				bgColor: "bg-2",
-				problems: "1 problem (1 error, 0 warnings)",
+				problems: "1 problem (1 error)",
 			});
 
 			// Check rows
@@ -206,7 +206,7 @@ describe("formatter:html", () => {
 				bgColor: "bg-2",
 				group: "f-0",
 				file: "foo.js",
-				problems: "1 problem (1 error, 0 warnings)",
+				problems: "1 problem (1 error)",
 			});
 			checkContentRow($, $("tr")[1], {
 				group: "f-0",
@@ -264,7 +264,7 @@ describe("formatter:html", () => {
 			// Check overview
 			checkOverview($, {
 				bgColor: "bg-1",
-				problems: "1 problem (0 errors, 1 warning)",
+				problems: "1 problem (1 warning)",
 			});
 
 			// Check rows
@@ -282,7 +282,7 @@ describe("formatter:html", () => {
 				bgColor: "bg-1",
 				group: "f-0",
 				file: "foo.js",
-				problems: "1 problem (0 errors, 1 warning)",
+				problems: "1 problem (1 warning)",
 			});
 			checkContentRow($, $("tr")[1], {
 				group: "f-0",
@@ -340,7 +340,7 @@ describe("formatter:html", () => {
 			// Check overview
 			checkOverview($, {
 				bgColor: "bg-2",
-				problems: "1 problem (1 error, 0 warnings)",
+				problems: "1 problem (1 error)",
 			});
 
 			// Check rows
@@ -358,7 +358,7 @@ describe("formatter:html", () => {
 				bgColor: "bg-2",
 				group: "f-0",
 				file: "foo.js",
-				problems: "1 problem (1 error, 0 warnings)",
+				problems: "1 problem (1 error)",
 			});
 			checkContentRow($, $("tr")[1], {
 				group: "f-0",
@@ -598,7 +598,7 @@ describe("formatter:html", () => {
 				bgColor: "bg-2",
 				group: "f-0",
 				file: "foo.js",
-				problems: "1 problem (1 error, 0 warnings)",
+				problems: "1 problem (1 error)",
 			});
 			checkContentRow($, $("tr")[1], {
 				group: "f-0",
@@ -611,7 +611,7 @@ describe("formatter:html", () => {
 				bgColor: "bg-1",
 				group: "f-1",
 				file: "bar.js",
-				problems: "1 problem (0 errors, 1 warning)",
+				problems: "1 problem (1 warning)",
 			});
 			checkContentRow($, $("tr")[3], {
 				group: "f-1",
@@ -696,7 +696,7 @@ describe("formatter:html", () => {
 			// Check overview
 			checkOverview($, {
 				bgColor: "bg-1",
-				problems: "2 problems (0 errors, 2 warnings)",
+				problems: "2 problems (2 warnings)",
 			});
 
 			// Check rows
@@ -714,7 +714,7 @@ describe("formatter:html", () => {
 				bgColor: "bg-1",
 				group: "f-0",
 				file: "foo.js",
-				problems: "1 problem (0 errors, 1 warning)",
+				problems: "1 problem (1 warning)",
 			});
 			checkContentRow($, $("tr")[1], {
 				group: "f-0",
@@ -727,7 +727,7 @@ describe("formatter:html", () => {
 				bgColor: "bg-1",
 				group: "f-1",
 				file: "bar.js",
-				problems: "1 problem (0 errors, 1 warning)",
+				problems: "1 problem (1 warning)",
 			});
 			checkContentRow($, $("tr")[3], {
 				group: "f-1",

--- a/tests/lib/cli-engine/formatters/stylish.js
+++ b/tests/lib/cli-engine/formatters/stylish.js
@@ -247,11 +247,11 @@ describe("formatter:stylish", () => {
 
 		it("should return a string in the correct format", () => {
 			const result = util.stripVTControlCharacters(formatter(code));
-			const summary = "\u2716 1 problem (1 error, 0 warnings)";
+			const summary = "\u2716 1 problem (1 error)";
 
 			assert.strictEqual(
 				result,
-				"\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem (1 error, 0 warnings)\n",
+				"\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem (1 error)\n",
 			);
 			assert(util.styleText.calledWith("reset"));
 			assert(util.styleText.neverCalledWithMatch("yellow", summary));
@@ -266,11 +266,11 @@ describe("formatter:stylish", () => {
 
 			it("should return a string in the correct format", () => {
 				const result = util.stripVTControlCharacters(formatter(code));
-				const summary = "\u2716 1 problem (1 error, 0 warnings)";
+				const summary = "\u2716 1 problem (1 error)";
 
 				assert.strictEqual(
 					result,
-					"\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem (1 error, 0 warnings)\n  1 error and 0 warnings potentially fixable with the `--fix` option.\n",
+					"\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem (1 error)\n  1 error and 0 warnings potentially fixable with the `--fix` option.\n",
 				);
 				assert(util.styleText.calledWith("reset"));
 				assert(util.styleText.neverCalledWithMatch("yellow", summary));
@@ -306,11 +306,11 @@ describe("formatter:stylish", () => {
 
 		it("should return a string in the correct format", () => {
 			const result = util.stripVTControlCharacters(formatter(code));
-			const summary = "\u2716 1 problem (0 errors, 1 warning)";
+			const summary = "\u2716 1 problem (1 warning)";
 
 			assert.strictEqual(
 				result,
-				"\nfoo.js\n  5:10  warning  Unexpected foo  foo\n\n\u2716 1 problem (0 errors, 1 warning)\n",
+				"\nfoo.js\n  5:10  warning  Unexpected foo  foo\n\n\u2716 1 problem (1 warning)\n",
 			);
 			assert(util.styleText.calledWith("reset"));
 			assert(util.styleText.calledWith("bold", summary));
@@ -325,11 +325,11 @@ describe("formatter:stylish", () => {
 
 			it("should return a string in the correct format", () => {
 				const result = util.stripVTControlCharacters(formatter(code));
-				const summary = "\u2716 1 problem (0 errors, 1 warning)";
+				const summary = "\u2716 1 problem (1 warning)";
 
 				assert.strictEqual(
 					result,
-					"\nfoo.js\n  5:10  warning  Unexpected foo  foo\n\n\u2716 1 problem (0 errors, 1 warning)\n  0 errors and 1 warning potentially fixable with the `--fix` option.\n",
+					"\nfoo.js\n  5:10  warning  Unexpected foo  foo\n\n\u2716 1 problem (1 warning)\n  0 errors and 1 warning potentially fixable with the `--fix` option.\n",
 				);
 				assert(util.styleText.calledWith("reset"));
 				assert(util.styleText.calledWith("bold", summary));
@@ -365,11 +365,11 @@ describe("formatter:stylish", () => {
 
 		it("should return a string in the correct format (retaining the ' .')", () => {
 			const result = util.stripVTControlCharacters(formatter(code));
-			const summary = "\u2716 1 problem (0 errors, 1 warning)";
+			const summary = "\u2716 1 problem (1 warning)";
 
 			assert.strictEqual(
 				result,
-				"\nfoo.js\n  5:10  warning  Unexpected .  foo\n\n\u2716 1 problem (0 errors, 1 warning)\n",
+				"\nfoo.js\n  5:10  warning  Unexpected .  foo\n\n\u2716 1 problem (1 warning)\n",
 			);
 			assert(util.styleText.calledWith("reset"));
 			assert(util.styleText.calledWith("bold", summary));
@@ -398,11 +398,11 @@ describe("formatter:stylish", () => {
 
 		it("should return a string in the correct format", () => {
 			const result = util.stripVTControlCharacters(formatter(code));
-			const summary = "\u2716 1 problem (1 error, 0 warnings)";
+			const summary = "\u2716 1 problem (1 error)";
 
 			assert.strictEqual(
 				result,
-				"\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem (1 error, 0 warnings)\n",
+				"\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem (1 error)\n",
 			);
 			assert(util.styleText.calledWith("reset"));
 			assert(util.styleText.neverCalledWithMatch("yellow", summary));
@@ -504,11 +504,11 @@ describe("formatter:stylish", () => {
 			});
 
 			const result = util.stripVTControlCharacters(formatter(code));
-			const summary = "\u2716 2 problems (2 errors, 0 warnings)";
+			const summary = "\u2716 2 problems (2 errors)";
 
 			assert.strictEqual(
 				result,
-				"\nfoo.js\n  5:10  error  Unexpected foo  foo\n\nbar.js\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems (2 errors, 0 warnings)\n",
+				"\nfoo.js\n  5:10  error  Unexpected foo  foo\n\nbar.js\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems (2 errors)\n",
 			);
 			assert(util.styleText.calledWith("reset"));
 			assert(util.styleText.neverCalledWithMatch("yellow", summary));
@@ -523,11 +523,11 @@ describe("formatter:stylish", () => {
 			});
 
 			const result = util.stripVTControlCharacters(formatter(code));
-			const summary = "\u2716 2 problems (0 errors, 2 warnings)";
+			const summary = "\u2716 2 problems (2 warnings)";
 
 			assert.strictEqual(
 				result,
-				"\nfoo.js\n  5:10  error  Unexpected foo  foo\n\nbar.js\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems (0 errors, 2 warnings)\n",
+				"\nfoo.js\n  5:10  error  Unexpected foo  foo\n\nbar.js\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems (2 warnings)\n",
 			);
 			assert(util.styleText.calledWith("reset"));
 			assert(util.styleText.neverCalledWithMatch("yellow", summary));
@@ -553,11 +553,11 @@ describe("formatter:stylish", () => {
 
 		it("should return a string without line and column", () => {
 			const result = util.stripVTControlCharacters(formatter(code));
-			const summary = "\u2716 1 problem (1 error, 0 warnings)";
+			const summary = "\u2716 1 problem (1 error)";
 
 			assert.strictEqual(
 				result,
-				"\nfoo.js\n  0:0  error  Couldn't find foo.js\n\n\u2716 1 problem (1 error, 0 warnings)\n",
+				"\nfoo.js\n  0:0  error  Couldn't find foo.js\n\n\u2716 1 problem (1 error)\n",
 			);
 			assert(util.styleText.calledWith("reset"));
 			assert(util.styleText.neverCalledWithMatch("yellow", summary));

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -631,7 +631,7 @@ describe("cli", () => {
 
 					const formattedOutput = log.info.firstCall.args[0];
 
-					assert.include(formattedOutput, "(1 error, 0 warnings)");
+					assert.include(formattedOutput, "(1 error)");
 				});
 
 				it(`should print nothing if there are no errors`, async () => {
@@ -2166,10 +2166,10 @@ describe("cli", () => {
 			});
 
 			[
-				[1, 0, "0 errors, 1 warning"],
-				["warn", 0, "0 errors, 1 warning"],
-				[2, 1, "1 error, 0 warnings"],
-				["error", 1, "1 error, 0 warnings"],
+				[1, 0, "1 warning"],
+				["warn", 0, "1 warning"],
+				[2, 1, "1 error"],
+				["error", 1, "1 error"],
 			].forEach(([setting, status, descriptor]) => {
 				it(`reports when --report-unused-inline-configs ${setting}`, async () => {
 					const exitCode = await cli.execute(

--- a/tests/tools/check-rule-examples.js
+++ b/tests/tools/check-rule-examples.js
@@ -103,7 +103,7 @@ describe("check-rule-examples", () => {
 				'  \x1B[2m154:1\x1B[22m  \x1B[31merror\x1B[39m  "jsx": false is the default and can be omitted\n' +
 				'  \x1B[2m164:4\x1B[22m  \x1B[31merror\x1B[39m  JSX is enabled, but the code block is tagged as "js". Use "jsx" or "tsx"\n' +
 				"\n" +
-				"\x1B[31m\x1B[1m✖ 25 problems (25 errors, 0 warnings)\x1B[22m\x1B[39m\n" +
+				"\x1B[31m\x1B[1m✖ 25 problems (25 errors)\x1B[22m\x1B[39m\n" +
 				"\x1B[0m\n";
 
 			assert.strictEqual(normalizedStderr, expectedStderr);


### PR DESCRIPTION
This addresses a pet peeve of mine, especially in a monorepo with maany libraries the summary likes to print a lot of lines

✖ 1 problem (0 errors, 1 warning)

which makes it hard to search for "error" to find the offending location. Printing that there are no errors does not really add any useful information, I trust eslint will print an error if there is one. Instead, just write

✖ 1 problem (1 warning)

if there are no errors!

<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [X] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

Just skip printing "0 errors" if there are no errors

#### What changes did you make? (Give an overview)

Removed the "0 errors" text from the output if there are no errors, so that I can grep for "error" and actually find the errors and not the non-errors.

#### Is there anything you'd like reviewers to focus on?

This is a trivial cli output formatting change