### PR TITLE
test: fix failing ecosystem test for `eslint-plugin-unicorn`

### DIFF
--- a/tools/test-ecosystem/plugins-data.json
+++ b/tools/test-ecosystem/plugins-data.json
@@ -45,13 +45,7 @@
   },
   "eslint-plugin-unicorn": {
     "commands": {
-      "install": [
-        "npm",
-        "install",
-        "--save-dev",
-        "core-js-compat@3.49.0",
-        "eslint-plugin-eslint-plugin@7.5.0"
-      ],
+      "install": ["npm", "install", "core-js-compat@3.49.0"],
       "test": ["npm", "run", "test"]
     },
     "commit": "dd52b4a41a344a36a6970994867e934128b57f03",

--- a/tools/test-ecosystem/plugins-data.json
+++ b/tools/test-ecosystem/plugins-data.json
@@ -49,6 +49,7 @@
         "npm",
         "install",
         "--save-dev",
+        "core-js-compat@3.49.0",
         "eslint-plugin-eslint-plugin@7.5.0"
       ],
       "test": ["npm", "run", "test"]


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:
Fix a failure in CI

The ecosystem test for `eslint-plugin-unicorn` started failing after `core-js-compat` v3.50.0 was released on 2026-08-05. That version empties the support data for `es.promise.try` and `esnext.promise.try`. In 3.49.0 both held a full engine map, `"node": "23.0"` among them. In 3.50.0 both are `{}`. So `require("core-js/stable/promise")` now counts as still needed on any target, and the `no-unnecessary-polyfills` test that expects one error gets none.

The change is deliberate upstream. The core-js 3.50.0 changelog marks `Promise.try` as not properly supported in any engine, following [tc39/ecma262#3883](https://github.com/tc39/ecma262/pull/3883), so a patch release will not bring the old data back.

An example run in CI is https://github.com/eslint/eslint/actions/runs/31060131270/job/94013612129.

#### What changes did you make? (Give an overview)

Pinned `core-js-compat` to 3.49.0 in the plugin data, alongside the existing `eslint-plugin-eslint-plugin` pin. This is the same approach #21156 took for that pin.

#### Is there anything you'd like reviewers to focus on?

`eslint-plugin-unicorn` depends on `core-js-compat` with a `^3.49.0` range, so moving the commit pin forward doesn't avoid this. 3.49.0 is the only published version that satisfies that range and still predates the change, so there is no newer pin to pick.

The plugin's own test needs an update before the pin can be dropped. That is tracked in sindresorhus/eslint-plugin-unicorn#3606.

Fixes #21190

<!-- markdownlint-disable-file MD004 -->
