### PR TITLE
fix: detect loop condition updates in arrow and function expressions

### DIFF
--- a/lib/rules/no-unmodified-loop-condition.js
+++ b/lib/rules/no-unmodified-loop-condition.js
@@ -108,18 +108,46 @@ const isInLoop = {
 	},
 };
 
+const FUNCTION_PATTERN = /^(?:ArrowFunction|Function)Expression$/u;
+
 /**
- * Gets the function which encloses a given reference.
- * This supports only FunctionDeclaration.
+ * Gets the name and scope of a callable that encloses a given reference.
+ * Supports FunctionDeclaration and function/arrow expressions bound to a variable.
  * @param {Reference} reference A reference to get.
- * @returns {ASTNode|null} The function node or null.
+ * @returns {{ name: string, scope: import("eslint-scope").Scope } | null} The callable info or null.
  */
-function getEncloseFunctionDeclaration(reference) {
+function getEnclosingCallable(reference) {
 	let node = reference.identifier;
 
 	while (node) {
 		if (node.type === "FunctionDeclaration") {
-			return node.id ? node : null;
+			return node.id
+				? { name: node.id.name, scope: reference.from.upper }
+				: null;
+		}
+
+		if (FUNCTION_PATTERN.test(node.type)) {
+			const parent = node.parent;
+
+			if (
+				parent.type === "VariableDeclarator" &&
+				parent.id.type === "Identifier"
+			) {
+				return { name: parent.id.name, scope: reference.from.upper };
+			}
+
+			if (
+				parent.type === "AssignmentExpression" &&
+				parent.left.type === "Identifier"
+			) {
+				return { name: parent.left.name, scope: reference.from.upper };
+			}
+
+			if (node.id) {
+				return { name: node.id.name, scope: reference.from.upper };
+			}
+
+			return null;
 		}
 
 		node = node.parent;
@@ -143,16 +171,13 @@ function hasModifierInLoop(condition, modifier) {
 		return true;
 	}
 
-	const funcNode = getEncloseFunctionDeclaration(modifier);
+	const callable = getEnclosingCallable(modifier);
 
-	if (!funcNode) {
+	if (!callable) {
 		return false;
 	}
 
-	const funcVar = astUtils.getVariableByName(
-		modifier.from.upper,
-		funcNode.id.name,
-	);
+	const funcVar = astUtils.getVariableByName(callable.scope, callable.name);
 
 	return Boolean(funcVar && funcVar.references.some(condition.isInLoop));
 }

--- a/tests/lib/rules/no-unmodified-loop-condition.js
+++ b/tests/lib/rules/no-unmodified-loop-condition.js
@@ -47,6 +47,18 @@ ruleTester.run("no-unmodified-loop-condition", rule, {
 		},
 		"var foo = 0; while (foo.ok) { }",
 		"var foo = 0; while (foo) { update(); } function update() { ++foo; }",
+		{
+			code: "let flag = false; const cb = () => { flag = true; }; while (flag === false) { cb(); }",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "var foo = 0; while (foo) { update(); } var update = function() { ++foo; };",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "var foo = 0; while (foo) { update(); } var update = function namedUpdate() { ++foo; };",
+			languageOptions: { ecmaVersion: 6 },
+		},
 		"var foo = 0, bar = 9; while (foo < bar) { foo += 1; }",
 		"var foo = 0, bar = 1, baz = 2; while (foo ? bar : baz) { foo += 1; }",
 		"var foo = 0, bar = 0; while (foo && bar) { ++foo; ++bar; }",


### PR DESCRIPTION
## Summary

- Extends `no-unmodified-loop-condition` so loop variables modified inside called arrow or function expressions are treated the same as function declarations
- Adds regression tests for arrow functions, function expressions, and named function expressions

Fixes #21085

## Test plan

- [x] `npm test -- tests/lib/rules/no-unmodified-loop-condition.js`
- [x] Verified the issue repro from #21085 no longer reports a false positive