### PR TITLE
fix: detect undeclared global objects in no-restricted-globals

### DIFF
--- a/lib/rules/no-restricted-globals.js
+++ b/lib/rules/no-restricted-globals.js
@@ -220,11 +220,22 @@ module.exports = {
 						globalObjectName,
 					);
 
-					if (!variable) {
-						return;
+					const references = [];
+					if (variable) {
+						references.push(...variable.references);
 					}
 
-					variable.references.forEach(reference => {
+					/*
+					 * Undeclared global objects (e.g. `window`, `global`) only
+					 * exist as unresolved "through" references, so they are
+					 * not captured by the lookup above.
+					 */
+					for (const reference of globalScope.through) {
+						if (reference.identifier.name === globalObjectName) {
+							references.push(reference);
+						}
+					}
+					references.forEach(reference => {
 						const identifier = reference.identifier;
 						let parent = identifier.parent;
 

--- a/tests/lib/rules/no-restricted-globals.js
+++ b/tests/lib/rules/no-restricted-globals.js
@@ -94,69 +94,6 @@ ruleTester.run("no-restricted-globals", rule, {
 			],
 		},
 		{
-			code: "window.foo()",
-			options: [{ globals: ["foo"] }],
-			languageOptions: { globals: globals.browser },
-		},
-		{
-			code: "self.foo()",
-			options: [{ globals: ["foo"] }],
-			languageOptions: { globals: globals.browser },
-		},
-		{
-			code: "globalThis.foo()",
-			options: [{ globals: ["foo"] }],
-			languageOptions: { ecmaVersion: 2020 },
-		},
-		{
-			code: "myGlobal.foo()",
-			options: [
-				{
-					globals: ["foo"],
-					globalObjects: ["myGlobal"],
-				},
-			],
-			languageOptions: { globals: { myGlobal: "readonly" } },
-		},
-		{
-			code: "window.foo()",
-			options: [
-				{
-					globals: ["foo"],
-					checkGlobalObject: true,
-				},
-			],
-		},
-		{
-			code: "self.foo()",
-			options: [
-				{
-					globals: ["foo"],
-					checkGlobalObject: true,
-				},
-			],
-		},
-		{
-			code: "globalThis.foo()",
-			options: [
-				{
-					globals: ["foo"],
-					checkGlobalObject: true,
-				},
-			],
-			languageOptions: { ecmaVersion: 6 },
-		},
-		{
-			code: "myGlobal.foo()",
-			options: [
-				{
-					globals: ["foo"],
-					checkGlobalObject: true,
-					globalObjects: ["myGlobal"],
-				},
-			],
-		},
-		{
 			code: "otherGlobal.foo()",
 			options: [
 				{
@@ -946,6 +883,89 @@ ruleTester.run("no-restricted-globals", rule, {
 				{
 					messageId: "defaultMessage",
 					data: { name: "foo" },
+				},
+			],
+		},
+		{
+			code: "window.foo()",
+			options: [{ globals: ["foo"], checkGlobalObject: true }],
+			errors: [
+				{
+					messageId: "defaultMessage",
+					data: { name: "foo" },
+				},
+			],
+		},
+		{
+			code: "self.foo()",
+			options: [{ globals: ["foo"], checkGlobalObject: true }],
+			errors: [
+				{
+					messageId: "defaultMessage",
+					data: { name: "foo" },
+				},
+			],
+		},
+		{
+			code: "globalThis.foo()",
+			options: [{ globals: ["foo"], checkGlobalObject: true }],
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "defaultMessage",
+					data: { name: "foo" },
+				},
+			],
+		},
+		{
+			code: "myGlobal.foo()",
+			options: [
+				{
+					globals: ["foo"],
+					checkGlobalObject: true,
+					globalObjects: ["myGlobal"],
+				},
+			],
+			errors: [
+				{
+					messageId: "defaultMessage",
+					data: { name: "foo" },
+				},
+			],
+		},
+		{
+			code: "global.foo()",
+			options: [
+				{
+					globals: ["foo"],
+					checkGlobalObject: true,
+					globalObjects: ["global"],
+				},
+			],
+			errors: [
+				{
+					messageId: "defaultMessage",
+					data: { name: "foo" },
+				},
+			],
+		},
+		{
+			code: "global.foo(); window.bar()",
+			options: [
+				{
+					globals: ["foo", "bar"],
+					checkGlobalObject: true,
+					globalObjects: ["global"],
+				},
+			],
+			errors: [
+				{
+					messageId: "defaultMessage",
+					data: { name: "foo" },
+				},
+				{
+					messageId: "defaultMessage",
+					data: { name: "bar" },
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [X] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))

#### What changes did you make? (Give an overview)

When `checkGlobalObject` is enabled, restricted globals accessed through a global object (e.g. `window.foo`, `global.foo`) were only reported when that global object was declared via `languageOptions.globals`. Undeclared global objects (`window`, `self`, `global`, `globalThis`, or a user-provided `globalObjects` entry) exist only as unresolved "through" references, so `astUtils.getVariableByName` returned `null` and the reference was skipped.

The rule now also walks `globalScope.through` for references whose identifier name matches a configured global object name, and reports them.

Fixes #21121

#### Is there anything you'd like reviewers to focus on?

None.
