### PR TITLE
fix: false positives in `getter-return` and `accessor-pairs`

### DIFF
--- a/lib/rules/accessor-pairs.js
+++ b/lib/rules/accessor-pairs.js
@@ -87,56 +87,6 @@ function isAccessorKind(node) {
 	return node.kind === "get" || node.kind === "set";
 }
 
-/**
- * Checks whether or not a given node is an argument of a specified method call.
- * @param {ASTNode} node A node to check.
- * @param {number} index An expected index of the node in arguments.
- * @param {string} object An expected name of the object of the method.
- * @param {string} property An expected name of the method.
- * @returns {boolean} `true` if the node is an argument of the specified method call.
- */
-function isArgumentOfMethodCall(node, index, object, property) {
-	const parent = node.parent;
-
-	return (
-		parent.type === "CallExpression" &&
-		astUtils.isSpecificMemberAccess(parent.callee, object, property) &&
-		parent.arguments[index] === node
-	);
-}
-
-/**
- * Checks whether or not a given node is a property descriptor.
- * @param {ASTNode} node A node to check.
- * @returns {boolean} `true` if the node is a property descriptor.
- */
-function isPropertyDescriptor(node) {
-	// Object.defineProperty(obj, "foo", {set: ...})
-	if (
-		isArgumentOfMethodCall(node, 2, "Object", "defineProperty") ||
-		isArgumentOfMethodCall(node, 2, "Reflect", "defineProperty")
-	) {
-		return true;
-	}
-
-	/*
-	 * Object.defineProperties(obj, {foo: {set: ...}})
-	 * Object.create(proto, {foo: {set: ...}})
-	 */
-	const grandparent = node.parent.parent;
-
-	return (
-		grandparent.type === "ObjectExpression" &&
-		(isArgumentOfMethodCall(grandparent, 1, "Object", "create") ||
-			isArgumentOfMethodCall(
-				grandparent,
-				1,
-				"Object",
-				"defineProperties",
-			))
-	);
-}
-
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -367,7 +317,7 @@ module.exports = {
 		 */
 		function checkObjectExpression(node) {
 			checkObjectLiteral(node);
-			if (isPropertyDescriptor(node)) {
+			if (astUtils.isPropertyDescriptor(node, sourceCode)) {
 				checkPropertyDescriptor(node);
 			}
 		}

--- a/lib/rules/getter-return.js
+++ b/lib/rules/getter-return.js
@@ -117,52 +117,11 @@ module.exports = {
 				if (
 					parent.type === "Property" &&
 					astUtils.getStaticPropertyName(parent) === "get" &&
-					parent.parent.type === "ObjectExpression"
+					parent.parent.type === "ObjectExpression" &&
+					astUtils.isPropertyDescriptor(parent.parent, sourceCode)
 				) {
-					// Object.defineProperty() or Reflect.defineProperty()
-					if (parent.parent.parent.type === "CallExpression") {
-						const callNode = parent.parent.parent.callee;
-
-						if (
-							astUtils.isSpecificMemberAccess(
-								callNode,
-								"Object",
-								"defineProperty",
-							) ||
-							astUtils.isSpecificMemberAccess(
-								callNode,
-								"Reflect",
-								"defineProperty",
-							)
-						) {
-							return true;
-						}
-					}
-
-					// Object.defineProperties() or Object.create()
-					if (
-						parent.parent.parent.type === "Property" &&
-						parent.parent.parent.parent.type ===
-							"ObjectExpression" &&
-						parent.parent.parent.parent.parent.type ===
-							"CallExpression"
-					) {
-						const callNode =
-							parent.parent.parent.parent.parent.callee;
-
-						return (
-							astUtils.isSpecificMemberAccess(
-								callNode,
-								"Object",
-								"defineProperties",
-							) ||
-							astUtils.isSpecificMemberAccess(
-								callNode,
-								"Object",
-								"create",
-							)
-						);
-					}
+					// Getter in a property descriptor
+					return true;
 				}
 			}
 			return false;

--- a/lib/rules/no-setter-return.js
+++ b/lib/rules/no-setter-return.js
@@ -16,16 +16,6 @@ const astUtils = require("./utils/ast-utils");
 //------------------------------------------------------------------------------
 
 /**
- * Determines whether the given node is used as a property descriptor.
- * @param {ASTNode} node The node to check.
- * @param {SourceCode} sourceCode Source code to which the node belongs.
- * @returns {boolean} `true` if the node is a property descriptor.
- */
-function isPropertyDescriptor(node, sourceCode) {
-	return astUtils.isPropertyDescriptor(node, sourceCode);
-}
-
-/**
  * Determines whether the given function node is used as a setter function.
  * @param {ASTNode} node The node to check.
  * @param {SourceCode} sourceCode Source code to which the node belongs.
@@ -48,7 +38,7 @@ function isSetter(node, sourceCode) {
 		parent.value === node &&
 		astUtils.getStaticPropertyName(parent) === "set" &&
 		parent.parent.type === "ObjectExpression" &&
-		isPropertyDescriptor(parent.parent, sourceCode)
+		astUtils.isPropertyDescriptor(parent.parent, sourceCode)
 	) {
 		// Setter in a property descriptor
 		return true;

--- a/lib/rules/no-setter-return.js
+++ b/lib/rules/no-setter-return.js
@@ -16,91 +16,13 @@ const astUtils = require("./utils/ast-utils");
 //------------------------------------------------------------------------------
 
 /**
- * Determines whether the given node is an argument of the specified global method call, at the given `index` position.
- * E.g., for given `index === 1`, this function checks for `objectName.methodName(foo, node)`, where objectName is a global variable.
- * @param {ASTNode} node The node to check.
- * @param {SourceCode} sourceCode Source code to which the node belongs.
- * @param {string} objectName Name of the global object.
- * @param {string} methodName Name of the method.
- * @param {number} index The given position.
- * @returns {boolean} `true` if the node is argument at the given position.
- */
-function isArgumentOfGlobalMethodCall(
-	node,
-	sourceCode,
-	objectName,
-	methodName,
-	index,
-) {
-	const callNode = node.parent;
-
-	return (
-		callNode.type === "CallExpression" &&
-		callNode.arguments[index] === node &&
-		astUtils.isSpecificMemberAccess(
-			callNode.callee,
-			objectName,
-			methodName,
-		) &&
-		sourceCode.isGlobalReference(
-			astUtils.skipChainExpression(callNode.callee).object,
-		)
-	);
-}
-
-/**
  * Determines whether the given node is used as a property descriptor.
  * @param {ASTNode} node The node to check.
  * @param {SourceCode} sourceCode Source code to which the node belongs.
  * @returns {boolean} `true` if the node is a property descriptor.
  */
 function isPropertyDescriptor(node, sourceCode) {
-	if (
-		isArgumentOfGlobalMethodCall(
-			node,
-			sourceCode,
-			"Object",
-			"defineProperty",
-			2,
-		) ||
-		isArgumentOfGlobalMethodCall(
-			node,
-			sourceCode,
-			"Reflect",
-			"defineProperty",
-			2,
-		)
-	) {
-		return true;
-	}
-
-	const parent = node.parent;
-
-	if (parent.type === "Property" && parent.value === node) {
-		const grandparent = parent.parent;
-
-		if (
-			grandparent.type === "ObjectExpression" &&
-			(isArgumentOfGlobalMethodCall(
-				grandparent,
-				sourceCode,
-				"Object",
-				"create",
-				1,
-			) ||
-				isArgumentOfGlobalMethodCall(
-					grandparent,
-					sourceCode,
-					"Object",
-					"defineProperties",
-					1,
-				))
-		) {
-			return true;
-		}
-	}
-
-	return false;
+	return astUtils.isPropertyDescriptor(node, sourceCode);
 }
 
 /**

--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -552,6 +552,91 @@ function isMethodWhichHasThisArg(node) {
 }
 
 /**
+ * Determines whether the given node is an argument of the specified global method call, at the given `index` position.
+ * E.g., for given `index === 1`, this function checks for `objectName.methodName(foo, node)`, where objectName is a global variable.
+ * @param {ASTNode} node The node to check.
+ * @param {SourceCode} sourceCode Source code to which the node belongs.
+ * @param {string} objectName Name of the global object.
+ * @param {string} methodName Name of the method.
+ * @param {number} index The given position.
+ * @returns {boolean} `true` if the node is argument at the given position.
+ * @private
+ */
+function isArgumentOfGlobalMethodCall(
+	node,
+	sourceCode,
+	objectName,
+	methodName,
+	index,
+) {
+	const callNode = node.parent;
+
+	return (
+		callNode.type === "CallExpression" &&
+		callNode.arguments[index] === node &&
+		isSpecificMemberAccess(callNode.callee, objectName, methodName) &&
+		sourceCode.isGlobalReference(
+			skipChainExpression(callNode.callee).object,
+		)
+	);
+}
+
+/**
+ * Determines whether the given node is used as a property descriptor.
+ * @param {ASTNode} node The node to check.
+ * @param {SourceCode} sourceCode Source code to which the node belongs.
+ * @returns {boolean} `true` if the node is a property descriptor.
+ */
+function isPropertyDescriptor(node, sourceCode) {
+	if (
+		isArgumentOfGlobalMethodCall(
+			node,
+			sourceCode,
+			"Object",
+			"defineProperty",
+			2,
+		) ||
+		isArgumentOfGlobalMethodCall(
+			node,
+			sourceCode,
+			"Reflect",
+			"defineProperty",
+			2,
+		)
+	) {
+		return true;
+	}
+
+	const parent = node.parent;
+
+	if (parent.type === "Property" && parent.value === node) {
+		const grandparent = parent.parent;
+
+		if (
+			grandparent.type === "ObjectExpression" &&
+			(isArgumentOfGlobalMethodCall(
+				grandparent,
+				sourceCode,
+				"Object",
+				"create",
+				1,
+			) ||
+				isArgumentOfGlobalMethodCall(
+					grandparent,
+					sourceCode,
+					"Object",
+					"defineProperties",
+					1,
+				))
+		) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
  * Creates the negate function of the given function.
  * @param {Function} f The function to negate.
  * @returns {Function} Negated function.
@@ -1510,6 +1595,7 @@ module.exports = {
 	isInLoop,
 	isArrayFromMethod,
 	isArrayFromAsyncMethod,
+	isPropertyDescriptor,
 	isParenthesised,
 	createGlobalLinebreakMatcher,
 	equalTokens,

--- a/tests/lib/rules/accessor-pairs.js
+++ b/tests/lib/rules/accessor-pairs.js
@@ -346,6 +346,33 @@ ruleTester.run("accessor-pairs", rule, {
 		},
 		"Object.create({ foo: { set(value) {} } }, { bar: { value: 1 } });",
 
+		// global object is shadowed
+		{
+			code: "let Object; Object.defineProperty(foo, 'bar', { get() {} })",
+			options: [{ getWithoutSet: true }],
+		},
+		{
+			code: "function f() { Reflect.defineProperty(foo, 'bar', { set(value) {} }); var Reflect;}",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		"function f(Object) { Object.defineProperties(foo, { bar: { set(value) {} } }) }",
+		{
+			code: "if (x) { const Object = getObject(); Object.create(foo, { bar: { get() {} } }) }",
+			options: [{ getWithoutSet: true }],
+		},
+
+		// global object doesn't exist
+		{
+			code: "Reflect.defineProperty(foo, 'bar', { get() {} })",
+			options: [{ getWithoutSet: true }],
+			languageOptions: { globals: { Reflect: "off" } },
+		},
+		"/* globals Object:off */ Object.defineProperty(foo, 'bar', { set(value) {} })",
+		{
+			code: "Object.defineProperties(foo, { bar: { set(value) {} } })",
+			languageOptions: { globals: { Object: "off" } },
+		},
+
 		//------------------------------------------------------------------------------
 		// Classes
 		//------------------------------------------------------------------------------

--- a/tests/lib/rules/accessor-pairs.js
+++ b/tests/lib/rules/accessor-pairs.js
@@ -333,6 +333,19 @@ ruleTester.run("accessor-pairs", rule, {
 			languageOptions: { ecmaVersion: 6 },
 		},
 
+		// wrong argument index (not in the property descriptor position)
+		"Object.defineProperty({ set: function(value) {} }, 'foo', { value: 1 });",
+		{
+			code: "Reflect.defineProperty({ get() {} }, 'foo', { value: 1 });",
+			options: [{ getWithoutSet: true }],
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "Object.defineProperties({ foo: { get() {} } }, { bar: { value: 1 } });",
+			options: [{ getWithoutSet: true }],
+		},
+		"Object.create({ foo: { set(value) {} } }, { bar: { value: 1 } });",
+
 		//------------------------------------------------------------------------------
 		// Classes
 		//------------------------------------------------------------------------------

--- a/tests/lib/rules/getter-return.js
+++ b/tests/lib/rules/getter-return.js
@@ -112,6 +112,35 @@ ruleTester.run("getter-return", rule, {
 		"foo.defineProperty(null, { get() {} });",
 		"foo.defineProperties(null, { bar: { get() {} } });",
 		"foo.create(null, { bar: { get() {} } });",
+
+		// wrong argument index (not in the property descriptor position)
+		"Object.defineProperty({ get() {} }, 'foo', { value: 1 });",
+		{
+			code: "Reflect.defineProperty({ get() {} }, 'foo', { value: 1 });",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		"Object.defineProperties({ foo: { get() {} } }, { bar: { value: 1 } });",
+		"Object.create({ foo: { get() {} } }, { bar: { value: 1 } });",
+
+		// global object is shadowed
+		"let Object; Object.defineProperty(foo, 'bar', { get() {} })",
+		{
+			code: "function f() { Reflect.defineProperty(foo, 'bar', { get() {} }); var Reflect;}",
+			languageOptions: { ecmaVersion: 6 },
+		},
+		"function f(Object) { Object.defineProperties(foo, { bar: { get() {} } }) }",
+		"if (x) { const Object = getObject(); Object.create(foo, { bar: { get() {} } }) }",
+
+		// global object doesn't exist
+		{
+			code: "Reflect.defineProperty(foo, 'bar', { get() {} })",
+			languageOptions: { globals: { Reflect: "off" } },
+		},
+		"/* globals Object:off */ Object.defineProperty(foo, 'bar', { get() {} })",
+		{
+			code: "Object.defineProperties(foo, { bar: { get() {} } })",
+			languageOptions: { globals: { Object: "off" } },
+		},
 	],
 
 	invalid: [

--- a/tests/lib/rules/utils/ast-utils.js
+++ b/tests/lib/rules/utils/ast-utils.js
@@ -2577,4 +2577,127 @@ describe("ast-utils", () => {
 			});
 		});
 	});
+
+	describe("isPropertyDescriptor", () => {
+		/**
+		 * Asserts that `isPropertyDescriptor` reports whether each `ObjectExpression`
+		 * node in the given code is used as a property descriptor.
+		 * @param {string} code the code to check.
+		 * @param {boolean[]} expected the expected result for each `ObjectExpression` node, in traversal order.
+		 * @param {Object} [languageOptions] the language options to use.
+		 * @returns {void}
+		 */
+		function assertResult(code, expected, languageOptions = {}) {
+			const results = [];
+			linter.verify(code, {
+				languageOptions,
+				plugins: {
+					test: {
+						rules: {
+							checker: {
+								create: mustCall(context => ({
+									ObjectExpression: mustCall(node => {
+										results.push(
+											astUtils.isPropertyDescriptor(
+												node,
+												context.sourceCode,
+											),
+										);
+									}),
+								})),
+							},
+						},
+					},
+				},
+				rules: { "test/checker": "error" },
+			});
+
+			assert.deepStrictEqual(results, expected);
+		}
+
+		it("should return true for a descriptor of Object.defineProperty", () => {
+			assertResult("Object.defineProperty(foo, 'bar', { value: 1 })", [
+				true,
+			]);
+		});
+
+		it("should return true for the third argument of Reflect.defineProperty", () => {
+			assertResult("Reflect.defineProperty(foo, 'bar', { value: 1 })", [
+				true,
+			]);
+		});
+
+		it("should return true for descriptors nested in Object.defineProperties", () => {
+			assertResult(
+				"Object.defineProperties(foo, { bar: { value: 1 } })",
+				[false, true],
+			);
+		});
+
+		it("should return true for descriptors nested in Object.create", () => {
+			assertResult("Object.create(proto, { bar: { value: 1 } })", [
+				false,
+				true,
+			]);
+		});
+
+		it("should return true for a call with optional chaining", () => {
+			assertResult("Object?.defineProperty(foo, 'bar', { value: 1 })", [
+				true,
+			]);
+		});
+
+		it("should return false for a standalone object literal", () => {
+			assertResult("const d = { value: 1 };", [false]);
+		});
+
+		it("should return false for a descriptor-like object at another position", () => {
+			assertResult(
+				"Object.defineProperty({ value: 1 }, 'bar', { value: 1 })",
+				[false, true],
+			);
+		});
+
+		it("should return false when the descriptor map is not the second argument", () => {
+			assertResult("Object.create({ bar: { value: 1 } }, foo)", [
+				false,
+				false,
+			]);
+		});
+
+		it("should return false when the object is not the global `Object`", () => {
+			assertResult("object.defineProperty(foo, 'bar', { value: 1 })", [
+				false,
+			]);
+		});
+
+		it("should return false for Reflect.defineProperties", () => {
+			assertResult(
+				"Reflect.defineProperties(foo, { bar: { value: 1 } })",
+				[false, false],
+			);
+		});
+
+		it("should return false when `Object` is shadowed", () => {
+			assertResult(
+				"let Object; Object.defineProperty(foo, 'bar', { value: 1 })",
+				[false],
+			);
+		});
+
+		it("should return false when the global `Object` is disabled", () => {
+			assertResult(
+				"Object.defineProperty(foo, 'bar', { value: 1 })",
+				[false],
+				{ globals: { Object: "off" } },
+			);
+		});
+
+		it("should return false for a computed key in the second argument of Object.defineProperties", () => {
+			assertResult(
+				"Object.defineProperties(foo, { [{ value: 1 }]: 1 })",
+				[false, false],
+			);
+		});
+	});
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
The false positives that occur when getters/setters are defined through global objects (`Object`, `Reflect`) fall into two main cases:

- **Wrong argument position**: an object containing `get`/`set` appears in an argument position other than the property descriptor position.
- **Not a global reference**: the object is not actually the global one (it's shadowed by a local variable, or the global doesn't exist at all, e.g. with `globals: off`).

```js
// Case 1: `get` in the target object, not in the property descriptor
Object.defineProperty({ get() {} }, "foo", { value: 1 });
Object.create({ foo: { get() {} } }, { bar: { value: 1 } });

// Case 2: `Object` is shadowed, not the global `Object`
function f(Object) {
    Object.defineProperty({}, "foo", { get() {} });
}
```

**1) Added test cases that catch these false positives**

- `getter-return`: covers both the wrong-argument-position and non-global-reference cases.
- `accessor-pairs`: covers the wrong-argument-position case (the existing logic already passes these tests — added to strengthen coverage) and the non-global-reference cases.

The new test cases were added only to the `valid` section, based on the existing tests for `no-setter-return`.

**2) Moved the fix logic into shared utility helpers and applied it**

- `no-setter-return` already had local helper functions that correctly check the argument position and whether the reference is global, so I moved them into `ast-utils`:
  - `isPropertyDescriptor`
  - `isArgumentOfGlobalMethodCall`
- All three rules (`getter-return`, `accessor-pairs`, and `no-setter-return`) now use `astUtils.isPropertyDescriptor(node, sourceCode)`.

#### Is there anything you'd like reviewers to focus on?
Of the two helpers I moved, `isArgumentOfGlobalMethodCall` is only used by `isPropertyDescriptor`, so I marked it as `@private` in its JSDoc and exported only `isPropertyDescriptor`.

fixes #21157

<!-- markdownlint-disable-file MD004 -->
