### PR TITLE
fix: Prevent no-var autofix when var is shadowed by catch parameter

### DIFF
--- a/lib/rules/no-var.js
+++ b/lib/rules/no-var.js
@@ -228,25 +228,21 @@ function hasReferenceBeforeDeclaration(variable) {
  * Scope analysis does not report this as a redeclaration, because the catch
  * parameter and the `var` are distinct variables living in distinct scopes, so
  * neither one has more than one definition.
+ *
+ * Resolving the name from the scope of the declaration is enough to detect it.
+ * A simple catch parameter is the only binding a `var` is allowed to shadow:
+ * any other block-scoped declaration of the same name makes the `var` itself a
+ * syntax error, and a function parameter shares its variable with the `var`, so
+ * that case is reported by `isRedeclared` instead.
  * @param {ASTNode} node A `VariableDeclaration` node to check.
  * @param {SourceCode} sourceCode The source code object.
  * @returns {Function} The predicate function which checks whether a given
  *      variable is shadowed by a `catch` clause parameter.
  */
 function isShadowedByCatchParameter(node, sourceCode) {
-	return variable => {
-		for (
-			let scope = sourceCode.getScope(node);
-			scope && scope !== variable.scope;
-			scope = scope.upper
-		) {
-			if (scope.type === "catch" && scope.set.has(variable.name)) {
-				return true;
-			}
-		}
-
-		return false;
-	};
+	return variable =>
+		astUtils.getVariableByName(sourceCode.getScope(node), variable.name) !==
+		variable;
 }
 
 //------------------------------------------------------------------------------

--- a/lib/rules/no-var.js
+++ b/lib/rules/no-var.js
@@ -221,6 +221,34 @@ function hasReferenceBeforeDeclaration(variable) {
 	});
 }
 
+/**
+ * Checks whether a given variable is shadowed by the parameter of an enclosing
+ * `catch` clause.
+ *
+ * Scope analysis does not report this as a redeclaration, because the catch
+ * parameter and the `var` are distinct variables living in distinct scopes, so
+ * neither one has more than one definition.
+ * @param {ASTNode} node A `VariableDeclaration` node to check.
+ * @param {SourceCode} sourceCode The source code object.
+ * @returns {Function} The predicate function which checks whether a given
+ *      variable is shadowed by a `catch` clause parameter.
+ */
+function isShadowedByCatchParameter(node, sourceCode) {
+	return variable => {
+		for (
+			let scope = sourceCode.getScope(node);
+			scope && scope !== variable.scope;
+			scope = scope.upper
+		) {
+			if (scope.type === "catch" && scope.set.has(variable.name)) {
+				return true;
+			}
+		}
+
+		return false;
+	};
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -276,6 +304,7 @@ module.exports = {
 		 * - A variable is referenced before its declaration.
 		 * - A variable is declared in statement position (e.g. a single-line `IfStatement`)
 		 * - A variable has name that is disallowed for `let` declarations.
+		 * - A variable is shadowed by a `catch` clause parameter.
 		 *
 		 * ## A variable is declared on a SwitchCase node.
 		 *
@@ -312,6 +341,15 @@ module.exports = {
 		 * the implementation simple, we only convert `var` to `let` within
 		 * loops when the variable is a loop assignee or the declaration has an
 		 * initializer.
+		 *
+		 * ## A variable is shadowed by a `catch` clause parameter.
+		 *
+		 * A `var` declaration may reuse the name of a simple catch clause
+		 * parameter, but the equivalent `let` declaration may not. Directly
+		 * inside the catch block, `let` would be a syntax error. In a nested
+		 * block, `let` is valid but changes behavior: the `var` assigns to the
+		 * catch parameter, while the `let` introduces a separate binding and
+		 * leaves the catch parameter untouched.
 		 * @param {ASTNode} node A variable declaration node to check.
 		 * @returns {boolean} `true` if it can fix the node.
 		 */
@@ -330,7 +368,8 @@ module.exports = {
 				variables.some(isRedeclared) ||
 				variables.some(isUsedFromOutsideOf(scopeNode)) ||
 				variables.some(hasNameDisallowedForLetDeclarations) ||
-				variables.some(hasReferenceBeforeDeclaration)
+				variables.some(hasReferenceBeforeDeclaration) ||
+				variables.some(isShadowedByCatchParameter(node, sourceCode))
 			) {
 				return false;
 			}

--- a/tests/lib/rules/no-var.js
+++ b/tests/lib/rules/no-var.js
@@ -505,6 +505,59 @@ ruleTester.run("no-var", rule, {
 				{ messageId: "unexpectedVar" },
 			],
 		},
+
+		// https://github.com/eslint/eslint/issues/21194
+		{
+			// `let` here would be a syntax error.
+			code: "function f() { try {} catch (e) { var e = 1; } }",
+			output: null,
+			errors: [{ messageId: "unexpectedVar" }],
+		},
+		{
+			code: "function f() { try {} catch (e) { var e; } }",
+			output: null,
+			errors: [{ messageId: "unexpectedVar" }],
+		},
+		{
+			// `let` here is valid, but assigns a new binding instead of `e`.
+			code: "function f() { try {} catch (e) { { var e = 1; } } }",
+			output: null,
+			errors: [{ messageId: "unexpectedVar" }],
+		},
+		{
+			code: "function f() { try {} catch (e) { try {} catch (x) { var e = 1; } } }",
+			output: null,
+			errors: [{ messageId: "unexpectedVar" }],
+		},
+		{
+			code: "function f() { try {} catch (e) { for (var e of []) {} } }",
+			output: null,
+			errors: [{ messageId: "unexpectedVar" }],
+		},
+
+		// Declarations that do not conflict with the catch parameter are still fixed.
+		{
+			code: "function f() { try {} catch (e) { var x = 1; } }",
+			output: "function f() { try {} catch (e) { let x = 1; } }",
+			errors: [{ messageId: "unexpectedVar" }],
+		},
+		{
+			code: "function f() { try {} catch (e) {} var e = 1; }",
+			output: "function f() { try {} catch (e) {} let e = 1; }",
+			errors: [{ messageId: "unexpectedVar" }],
+		},
+		{
+			code: "function f() { try {} catch (e) { function g() { var e = 1; } } }",
+			output: "function f() { try {} catch (e) { function g() { let e = 1; } } }",
+			errors: [{ messageId: "unexpectedVar" }],
+		},
+		{
+			// A class static block is a variable scope of its own.
+			code: "function f() { try {} catch (e) { class C { static { var e = 1; } } } }",
+			output: "function f() { try {} catch (e) { class C { static { let e = 1; } } } }",
+			languageOptions: { ecmaVersion: 2022 },
+			errors: [{ messageId: "unexpectedVar" }],
+		},
 	],
 });
 


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #21194

#### What changes did you make? (Give an overview)

`no-var` autofixed a `var` declaration that reuses the name of a catch clause
parameter. A `var` may do this (Annex B.3.4), but the equivalent `let` may not,
and the fix breaks the code in two different ways:

```js
function f() {
    try { throw new Error("boom"); }
    catch (e) { var e = 99; console.log(e); }        // 99
}
// after --fix: `let e = 99` -> SyntaxError: Identifier 'e' has already been declared

function g() {
    try { throw new Error("boom"); }
    catch (e) { { var e = 99; } console.log(e); }    // 99
}
// after --fix: `{ let e = 99; }` -> parses, but logs the Error instead of 99
```

Directly inside the catch block the result is a syntax error. In a nested block
it is valid syntax, but the `var` assigns to the catch parameter while the `let`
introduces a separate binding, so the value silently changes.

None of the existing checks catch this:

- `isRedeclared` tests `defs.length >= 2`, but the catch parameter and the `var`
  are distinct variables in distinct scopes, so each has exactly one definition.
  (The function parameter equivalent, `function f(e) { var e = 1; }`, shares a
  scope and is already handled.)
- The reference-based checks cannot see it either. Inside the catch block, `e`
  resolves to the catch parameter, so the `var` ends up with no references at
  all — `isUsedFromOutsideOf` and `hasReferenceBeforeDeclaration` have nothing
  to look at.

Added `isShadowedByCatchParameter`, which walks the scope chain from the
declaration's scope up to the variable's scope, looking for a catch scope that
binds the same name. Nested blocks fall out of this for free, since they are
already links in that chain.

Restricting the check to catch scopes is sufficient: every other construct that
introduces a block-scoped binding makes a same-named `var` inside it a syntax
error, so such code cannot reach the rule. A simple catch parameter is the only
binding a `var` is permitted to shadow this way.

Declarations that do not conflict are still autofixed. Four of the nine added
tests cover that: a differently-named `var` in the catch block, a same-named
`var` outside it, and same-named `var`s inside a nested function and inside a
class static block (both of which are variable scopes of their own, so the
scope walk stops before reaching the catch scope).

#### Is there anything you'd like reviewers to focus on?

1. Whether blocking the nested-block case belongs in this PR. It is not a syntax
   error, only a silent behavior change. I included it because the rule already
   declines to fix in several situations that are valid syntax but change
   behavior (`isUsedFromOutsideOf`, `isReferencedInClosure`, and the loop
   checks), so it seemed consistent — but I am happy to narrow the scope to the
   syntax error case if you would rather keep them separate.

2. Whether walking the scope chain is the preferred approach, or whether this
   should be folded into `isRedeclared` instead.