### PR TITLE
fix: escape reserved characters in rule id in `html` formatter

### DIFF
--- a/lib/cli-engine/formatters/html.js
+++ b/lib/cli-engine/formatters/html.js
@@ -244,7 +244,7 @@ function messageTemplate(it) {
     <td class="clr-${severityNumber}">${severityName}</td>
     <td>${encodeHTML(message)}</td>
     <td>
-        <a href="${ruleUrl ? ruleUrl : ""}" target="_blank" rel="noopener noreferrer">${ruleId ? ruleId : ""}</a>
+        <a href="${ruleUrl ? ruleUrl : ""}" target="_blank" rel="noopener noreferrer">${encodeHTML(ruleId)}</a>
     </td>
 </tr>
 `.trimStart();

--- a/tests/lib/cli-engine/formatters/html.js
+++ b/tests/lib/cli-engine/formatters/html.js
@@ -792,6 +792,58 @@ describe("formatter:html", () => {
 		});
 	});
 
+	describe("when passing a single message with special characters in the rule id", () => {
+		const rulesMeta = {
+			"<&>": {
+				type: "problem",
+
+				docs: {
+					description:
+						"This is a rule with special characters in its id",
+					recommended: true,
+					url: "https://example.com/some-rule",
+				},
+
+				fixable: "code",
+
+				messages: {
+					message1: "This is a message for rule '<&>'.",
+				},
+			},
+		};
+		const code = {
+			results: [
+				{
+					filePath: "foo.js",
+					errorCount: 1,
+					warningCount: 0,
+					messages: [
+						{
+							message: "Unexpected foo.",
+							severity: 2,
+							line: 5,
+							column: 10,
+							ruleId: "<&>",
+							source: "foo",
+						},
+					],
+				},
+			],
+			rulesMeta,
+		};
+
+		it("should escape the rule id", () => {
+			const result = formatter(code.results, { rulesMeta });
+			const $ = cheerio.load(result);
+
+			assert.strictEqual(
+				$("td").eq(3).html().trim(),
+				'<a href="https://example.com/some-rule" target="_blank" rel="noopener noreferrer">&lt;&amp;&gt;</a>',
+				"Check that rule id is escaped correctly",
+			);
+		});
+	});
+
 	describe("when passing a single message with no rule id or message", () => {
 		const code = [
 			{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment (`npx eslint --env-info`):**

Node version: v24.18.0
npm version: v11.16.0
Local ESLint version: v10.7.0 (Currently used)
Global ESLint version: v10.7.0
Operating System: darwin 25.5.0

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

no config file

**What did you do? Please include the actual source code causing the issue.**

```js
import { ESLint } from "eslint";
import { writeFile } from "node:fs/promises";

const eslint = new ESLint({ overrideConfigFile: true });

const results = await eslint.lintText(
  "/* eslint-disable '<img src=x onerror=alert(1)>' */\nconst x = 1;\n",
  { filePath: "input.js" }
);

const formatter = await eslint.loadFormatter("html");
const html = await formatter.format(results);

await writeFile("eslint-report.html", html);
```

This issue was initially reported as a security vulnerability, but under our [security policy](https://github.com/eslint/eslint/security/policy), it does not qualify as one.

**What did you expect to happen?**

Some special HTML characters like `<`, `>` and `&` are allowed for rule ids, and so they should be escaped in the HTML output.

**What actually happened? Please include the actual, raw output from ESLint.**

Special HTML characters in rule ids are not escaped, which can produce invalid output and allows for HTML injection.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR makes sure that rule ids are escaped in the output of the `html` formatter.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
