### PR TITLE
fix: don't treat shadowed require as CommonJS require (fixes #21180)

### DIFF
--- a/lib/rules/one-var.js
+++ b/lib/rules/one-var.js
@@ -213,11 +213,60 @@ module.exports = {
 		 * @returns {bool} if decl is a require, return true; else return false.
 		 * @private
 		 */
-		function isRequire(decl) {
+		/**
+		 * Finds the eslint-scope reference in the given scope.
+		 * @param {Object} scope The scope to search.
+		 * @param {ASTNode} node The identifier node.
+		 * @returns {Reference|null} Returns the found reference or null if none were found.
+		 * @private
+		 */
+		function findReference(scope, node) {
+			const references = scope.references.filter(
+				reference =>
+					reference.identifier.range[0] === node.range[0] &&
+					reference.identifier.range[1] === node.range[1],
+			);
+
+			if (references.length === 1) {
+				return references[0];
+			}
+
+			return null;
+		}
+
+		/**
+		 * Checks if the given identifier node is shadowed in the given scope.
+		 * @param {Object} scope The current scope.
+		 * @param {ASTNode} node The identifier node to check.
+		 * @returns {boolean} Whether or not the name is shadowed.
+		 * @private
+		 */
+		function isShadowed(scope, node) {
+			const reference = findReference(scope, node);
+
 			return (
-				decl.init &&
-				decl.init.type === "CallExpression" &&
-				decl.init.callee.name === "require"
+				reference &&
+				reference.resolved &&
+				reference.resolved.defs.length > 0
+			);
+		}
+
+		/**
+		 * Check if a variable declaration is a require.
+		 * @param {ASTNode} decl variable declaration Node
+		 * @returns {bool} if decl is a require, return true; else return false.
+		 * @private
+		 */
+		function isRequire(decl) {
+			if (!decl.init || decl.init.type !== "CallExpression") {
+				return false;
+			}
+
+			const callee = decl.init.callee;
+
+			return (
+				callee.name === "require" &&
+				!isShadowed(sourceCode.getScope(callee), callee)
 			);
 		}
 

--- a/lib/types/rules.d.ts
+++ b/lib/types/rules.d.ts
@@ -4662,6 +4662,7 @@ export interface ESLintRules extends Linter.RulesRecord {
 	 * @since 0.0.9
 	 * @see https://eslint.org/docs/latest/rules/one-var
 	 */
+
 	"one-var": Linter.RuleEntry<
 		[
 			| "always"

--- a/tests/lib/rules/one-var.js
+++ b/tests/lib/rules/one-var.js
@@ -221,6 +221,18 @@ ruleTester.run("one-var", rule, {
 			code: "var foo = require('foo'); var bar = 'bar';",
 			options: [{ separateRequires: true, var: "always" }],
 		},
+		{
+			code: "function foo(require) { const bar = require('bar'), baz = 'baz'; }",
+			options: [{ separateRequires: true, const: "always" }],
+		},
+		{
+			code: "function foo(require) { var bar = require('bar'), baz = 'baz'; }",
+			options: [{ separateRequires: true, var: "always" }],
+		},
+		{
+			code: "function foo(require) { let bar = require('bar'), baz = 'baz'; }",
+			options: [{ separateRequires: true, const: "always" }],
+		},
 
 		// https://github.com/eslint/eslint/issues/4680
 		{


### PR DESCRIPTION
fixes #21180

The one-var rule with separateRequires was treating any call expression with a callee named 'require' as a CommonJS require, even when 'require' is a local parameter or variable.

**Before:**


**After:**


The fix adds two helpers (findReference, isShadowed) using the same pattern as the global-require rule to check whether the 'require' identifier is actually a global reference before treating it as CommonJS require.

Changes:
- lib/rules/one-var.js: scope-aware require detection
- tests/lib/rules/one-var.js: tests for shadowed require parameters