### PR TITLE
ci: add `triage:no` label to Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
           interval: "weekly"
       commit-message:
           prefix: "ci"
+      labels:
+          - "dependencies"
+          - "github_actions"
+          - "triage:no"


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR adds the `triage:no` label to Dependabot’s GitHub Actions updates to follow the same convention used by Renovate (https://github.com/eslint/workflows/blob/main/.github/renovate/base.json5#L8).

I noticed this inconsistency while looking into the reason in the Discord team channel: https://discord.com/channels/688543509199716507/688770853588172860/1529946622077833456

The default labels Dependabot adds automatically are no longer applied when using a custom `labels` field, so I added the ones that had been applied before.

#### Is there anything you'd like reviewers to focus on?

References:

- dependabot `labels` field: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#labels--
- renovate setup in `workflows` repository: https://github.com/eslint/workflows/blob/main/.github/renovate/base.json5#L8

<!-- markdownlint-disable-file MD004 -->
