### PR TITLE
fix: treat imports with different attributes as distinct modules

### DIFF
--- a/lib/rules/no-duplicate-imports.js
+++ b/lib/rules/no-duplicate-imports.js
@@ -158,7 +158,31 @@ function getNodesByDeclarationType(nodes, type) {
  */
 function getModule(node) {
 	if (node && node.source && node.source.value) {
-		return node.source.value.trim();
+		const moduleName = node.source.value.trim();
+
+		/*
+		 * If the import has attributes, include them in the module key
+		 * so that imports from the same module with different attributes
+		 * are not treated as duplicates (e.g., `with { type: "json" }`
+		 * vs `with { type: "text" }`).
+		 */
+		if (node.attributes && node.attributes.length > 0) {
+			const attributesString = node.attributes
+				.map(attribute => {
+					const key =
+						attribute.key.type === "Identifier"
+							? attribute.key.name
+							: attribute.key.value;
+
+					return `${key}=${attribute.value.value}`;
+				})
+				.sort()
+				.join(",");
+
+			return `${moduleName} with {${attributesString}}`;
+		}
+
+		return moduleName;
 	}
 	return "";
 }

--- a/lib/types/rules.d.ts
+++ b/lib/types/rules.d.ts
@@ -2380,6 +2380,7 @@ export interface ESLintRules extends Linter.RulesRecord {
 	 * @since 2.5.0
 	 * @see https://eslint.org/docs/latest/rules/no-duplicate-imports
 	 */
+    
 	"no-duplicate-imports": Linter.RuleEntry<
 		[
 			Partial<{

--- a/tests/lib/rules/no-duplicate-imports.js
+++ b/tests/lib/rules/no-duplicate-imports.js
@@ -71,6 +71,29 @@ ruleTester.run("no-duplicate-imports", rule, {
 			code: 'export { something } from "os";\nexport * from "os";',
 			options: [{ includeExports: true }],
 		},
+
+		// Import attributes with different values should not be duplicates
+		{
+			code: 'import data from "./data.json" with { type: "json" };\nimport text from "./data.json" with { type: "text" };',
+			languageOptions: { ecmaVersion: 2025, sourceType: "module" },
+		},
+		{
+			code: 'import "./data.json" with { type: "json" };\nimport "./data.json" with { type: "text" };',
+			languageOptions: { ecmaVersion: 2025, sourceType: "module" },
+		},
+		{
+			code: 'import data from "./data.json" with { type: "json", priority: "high" };\nimport text from "./data.json" with { type: "text" };',
+			languageOptions: { ecmaVersion: 2025, sourceType: "module" },
+		},
+		{
+			code: 'import * as jsonMod from "./data.json" with { type: "json" };\nimport * as textMod from "./data.json" with { type: "text" };',
+			languageOptions: { ecmaVersion: 2025, sourceType: "module" },
+		},
+		{
+			code: 'export { default } from "./data.json" with { type: "json" };\nexport { name } from "./data.json" with { type: "text" };',
+			options: [{ includeExports: true }],
+			languageOptions: { ecmaVersion: 2025, sourceType: "module" },
+		},
 	],
 	invalid: [
 		{
@@ -207,6 +230,51 @@ ruleTester.run("no-duplicate-imports", rule, {
 				{
 					messageId: "exportAs",
 					data: { module: "os" },
+				},
+			],
+		},
+
+		// Import attributes with same values should be duplicates
+		{
+			code: 'import data from "./data.json" with { type: "json" };\nimport text from "./data.json" with { type: "json" };',
+			languageOptions: { ecmaVersion: 2025, sourceType: "module" },
+			errors: [
+				{
+					messageId: "import",
+					data: { module: "./data.json with {type=json}" },
+				},
+			],
+		},
+		{
+			code: 'import "./data.json" with { type: "json" };\nimport "./data.json" with { type: "json" };',
+			languageOptions: { ecmaVersion: 2025, sourceType: "module" },
+			errors: [
+				{
+					messageId: "import",
+					data: { module: "./data.json with {type=json}" },
+				},
+			],
+		},
+		{
+			code: 'import data from "./data.json" with { type: "json", priority: "high" };\nimport text from "./data.json" with { type: "json", priority: "high" };',
+			languageOptions: { ecmaVersion: 2025, sourceType: "module" },
+			errors: [
+				{
+					messageId: "import",
+					data: {
+						module: "./data.json with {priority=high,type=json}",
+					},
+				},
+			],
+		},
+		{
+			code: 'export { default } from "./data.json" with { type: "json" };\nexport { name } from "./data.json" with { type: "json" };',
+			options: [{ includeExports: true }],
+			languageOptions: { ecmaVersion: 2025, sourceType: "module" },
+			errors: [
+				{
+					messageId: "export",
+					data: { module: "./data.json with {type=json}" },
 				},
 			],
 		},


### PR DESCRIPTION
## Problem

The `no-duplicate-imports` rule uses only the module specifier (e.g., `./data.json`) as the deduplication key, ignoring import attributes entirely. This causes false positives when two imports from the same module use different attributes:

```js
import data from "./data.json" with { type: "json" };
import text from "./data.json" with { type: "text" }; // false positive: flagged as duplicate
```

These are semantically distinct imports — they request different transformations from the runtime — so they should not be flagged as duplicates.

## Solution

Modified `getModule()` to include a sorted, deterministic representation of import attributes in the module key. Two imports are now only considered duplicates if they share both the same module specifier AND the same attributes.

```js
// No longer flagged — different attributes mean different imports
import data from "./data.json" with { type: "json" };
import text from "./data.json" with { type: "text" };

// Still flagged — same module, same attributes
import data from "./data.json" with { type: "json" };
import text from "./data.json" with { type: "json" };
```

## Key design decisions

- Attributes are serialized as `key=value` pairs, sorted alphabetically, so `{ type: "json", priority: "high" }` and `{ priority: "high", type: "json" }` produce the same key
- Uses `attribute.key.name` for Identifier keys and `attribute.key.value` for StringLiteral keys
- The module key format is `./data.json with {priority=high,type=json}` — readable in error messages
- Attribute keys are sorted for deterministic comparison regardless of declaration order
