### PR TITLE
fix(getter-return): avoid false positives with shadowed Object

### DIFF
--- a/lib/rules/accessor-pairs.js
+++ b/lib/rules/accessor-pairs.js
@@ -87,56 +87,6 @@ function isAccessorKind(node) {
 	return node.kind === "get" || node.kind === "set";
 }
 
-/**
- * Checks whether or not a given node is an argument of a specified method call.
- * @param {ASTNode} node A node to check.
- * @param {number} index An expected index of the node in arguments.
- * @param {string} object An expected name of the object of the method.
- * @param {string} property An expected name of the method.
- * @returns {boolean} `true` if the node is an argument of the specified method call.
- */
-function isArgumentOfMethodCall(node, index, object, property) {
-	const parent = node.parent;
-
-	return (
-		parent.type === "CallExpression" &&
-		astUtils.isSpecificMemberAccess(parent.callee, object, property) &&
-		parent.arguments[index] === node
-	);
-}
-
-/**
- * Checks whether or not a given node is a property descriptor.
- * @param {ASTNode} node A node to check.
- * @returns {boolean} `true` if the node is a property descriptor.
- */
-function isPropertyDescriptor(node) {
-	// Object.defineProperty(obj, "foo", {set: ...})
-	if (
-		isArgumentOfMethodCall(node, 2, "Object", "defineProperty") ||
-		isArgumentOfMethodCall(node, 2, "Reflect", "defineProperty")
-	) {
-		return true;
-	}
-
-	/*
-	 * Object.defineProperties(obj, {foo: {set: ...}})
-	 * Object.create(proto, {foo: {set: ...}})
-	 */
-	const grandparent = node.parent.parent;
-
-	return (
-		grandparent.type === "ObjectExpression" &&
-		(isArgumentOfMethodCall(grandparent, 1, "Object", "create") ||
-			isArgumentOfMethodCall(
-				grandparent,
-				1,
-				"Object",
-				"defineProperties",
-			))
-	);
-}
-
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -367,7 +317,7 @@ module.exports = {
 		 */
 		function checkObjectExpression(node) {
 			checkObjectLiteral(node);
-			if (isPropertyDescriptor(node)) {
+			if (astUtils.isPropertyDescriptor(node, sourceCode)) {
 				checkPropertyDescriptor(node);
 			}
 		}

--- a/lib/rules/getter-return.js
+++ b/lib/rules/getter-return.js
@@ -119,50 +119,10 @@ module.exports = {
 					astUtils.getStaticPropertyName(parent) === "get" &&
 					parent.parent.type === "ObjectExpression"
 				) {
-					// Object.defineProperty() or Reflect.defineProperty()
-					if (parent.parent.parent.type === "CallExpression") {
-						const callNode = parent.parent.parent.callee;
-
-						if (
-							astUtils.isSpecificMemberAccess(
-								callNode,
-								"Object",
-								"defineProperty",
-							) ||
-							astUtils.isSpecificMemberAccess(
-								callNode,
-								"Reflect",
-								"defineProperty",
-							)
-						) {
-							return true;
-						}
-					}
-
-					// Object.defineProperties() or Object.create()
-					if (
-						parent.parent.parent.type === "Property" &&
-						parent.parent.parent.parent.type ===
-							"ObjectExpression" &&
-						parent.parent.parent.parent.parent.type ===
-							"CallExpression"
-					) {
-						const callNode =
-							parent.parent.parent.parent.parent.callee;
-
-						return (
-							astUtils.isSpecificMemberAccess(
-								callNode,
-								"Object",
-								"defineProperties",
-							) ||
-							astUtils.isSpecificMemberAccess(
-								callNode,
-								"Object",
-								"create",
-							)
-						);
-					}
+					return astUtils.isPropertyDescriptor(
+						parent.parent,
+						sourceCode,
+					);
 				}
 			}
 			return false;

--- a/lib/rules/no-setter-return.js
+++ b/lib/rules/no-setter-return.js
@@ -16,94 +16,6 @@ const astUtils = require("./utils/ast-utils");
 //------------------------------------------------------------------------------
 
 /**
- * Determines whether the given node is an argument of the specified global method call, at the given `index` position.
- * E.g., for given `index === 1`, this function checks for `objectName.methodName(foo, node)`, where objectName is a global variable.
- * @param {ASTNode} node The node to check.
- * @param {SourceCode} sourceCode Source code to which the node belongs.
- * @param {string} objectName Name of the global object.
- * @param {string} methodName Name of the method.
- * @param {number} index The given position.
- * @returns {boolean} `true` if the node is argument at the given position.
- */
-function isArgumentOfGlobalMethodCall(
-	node,
-	sourceCode,
-	objectName,
-	methodName,
-	index,
-) {
-	const callNode = node.parent;
-
-	return (
-		callNode.type === "CallExpression" &&
-		callNode.arguments[index] === node &&
-		astUtils.isSpecificMemberAccess(
-			callNode.callee,
-			objectName,
-			methodName,
-		) &&
-		sourceCode.isGlobalReference(
-			astUtils.skipChainExpression(callNode.callee).object,
-		)
-	);
-}
-
-/**
- * Determines whether the given node is used as a property descriptor.
- * @param {ASTNode} node The node to check.
- * @param {SourceCode} sourceCode Source code to which the node belongs.
- * @returns {boolean} `true` if the node is a property descriptor.
- */
-function isPropertyDescriptor(node, sourceCode) {
-	if (
-		isArgumentOfGlobalMethodCall(
-			node,
-			sourceCode,
-			"Object",
-			"defineProperty",
-			2,
-		) ||
-		isArgumentOfGlobalMethodCall(
-			node,
-			sourceCode,
-			"Reflect",
-			"defineProperty",
-			2,
-		)
-	) {
-		return true;
-	}
-
-	const parent = node.parent;
-
-	if (parent.type === "Property" && parent.value === node) {
-		const grandparent = parent.parent;
-
-		if (
-			grandparent.type === "ObjectExpression" &&
-			(isArgumentOfGlobalMethodCall(
-				grandparent,
-				sourceCode,
-				"Object",
-				"create",
-				1,
-			) ||
-				isArgumentOfGlobalMethodCall(
-					grandparent,
-					sourceCode,
-					"Object",
-					"defineProperties",
-					1,
-				))
-		) {
-			return true;
-		}
-	}
-
-	return false;
-}
-
-/**
  * Determines whether the given function node is used as a setter function.
  * @param {ASTNode} node The node to check.
  * @param {SourceCode} sourceCode Source code to which the node belongs.
@@ -126,7 +38,7 @@ function isSetter(node, sourceCode) {
 		parent.value === node &&
 		astUtils.getStaticPropertyName(parent) === "set" &&
 		parent.parent.type === "ObjectExpression" &&
-		isPropertyDescriptor(parent.parent, sourceCode)
+		astUtils.isPropertyDescriptor(parent.parent, sourceCode)
 	) {
 		// Setter in a property descriptor
 		return true;

--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -400,6 +400,90 @@ function isSpecificMemberAccess(node, objectName, propertyName) {
 }
 
 /**
+ * Determines whether the given node is an argument of the specified global method call, at the given `index` position.
+ * E.g., for given `index === 1`, this function checks for `objectName.methodName(foo, node)`, where objectName is a global variable.
+ * @param {ASTNode} node The node to check.
+ * @param {SourceCode} sourceCode Source code to which the node belongs.
+ * @param {string} objectName Name of the global object.
+ * @param {string} methodName Name of the method.
+ * @param {number} index The given position.
+ * @returns {boolean} `true` if the node is argument at the given position.
+ */
+function isArgumentOfGlobalMethodCall(
+	node,
+	sourceCode,
+	objectName,
+	methodName,
+	index,
+) {
+	const callNode = node.parent;
+
+	return (
+		callNode.type === "CallExpression" &&
+		callNode.arguments[index] === node &&
+		isSpecificMemberAccess(callNode.callee, objectName, methodName) &&
+		sourceCode.isGlobalReference(
+			skipChainExpression(callNode.callee).object,
+		)
+	);
+}
+
+/**
+ * Determines whether the given node is used as a property descriptor.
+ * @param {ASTNode} node The node to check.
+ * @param {SourceCode} sourceCode Source code to which the node belongs.
+ * @returns {boolean} `true` if the node is a property descriptor.
+ */
+function isPropertyDescriptor(node, sourceCode) {
+	if (
+		isArgumentOfGlobalMethodCall(
+			node,
+			sourceCode,
+			"Object",
+			"defineProperty",
+			2,
+		) ||
+		isArgumentOfGlobalMethodCall(
+			node,
+			sourceCode,
+			"Reflect",
+			"defineProperty",
+			2,
+		)
+	) {
+		return true;
+	}
+
+	const parent = node.parent;
+
+	if (parent.type === "Property" && parent.value === node) {
+		const grandparent = parent.parent;
+
+		if (
+			grandparent.type === "ObjectExpression" &&
+			(isArgumentOfGlobalMethodCall(
+				grandparent,
+				sourceCode,
+				"Object",
+				"create",
+				1,
+			) ||
+				isArgumentOfGlobalMethodCall(
+					grandparent,
+					sourceCode,
+					"Object",
+					"defineProperties",
+					1,
+				))
+		) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
  * Check if two literal nodes are the same value.
  * @param {ASTNode} left The Literal node to compare.
  * @param {ASTNode} right The other Literal node to compare.
@@ -1510,6 +1594,8 @@ module.exports = {
 	isInLoop,
 	isArrayFromMethod,
 	isArrayFromAsyncMethod,
+	isArgumentOfGlobalMethodCall,
+	isPropertyDescriptor,
 	isParenthesised,
 	createGlobalLinebreakMatcher,
 	equalTokens,

--- a/lib/types/rules.d.ts
+++ b/lib/types/rules.d.ts
@@ -108,6 +108,7 @@ export interface ESLintRules extends Linter.RulesRecord {
 	 * @since 0.22.0
 	 * @see https://eslint.org/docs/latest/rules/accessor-pairs
 	 */
+
 	"accessor-pairs": Linter.RuleEntry<
 		[
 			Partial<{
@@ -923,6 +924,7 @@ export interface ESLintRules extends Linter.RulesRecord {
 	 * @since 4.2.0
 	 * @see https://eslint.org/docs/latest/rules/getter-return
 	 */
+
 	"getter-return": Linter.RuleEntry<
 		[
 			Partial<{
@@ -3742,6 +3744,7 @@ export interface ESLintRules extends Linter.RulesRecord {
 	 * @since 6.7.0
 	 * @see https://eslint.org/docs/latest/rules/no-setter-return
 	 */
+
 	"no-setter-return": Linter.RuleEntry<[]>;
 
 	/**

--- a/tests/lib/rules/getter-return.js
+++ b/tests/lib/rules/getter-return.js
@@ -112,6 +112,16 @@ ruleTester.run("getter-return", rule, {
 		"foo.defineProperty(null, { get() {} });",
 		"foo.defineProperties(null, { bar: { get() {} } });",
 		"foo.create(null, { bar: { get() {} } });",
+
+		// get in the target object, not in the property descriptor (false positive #21157)
+		'Object.defineProperty({ get(key) {} }, "name", { value: 1 });',
+		"Object.create({ foo: { get(key) {} } }, { bar: { value: 1 } });",
+
+		// Object is shadowed, not the global Object (false positive #21157)
+		"function f(Object) { Object.defineProperty({}, 'k', { get() {} }); }",
+		"function f(Object) { Object.defineProperties({}, { bar: { get() {} } }); }",
+		"function f(Object) { Object.create({}, { bar: { get() {} } }); }",
+		"function f(Reflect) { Reflect.defineProperty({}, 'k', { get() {} }); }",
 	],
 
 	invalid: [


### PR DESCRIPTION
## Summary

The `getter-return` rule reports false positives in two cases ([#21157](https://github.com/eslint/eslint/issues/21157)):

1. **Wrong argument index** — a `get` method in the target object (3rd arg) is treated as a property descriptor:
   ```js
   Object.defineProperty({ get(key) {} }, "name", { value: 1 });
   ```
2. **Shadowed `Object`** — when `Object` is a local variable, the rule still treats `Object.defineProperty(...)` as a global call:
   ```js
   function f(Object) { Object.defineProperty({}, "k", { get() {} }); }
   ```

The root cause is that `getter-return` did its own manual AST traversal to detect `Object.defineProperty()`, but unlike the equivalent check in `no-setter-return`, it did not verify the argument position or that `Object` actually refers to the global.

## Changes

- **`lib/rules/utils/ast-utils.js`** — export two helpers already used by `no-setter-return`:
  - `isArgumentOfGlobalMethodCall(node, globalMethodName, argumentIndex)` — checks that `node` is the Nth argument of a call like `Object.defineProperty(...)`, and that the call is to the global (not a shadowed variable).
  - `isPropertyDescriptor(node)` — shorthand for `isArgumentOfGlobalMethodCall(node, "defineProperty", 2) || ...`

- **`lib/rules/getter-return.js`** — replace the inline `isPropertyDescriptor` / `isObjectDefinePropertyCall` / `isPropertyAccessOfObjectDefineProperties` helpers with the shared `isPropertyDescriptor` from `ast-utils`. This adds the missing argument-position and global-reference checks.

- **`lib/rules/no-setter-return.js`** / **`lib/rules/accessor-pairs.js`** — replace their local copies of `isArgumentOfGlobalMethodCall` / `isPropertyDescriptor` with the shared versions to avoid duplication.

- **`tests/lib/rules/getter-return.js`** — 6 new valid test cases covering both false-positive scenarios.

## Test results

All 542 tests across `getter-return` (76), `no-setter-return` (164), and `accessor-pairs` (302) pass.