### PR TITLE
docs: fix broken links in Further Reading sections

### DIFF
--- a/docs/src/_data/further_reading_links.json
+++ b/docs/src/_data/further_reading_links.json
@@ -838,5 +838,19 @@
     "logo": "https://developer.mozilla.org/favicon.ico",
     "title": "parseInt() - JavaScript | MDN",
     "description": "The parseInt() function parses a string argument and returns an integer of the specified radix (the base in mathematical numeral systems)."
+  },
+  "https://web.archive.org/web/20231210222710/https://craftsmanshipforsoftware.com/2015/05/25/complexity-for-javascript/": {
+    "domain": "web.archive.org",
+    "url": "https://web.archive.org/web/20231210222710/https://craftsmanshipforsoftware.com/2015/05/25/complexity-for-javascript/",
+    "logo": "https://s0.wp.com/i/webclip.png",
+    "title": "Complexity for JavaScript",
+    "description": "The control of complexity control presents the core problem of software development. The huge variety of decisions a developer faces on a day-to-day basis cry for methods of controlling and contain…"
+  },
+  "https://github.com/petkaantonov/bluebird/blob/master/docs/docs/warning-explanations.md#warning-a-promise-was-rejected-with-a-non-error": {
+    "domain": "github.com",
+    "url": "https://github.com/petkaantonov/bluebird/blob/master/docs/docs/warning-explanations.md#warning-a-promise-was-rejected-with-a-non-error",
+    "logo": "https://github.com/fluidicon.png",
+    "title": "bluebird/docs/docs/warning-explanations.md at master · petkaantonov/bluebird",
+    "description": ":bird: :zap: Bluebird is a full featured promise library with unmatched performance. - petkaantonov/bluebird"
   }
 }

--- a/docs/src/rules/complexity.md
+++ b/docs/src/rules/complexity.md
@@ -11,7 +11,7 @@ related_rules:
 further_reading:
 - https://en.wikipedia.org/wiki/Cyclomatic_complexity
 - https://ariya.io/2012/12/complexity-analysis-of-javascript-code
-- https://craftsmanshipforsoftware.com/2015/05/25/complexity-for-javascript/
+- https://web.archive.org/web/20231210222710/https://craftsmanshipforsoftware.com/2015/05/25/complexity-for-javascript/
 - https://web.archive.org/web/20160808115119/http://jscomplexity.org/complexity
 - https://github.com/eslint/eslint/issues/4808#issuecomment-167795140
 ---

--- a/docs/src/rules/prefer-promise-reject-errors.md
+++ b/docs/src/rules/prefer-promise-reject-errors.md
@@ -4,7 +4,7 @@ rule_type: suggestion
 related_rules:
 - no-throw-literal
 further_reading:
-- http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-rejected-with-a-non-error
+- https://github.com/petkaantonov/bluebird/blob/master/docs/docs/warning-explanations.md#warning-a-promise-was-rejected-with-a-non-error
 ---
 
 


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

I updated broken external links in the Further Reading sections of the `complexity` and `prefer-promise-reject-errors` rule documentation.

The `Complexity for JavaScript` link in the `complexity` documentation currently redirects to a domain unrelated to the original content. Since I could not find a valid page where the original article had been moved, I replaced the link with an Internet Archive snapshot that preserves the original article.

The Bluebird link referenced in the `prefer-promise-reject-errors` documentation also no longer serves the original content. However, since the original document is still available in the official Bluebird GitHub repository, I replaced the broken link with the corresponding document in the official repository instead of using an archived version.

#### Is there anything you'd like reviewers to focus on?

I replaced these links in the Further Reading sections with an Internet Archive snapshot and the corresponding document in the official GitHub repository. I would appreciate feedback on whether these replacements are appropriate.