### PR TITLE
docs: replace deprecated semi rule in examples

### DIFF
--- a/docs/src/use/formatters/index.md
+++ b/docs/src/use/formatters/index.md
@@ -52,7 +52,7 @@ export default defineConfig([
 			"consistent-return": 2,
 			"indent"           : [1, 4],
 			"no-else-return"   : 1,
-			"semi"             : [1, "always"],
+                        "eqeqeq"           : 2,
 			"space-unary-ops"  : 2
 		}
 	}


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x ] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This pull request updates a documentation example to remove the deprecated `semi` rule. The example in `docs/src/use/formatters/index.md` now uses the supported `eqeqeq` rule instead, preventing users from seeing deprecated rule usage in the documentation.

This addresses #20892.
#### Is there anything you'd like reviewers to focus on?

Please review whether replacing the deprecated `semi` rule example with `eqeqeq` is the appropriate replacement for this documentation example.

<!-- markdownlint-disable-file MD004 -->
