### PR TITLE
docs: include TypeScript config names in CLI help

### DIFF
--- a/docs/src/use/command-line-interface.md
+++ b/docs/src/use/command-line-interface.md
@@ -86,8 +86,8 @@ You can view all the CLI options by running `npx eslint -h`.
 eslint [options] file.js [file.js] [dir]
 
 Basic configuration:
-  --no-config-lookup               Disable look up for eslint.config.js
-  -c, --config path::String        Use this configuration instead of eslint.config.js, eslint.config.mjs, or eslint.config.cjs
+  --no-config-lookup               Disable look up for eslint.config.{js,mjs,cjs,ts,mts,cts}
+  -c, --config path::String        Use this configuration instead of eslint.config.{js,mjs,cjs,ts,mts,cts}
   --inspect-config                 Open the config inspector with the current configuration
   --ext [String]                   Specify additional file extensions to lint
   --global [String]                Define global variables

--- a/lib/options.js
+++ b/lib/options.js
@@ -90,14 +90,14 @@ module.exports = function () {
 				option: "config-lookup",
 				type: "Boolean",
 				default: "true",
-				description: "Disable look up for eslint.config.js",
+				description: "Disable look up for eslint.config.{js,mjs,cjs,ts,mts,cts}",
 			},
 			{
 				option: "config",
 				alias: "c",
 				type: "path::String",
 				description:
-					"Use this configuration instead of eslint.config.js, eslint.config.mjs, or eslint.config.cjs",
+					"Use this configuration instead of eslint.config.{js,mjs,cjs,ts,mts,cts}",
 			},
 			{
 				option: "inspect-config",


### PR DESCRIPTION
## Summary
- Update `--config` and `--no-config-lookup` help text in `lib/options.js` to use `eslint.config.{js,mjs,cjs,ts,mts,cts}` so TypeScript config filenames are covered.
- Keep the embedded CLI help block in `docs/src/use/command-line-interface.md` in sync.

Fixes #21111

## Test plan
- [ ] Run `npx eslint -h` and confirm both option descriptions list the TypeScript config extensions.
- [ ] Spot-check the Options section on the Command Line Interface docs page matches the help output.