### PR TITLE
fix: ignore meta-property names in `id-denylist`

### DIFF
--- a/lib/rules/id-denylist.js
+++ b/lib/rules/id-denylist.js
@@ -156,6 +156,10 @@ module.exports = {
 
 			const parent = node.parent;
 
+			if (parent.type === "MetaProperty") {
+				return false;
+			}
+
 			/*
 			 * Member access has special rules for checking property names.
 			 * Read access to a property with a restricted name is allowed, because it can be on an object that user has no control over.

--- a/tests/lib/rules/id-denylist.js
+++ b/tests/lib/rules/id-denylist.js
@@ -235,6 +235,18 @@ ruleTester.run("id-denylist", rule, {
 			languageOptions: { ecmaVersion: 2022 },
 		},
 
+		// Meta-properties
+		{
+			code: "import.meta",
+			options: ["import", "meta"],
+			languageOptions: { ecmaVersion: 2020, sourceType: "module" },
+		},
+		{
+			code: "function foo() { new.target; }",
+			options: ["new", "target"],
+			languageOptions: { ecmaVersion: 6 },
+		},
+
 		// Import attribute keys
 		{
 			code: "import foo from 'foo.json' with { type: 'json' }",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:** v24.16.0
- **npm version:** v11.13.0
- **Local ESLint version:** v10.8.0
- **Global ESLint version:** no
- **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->

```js
export default [{}];
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint id-denylist: ["error", "import", "meta", "new", "target"] */

import.meta;

function foo() {
  new.target;
}
```

[Playground](https://eslint.org/play/#eyJ0ZXh0IjoiLyogZXNsaW50IGlkLWRlbnlsaXN0OiBbXCJlcnJvclwiLCBcImltcG9ydFwiLCBcIm1ldGFcIiwgXCJuZXdcIiwgXCJ0YXJnZXRcIl0gKi9cblxuaW1wb3J0Lm1ldGE7XG5cbmZ1bmN0aW9uIGZvbygpIHtcbiAgbmV3LnRhcmdldDtcbn0iLCJvcHRpb25zIjp7InJ1bGVzIjp7fSwibGFuZ3VhZ2VPcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYUZlYXR1cmVzIjp7fX19fX0=)

**What did you expect to happen?**

No errors. `import.meta` and `new.target` are language-defined meta-properties, not user-defined identifiers.

**What actually happened? Please include the actual, raw output from ESLint.**

```
Identifier 'import' is restricted.
Identifier 'meta' is restricted.
Identifier 'new' is restricted.
Identifier 'target' is restricted.
```

#### What changes did you make? (Give an overview)

Updated `id-denylist` to ignore identifiers whose parent node is `MetaProperty`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
