### PR TITLE
fix: prevent ASI hazards in no-unused-labels autofix

### DIFF
--- a/lib/rules/no-unused-labels.js
+++ b/lib/rules/no-unused-labels.js
@@ -40,6 +40,28 @@ module.exports = {
 		let scopeInfo = null;
 
 		/**
+		 * Checks whether removing a label could create an Automatic Semicolon
+		 * Insertion (ASI) hazard.
+		 * @param {ASTNode} node The node to check.
+		 * @returns {boolean} Whether removing the label may change parsing.
+		 */
+		function maybeAsiHazard(node) {
+			const SAFE_TOKENS_BEFORE = /^[:;{]$/u;
+			const UNSAFE_CHARS_AFTER = /^[-[(/+`]/u;
+
+			const tokenBefore = sourceCode.getTokenBefore(node);
+			const firstToken = sourceCode.getFirstToken(node.body);
+
+			return (
+				Boolean(firstToken) &&
+				UNSAFE_CHARS_AFTER.test(firstToken.value) &&
+				firstToken.value !== "++" &&
+				firstToken.value !== "--" &&
+				Boolean(tokenBefore) &&
+				!SAFE_TOKENS_BEFORE.test(tokenBefore.value)
+			);
+		}
+		/**
 		 * Adds a scope info to the stack.
 		 * @param {ASTNode} node A node to add. This is a LabeledStatement.
 		 * @returns {void}
@@ -71,6 +93,10 @@ module.exports = {
 				}) !==
 				sourceCode.getTokenBefore(node.body, { includeComments: true })
 			) {
+				return false;
+			}
+
+			if (maybeAsiHazard(node)) {
 				return false;
 			}
 

--- a/tests/lib/rules/no-unused-labels.js
+++ b/tests/lib/rules/no-unused-labels.js
@@ -146,6 +146,47 @@ ruleTester.run("no-unused-labels", rule, {
 			errors: [{ messageId: "unused", data: { name: "A" } }],
 		},
 
+		// https://github.com/eslint/eslint/issues/21165
+
+		{
+			code: "foo()\nA: [1, 2, 3].forEach(x => x)",
+			output: null,
+			languageOptions: { ecmaVersion: 6 },
+			errors: [{ messageId: "unused", data: { name: "A" } }],
+		},
+		{
+			code: "foo()\nA: (1)",
+			output: null,
+			errors: [{ messageId: "unused", data: { name: "A" } }],
+		},
+		{
+			code: "foo()\nA: /foo/.test('foo')",
+			output: null,
+			errors: [{ messageId: "unused", data: { name: "A" } }],
+		},
+		{
+			code: "foo()\nA: +1",
+			output: null,
+			errors: [{ messageId: "unused", data: { name: "A" } }],
+		},
+		{
+			code: "foo()\nA: -1",
+			output: null,
+			errors: [{ messageId: "unused", data: { name: "A" } }],
+		},
+		{
+			code: "foo()\nA: `foo`",
+			output: null,
+			languageOptions: { ecmaVersion: 6 },
+			errors: [{ messageId: "unused", data: { name: "A" } }],
+		},
+		{
+			code: "foo();\nA: [1, 2, 3].forEach(x => x)",
+			output: "foo();\n[1, 2, 3].forEach(x => x)",
+			languageOptions: { ecmaVersion: 6 },
+			errors: [{ messageId: "unused", data: { name: "A" } }],
+		},
+
 		/*
 		 * Below is fatal errors.
 		 * "A: break B",


### PR DESCRIPTION
## Summary

Prevents the `no-unused-labels` autofix from removing a label when doing so could create an Automatic Semicolon Insertion (ASI) hazard.

The autofix is now disabled when the labeled statement body starts with `[`, `(`, `/`, `+`, `-`, or a template literal and the preceding token does not safely separate the statements.

## Related Issues

Fixes #21165

## Tests

Added regression tests covering:

* `[`
* `(`
* `/`
* `+`
* `-`
* Template literals
* A safe case where the preceding statement ends with a semicolon and the autofix remains available

## Test Results

```text
38568 passing
11 pending
```
