### PR TITLE
fix: ignore meta-property names in `id-match`

### DIFF
--- a/lib/rules/id-match.js
+++ b/lib/rules/id-match.js
@@ -218,7 +218,8 @@ module.exports = {
 
 				if (
 					isReferenceToGlobalVariable(node) ||
-					astUtils.isImportAttributeKey(node)
+					astUtils.isImportAttributeKey(node) ||
+					parent.type === "MetaProperty"
 				) {
 					return;
 				}

--- a/tests/lib/rules/id-match.js
+++ b/tests/lib/rules/id-match.js
@@ -344,6 +344,16 @@ ruleTester.run("id-match", rule, {
 			languageOptions: { ecmaVersion: 2022 },
 		},
 
+		// Meta-properties
+		{
+			code: "import.meta",
+			options: ["^$"],
+		},
+		{
+			code: "function foo() { new.target; }",
+			options: ["^foo$"],
+		},
+
 		// Import attribute keys
 		{
 			code: "import foo from 'foo.json' with { type: 'json' }",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:** v24.16.0
- **npm version:** v11.13.0
- **Local ESLint version:** v10.8.0
- **Global ESLint version:** no
- **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->

```js
export default [{}];
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint id-match: ["error", "^foo$"] */

import.meta;

function foo() {
  new.target;
}
```

[Playground](https://eslint.org/play/#eyJ0ZXh0IjoiLyogZXNsaW50IGlkLW1hdGNoOiBbXCJlcnJvclwiLCBcIl5mb28kXCJdICovXG5cbmltcG9ydC5tZXRhO1xuXG5mdW5jdGlvbiBmb28oKSB7XG4gIG5ldy50YXJnZXQ7XG59XG4iLCJvcHRpb25zIjp7InJ1bGVzIjp7fSwibGFuZ3VhZ2VPcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYUZlYXR1cmVzIjp7fX19fX0=)

**What did you expect to happen?**

No errors. The names in `import.meta` and `new.target` are defined by the language, not user-defined identifiers that should be checked against the configured pattern.

**What actually happened? Please include the actual, raw output from ESLint.**

```
Identifier 'import' does not match the pattern '^foo$'.
Identifier 'meta' does not match the pattern '^foo$'.
Identifier 'new' does not match the pattern '^foo$'.
Identifier 'target' does not match the pattern '^foo$'.
```

#### What changes did you make? (Give an overview)

Updated `id-match` to ignore identifiers whose parent node is `MetaProperty`.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
