### PR TITLE
test: add error locations to `no-undef`

### DIFF
--- a/tests/lib/rules/no-undef.js
+++ b/tests/lib/rules/no-undef.js
@@ -269,6 +269,10 @@ ruleTester.run("no-undef", rule, {
 				{
 					messageId: "undef",
 					data: { name: "a" },
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 2,
 				},
 			],
 		},
@@ -279,6 +283,10 @@ ruleTester.run("no-undef", rule, {
 				{
 					messageId: "undef",
 					data: { name: "anUndefinedVar" },
+					line: 1,
+					column: 12,
+					endLine: 1,
+					endColumn: 26,
 				},
 			],
 		},
@@ -288,6 +296,10 @@ ruleTester.run("no-undef", rule, {
 				{
 					messageId: "undef",
 					data: { name: "b" },
+					line: 1,
+					column: 9,
+					endLine: 1,
+					endColumn: 10,
 				},
 			],
 		},
@@ -297,6 +309,10 @@ ruleTester.run("no-undef", rule, {
 				{
 					messageId: "undef",
 					data: { name: "b" },
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 17,
 				},
 			],
 		},
@@ -306,6 +322,10 @@ ruleTester.run("no-undef", rule, {
 				{
 					messageId: "undef",
 					data: { name: "window" },
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 7,
 				},
 			],
 		},
@@ -315,6 +335,10 @@ ruleTester.run("no-undef", rule, {
 				{
 					messageId: "undef",
 					data: { name: "Intl" },
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 5,
 				},
 			],
 		},
@@ -324,6 +348,10 @@ ruleTester.run("no-undef", rule, {
 				{
 					messageId: "undef",
 					data: { name: "require" },
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 8,
 				},
 			],
 		},
@@ -333,7 +361,16 @@ ruleTester.run("no-undef", rule, {
 				ecmaVersion: 6,
 				parserOptions: { ecmaFeatures: { jsx: true } },
 			},
-			errors: [{ messageId: "undef", data: { name: "a" } }],
+			errors: [
+				{
+					messageId: "undef",
+					data: { name: "a" },
+					line: 1,
+					column: 36,
+					endLine: 1,
+					endColumn: 37,
+				},
+			],
 		},
 		{
 			code: "var React, App; React.render(<App attr={a} />);",
@@ -341,29 +378,79 @@ ruleTester.run("no-undef", rule, {
 				ecmaVersion: 6,
 				parserOptions: { ecmaFeatures: { jsx: true } },
 			},
-			errors: [{ messageId: "undef", data: { name: "a" } }],
+			errors: [
+				{
+					messageId: "undef",
+					data: { name: "a" },
+					line: 1,
+					column: 41,
+					endLine: 1,
+					endColumn: 42,
+				},
+			],
 		},
 		{
 			code: "[a] = [0];",
 			languageOptions: { ecmaVersion: 6 },
-			errors: [{ messageId: "undef", data: { name: "a" } }],
+			errors: [
+				{
+					messageId: "undef",
+					data: { name: "a" },
+					line: 1,
+					column: 2,
+					endLine: 1,
+					endColumn: 3,
+				},
+			],
 		},
 		{
 			code: "({a} = {});",
 			languageOptions: { ecmaVersion: 6 },
-			errors: [{ messageId: "undef", data: { name: "a" } }],
+			errors: [
+				{
+					messageId: "undef",
+					data: { name: "a" },
+					line: 1,
+					column: 3,
+					endLine: 1,
+					endColumn: 4,
+				},
+			],
 		},
 		{
 			code: "({b: a} = {});",
 			languageOptions: { ecmaVersion: 6 },
-			errors: [{ messageId: "undef", data: { name: "a" } }],
+			errors: [
+				{
+					messageId: "undef",
+					data: { name: "a" },
+					line: 1,
+					column: 6,
+					endLine: 1,
+					endColumn: 7,
+				},
+			],
 		},
 		{
 			code: "[obj.a, obj.b] = [0, 1];",
 			languageOptions: { ecmaVersion: 6 },
 			errors: [
-				{ messageId: "undef", data: { name: "obj" } },
-				{ messageId: "undef", data: { name: "obj" } },
+				{
+					messageId: "undef",
+					data: { name: "obj" },
+					line: 1,
+					column: 2,
+					endLine: 1,
+					endColumn: 5,
+				},
+				{
+					messageId: "undef",
+					data: { name: "obj" },
+					line: 1,
+					column: 9,
+					endLine: 1,
+					endColumn: 12,
+				},
 			],
 		},
 
@@ -373,7 +460,16 @@ ruleTester.run("no-undef", rule, {
 			languageOptions: {
 				ecmaVersion: 2018,
 			},
-			errors: [{ messageId: "undef", data: { name: "b" } }],
+			errors: [
+				{
+					messageId: "undef",
+					data: { name: "b" },
+					line: 1,
+					column: 28,
+					endLine: 1,
+					endColumn: 29,
+				},
+			],
 		},
 
 		// class static blocks
@@ -382,91 +478,208 @@ ruleTester.run("no-undef", rule, {
 			languageOptions: {
 				ecmaVersion: 2022,
 			},
-			errors: [{ messageId: "undef", data: { name: "a" } }],
+			errors: [
+				{
+					messageId: "undef",
+					data: { name: "a" },
+					line: 1,
+					column: 20,
+					endLine: 1,
+					endColumn: 21,
+				},
+			],
 		},
 		{
 			code: "class C { static { { let a; } a; } }",
 			languageOptions: {
 				ecmaVersion: 2022,
 			},
-			errors: [{ messageId: "undef", data: { name: "a" }, column: 31 }],
+			errors: [
+				{
+					messageId: "undef",
+					data: { name: "a" },
+					line: 1,
+					column: 31,
+					endLine: 1,
+					endColumn: 32,
+				},
+			],
 		},
 		{
 			code: "class C { static { { function a() {} } a; } }",
 			languageOptions: {
 				ecmaVersion: 2022,
 			},
-			errors: [{ messageId: "undef", data: { name: "a" }, column: 40 }],
+			errors: [
+				{
+					messageId: "undef",
+					data: { name: "a" },
+					line: 1,
+					column: 40,
+					endLine: 1,
+					endColumn: 41,
+				},
+			],
 		},
 		{
 			code: "class C { static { function foo() { var a; }  a; } }",
 			languageOptions: {
 				ecmaVersion: 2022,
 			},
-			errors: [{ messageId: "undef", data: { name: "a" }, column: 47 }],
+			errors: [
+				{
+					messageId: "undef",
+					data: { name: "a" },
+					line: 1,
+					column: 47,
+					endLine: 1,
+					endColumn: 48,
+				},
+			],
 		},
 		{
 			code: "class C { static { var a; } static { a; } }",
 			languageOptions: {
 				ecmaVersion: 2022,
 			},
-			errors: [{ messageId: "undef", data: { name: "a" }, column: 38 }],
+			errors: [
+				{
+					messageId: "undef",
+					data: { name: "a" },
+					line: 1,
+					column: 38,
+					endLine: 1,
+					endColumn: 39,
+				},
+			],
 		},
 		{
 			code: "class C { static { let a; } static { a; } }",
 			languageOptions: {
 				ecmaVersion: 2022,
 			},
-			errors: [{ messageId: "undef", data: { name: "a" }, column: 38 }],
+			errors: [
+				{
+					messageId: "undef",
+					data: { name: "a" },
+					line: 1,
+					column: 38,
+					endLine: 1,
+					endColumn: 39,
+				},
+			],
 		},
 		{
 			code: "class C { static { function a(){} } static { a; } }",
 			languageOptions: {
 				ecmaVersion: 2022,
 			},
-			errors: [{ messageId: "undef", data: { name: "a" }, column: 46 }],
+			errors: [
+				{
+					messageId: "undef",
+					data: { name: "a" },
+					line: 1,
+					column: 46,
+					endLine: 1,
+					endColumn: 47,
+				},
+			],
 		},
 		{
 			code: "class C { static { var a; } foo() { a; } }",
 			languageOptions: {
 				ecmaVersion: 2022,
 			},
-			errors: [{ messageId: "undef", data: { name: "a" }, column: 37 }],
+			errors: [
+				{
+					messageId: "undef",
+					data: { name: "a" },
+					line: 1,
+					column: 37,
+					endLine: 1,
+					endColumn: 38,
+				},
+			],
 		},
 		{
 			code: "class C { static { let a; } foo() { a; } }",
 			languageOptions: {
 				ecmaVersion: 2022,
 			},
-			errors: [{ messageId: "undef", data: { name: "a" }, column: 37 }],
+			errors: [
+				{
+					messageId: "undef",
+					data: { name: "a" },
+					line: 1,
+					column: 37,
+					endLine: 1,
+					endColumn: 38,
+				},
+			],
 		},
 		{
 			code: "class C { static { var a; } [a]; }",
 			languageOptions: {
 				ecmaVersion: 2022,
 			},
-			errors: [{ messageId: "undef", data: { name: "a" }, column: 30 }],
+			errors: [
+				{
+					messageId: "undef",
+					data: { name: "a" },
+					line: 1,
+					column: 30,
+					endLine: 1,
+					endColumn: 31,
+				},
+			],
 		},
 		{
 			code: "class C { static { let a; } [a]; }",
 			languageOptions: {
 				ecmaVersion: 2022,
 			},
-			errors: [{ messageId: "undef", data: { name: "a" }, column: 30 }],
+			errors: [
+				{
+					messageId: "undef",
+					data: { name: "a" },
+					line: 1,
+					column: 30,
+					endLine: 1,
+					endColumn: 31,
+				},
+			],
 		},
 		{
 			code: "class C { static { function a() {} } [a]; }",
 			languageOptions: {
 				ecmaVersion: 2022,
 			},
-			errors: [{ messageId: "undef", data: { name: "a" }, column: 39 }],
+			errors: [
+				{
+					messageId: "undef",
+					data: { name: "a" },
+					line: 1,
+					column: 39,
+					endLine: 1,
+					endColumn: 40,
+				},
+			],
 		},
 		{
 			code: "class C { static { var a; } } a;",
 			languageOptions: {
 				ecmaVersion: 2022,
 			},
-			errors: [{ messageId: "undef", data: { name: "a" }, column: 31 }],
+			errors: [
+				{
+					messageId: "undef",
+					data: { name: "a" },
+					line: 1,
+					column: 31,
+					endLine: 1,
+					endColumn: 32,
+				},
+			],
 		},
 		{
 			code: "<App />;",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: Adds location assertions to existing rule tests to improve coverage

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Some of the rule tests omit part of the location information (`line`, `column`, `endLine`, `endColumn`) in their `errors` assertions. Because of this, a regression that still reports the correct error but at the wrong location could slip through unnoticed. To help catch cases like that, I've filled in the missing location fields in the invalid test cases for `no-undef`.

#### Is there anything you'd like reviewers to focus on?
Nothing in particular.
<!-- markdownlint-disable-file MD004 -->
