### PR TITLE
chore: add missing backticks in JSDoc

### DIFF
--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -245,7 +245,7 @@ function normalizeLanguageName(languageName) {
  * @param {string} configLanguageName The normalized language name from the config (e.g., "js/js").
  * @param {Array<string>} validPluginNames The valid plugin name aliases for the config's plugin
  *   (normalized plugin name plus its `meta.namespace` if defined).
- * @returns {boolean} True if the rule supports the language, false otherwise.
+ * @returns {boolean} `true` if the rule supports the language, `false` otherwise.
  */
 function doesRuleSupportLanguage(
 	ruleLangs,
@@ -404,7 +404,7 @@ function languageOptionsToJSON(languageOptions, objectKey = "languageOptions") {
  * Gets or creates a validator for a rule.
  * @param {Object} rule The rule to get a validator for.
  * @param {string} ruleId The ID of the rule (for error reporting).
- * @returns {Function|null} A validation function or null if no validation is needed.
+ * @returns {Function|null} A validation function or `null` if no validation is needed.
  * @throws {InvalidRuleOptionsSchemaError} If a rule's `meta.schema` is invalid.
  */
 function getOrCreateValidator(rule, ruleId) {

--- a/lib/languages/js/index.js
+++ b/lib/languages/js/index.js
@@ -157,7 +157,7 @@ module.exports = {
 	 * @param {string} className The class name to check.
 	 * @param {ASTNode} node The node to check.
 	 * @param {Array<ASTNode>} ancestry The ancestry of the node.
-	 * @returns {boolean} True if there's a match, false if not.
+	 * @returns {boolean} `true` if there's a match, `false` if not.
 	 * @throws {Error} When an unknown class name is passed.
 	 */
 	matchesSelectorClass(className, node, ancestry) {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->


<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
 I added missing backticks around literals in the JSDoc comments in `lib/languages/js/index.js` and `lib/config/config.js`.
Similar to #19226 and #19313.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
