### PR TITLE
test: add error locations to `require-await`

### DIFF
--- a/tests/lib/rules/require-await.js
+++ b/tests/lib/rules/require-await.js
@@ -111,6 +111,10 @@ ruleTester.run("require-await", rule, {
 				{
 					messageId: "missingAwait",
 					data: { name: "Async function 'foo'" },
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 19,
 					suggestions: [
 						{
 							output: "function foo() { doSomething() }",
@@ -126,6 +130,10 @@ ruleTester.run("require-await", rule, {
 				{
 					messageId: "missingAwait",
 					data: { name: "Async function" },
+					line: 1,
+					column: 2,
+					endLine: 1,
+					endColumn: 16,
 					suggestions: [
 						{
 							output: "(function() { doSomething() })",
@@ -141,6 +149,10 @@ ruleTester.run("require-await", rule, {
 				{
 					messageId: "missingAwait",
 					data: { name: "Async arrow function" },
+					line: 1,
+					column: 10,
+					endLine: 1,
+					endColumn: 12,
 					suggestions: [
 						{
 							output: "() => { doSomething() }",
@@ -156,6 +168,10 @@ ruleTester.run("require-await", rule, {
 				{
 					messageId: "missingAwait",
 					data: { name: "Async arrow function" },
+					line: 1,
+					column: 10,
+					endLine: 1,
+					endColumn: 12,
 					suggestions: [
 						{
 							output: "() => doSomething()",
@@ -171,6 +187,10 @@ ruleTester.run("require-await", rule, {
 				{
 					messageId: "missingAwait",
 					data: { name: "Async method 'foo'" },
+					line: 1,
+					column: 4,
+					endLine: 1,
+					endColumn: 13,
 					suggestions: [
 						{
 							output: "({ foo() { doSomething() } })",
@@ -186,6 +206,10 @@ ruleTester.run("require-await", rule, {
 				{
 					messageId: "missingAwait",
 					data: { name: "Async method 'foo'" },
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 20,
 					suggestions: [
 						{
 							output: "class A { foo() { doSomething() } }",
@@ -201,6 +225,10 @@ ruleTester.run("require-await", rule, {
 				{
 					messageId: "missingAwait",
 					data: { name: "Async method 'foo'" },
+					line: 1,
+					column: 10,
+					endLine: 1,
+					endColumn: 19,
 					suggestions: [
 						{
 							output: "(class { foo() { doSomething() } })",
@@ -216,6 +244,10 @@ ruleTester.run("require-await", rule, {
 				{
 					messageId: "missingAwait",
 					data: { name: "Async method ''" },
+					line: 1,
+					column: 10,
+					endLine: 1,
+					endColumn: 18,
 					suggestions: [
 						{
 							output: "(class { ''() { doSomething() } })",
@@ -231,6 +263,10 @@ ruleTester.run("require-await", rule, {
 				{
 					messageId: "missingAwait",
 					data: { name: "Async function 'foo'" },
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 19,
 					suggestions: [
 						{
 							output: "function foo() { async () => { await doSomething() } }",
@@ -246,6 +282,10 @@ ruleTester.run("require-await", rule, {
 				{
 					messageId: "missingAwait",
 					data: { name: "Async arrow function" },
+					line: 1,
+					column: 40,
+					endLine: 1,
+					endColumn: 42,
 					suggestions: [
 						{
 							output: "async function foo() { await (() => { doSomething() }) }",
@@ -261,6 +301,10 @@ ruleTester.run("require-await", rule, {
 				{
 					messageId: "missingAwait",
 					data: { name: "Async method 'async'" },
+					line: 1,
+					column: 15,
+					endLine: 1,
+					endColumn: 40,
 					suggestions: [
 						{
 							output: "const obj = { async: function foo() { bar(); } }",
@@ -276,6 +320,10 @@ ruleTester.run("require-await", rule, {
 				{
 					messageId: "missingAwait",
 					data: { name: "Async function 'foo'" },
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 33,
 					suggestions: [
 						{
 							output: "/* test */ function foo() { doSomething() }",
@@ -295,6 +343,10 @@ ruleTester.run("require-await", rule, {
 				{
 					messageId: "missingAwait",
 					data: { name: "Async method" },
+					line: 3,
+					column: 17,
+					endLine: 3,
+					endColumn: 26,
 					suggestions: [
 						{
 							output: `class A {
@@ -317,6 +369,10 @@ ruleTester.run("require-await", rule, {
 				{
 					messageId: "missingAwait",
 					data: { name: "Async method" },
+					line: 3,
+					column: 17,
+					endLine: 3,
+					endColumn: 26,
 					suggestions: [
 						{
 							output: `class A {
@@ -339,6 +395,10 @@ ruleTester.run("require-await", rule, {
 				{
 					messageId: "missingAwait",
 					data: { name: "Async method 'in'" },
+					line: 3,
+					column: 17,
+					endLine: 3,
+					endColumn: 25,
 					suggestions: [
 						{
 							output: `class A {
@@ -360,6 +420,10 @@ ruleTester.run("require-await", rule, {
 				{
 					messageId: "missingAwait",
 					data: { name: "Async method 'in'" },
+					line: 3,
+					column: 17,
+					endLine: 3,
+					endColumn: 25,
 					suggestions: [
 						{
 							output: `const obj = {
@@ -381,6 +445,10 @@ ruleTester.run("require-await", rule, {
 				{
 					messageId: "missingAwait",
 					data: { name: "Async arrow function" },
+					line: 2,
+					column: 26,
+					endLine: 2,
+					endColumn: 28,
 					suggestions: [
 						{
 							output: `foo
@@ -402,6 +470,10 @@ ruleTester.run("require-await", rule, {
 				{
 					messageId: "missingAwait",
 					data: { name: "Async method" },
+					line: 3,
+					column: 17,
+					endLine: 3,
+					endColumn: 29,
 					suggestions: [
 						{
 							output: `class A {
@@ -423,6 +495,10 @@ ruleTester.run("require-await", rule, {
 				{
 					messageId: "missingAwait",
 					data: { name: "Async function 'run'" },
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 19,
 					suggestions: [
 						{
 							output: "function run() { using resource = getResource(); }",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: Improve existing tests (add error location assertions)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Added missing `line`, `column`, `endLine`, and `endColumn` properties to the error objects in the invalid test cases of `require-await`.

**For context:**
This rule computes its report location via the shared `getFunctionHeadLoc()` helper. It was the last of the helper's 13 consumers without location assertions in its tests, so a regression in the computed location would currently go unnoticed.

#### Is there anything you'd like reviewers to focus on?
no
<!-- markdownlint-disable-file MD004 -->
