### PR TITLE
docs: update moved compat-table links in Further Reading

### DIFF
--- a/docs/src/_data/further_reading_links.json
+++ b/docs/src/_data/further_reading_links.json
@@ -852,5 +852,19 @@
     "logo": "https://github.com/fluidicon.png",
     "title": "bluebird/docs/docs/warning-explanations.md at master · petkaantonov/bluebird",
     "description": ":bird: :zap: Bluebird is a full featured promise library with unmatched performance. - petkaantonov/bluebird"
+  },
+  "https://compat-table.github.io/compat-table/es5/#test-Object/array_literal_extensions_Reserved_words_as_property_names": {
+    "domain": "compat-table.github.io",
+    "url": "https://compat-table.github.io/compat-table/es5/#test-Object/array_literal_extensions_Reserved_words_as_property_names",
+    "logo": "https://compat-table.github.io/compat-table/favicon.ico",
+    "title": "ECMAScript 5 compatibility table",
+    "description": null
+  },
+  "https://compat-table.github.io/compat-table/es6/": {
+    "domain": "compat-table.github.io",
+    "url": "https://compat-table.github.io/compat-table/es6/",
+    "logo": "https://compat-table.github.io/compat-table/favicon.ico",
+    "title": "ECMAScript 6 compatibility table",
+    "description": null
   }
 }

--- a/docs/src/rules/no-iterator.md
+++ b/docs/src/rules/no-iterator.md
@@ -3,7 +3,7 @@ title: no-iterator
 rule_type: suggestion
 further_reading:
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators
-- https://kangax.github.io/es5-compat-table/es6/#Iterators
+- https://compat-table.github.io/compat-table/es6/
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#Object_methods
 ---
 

--- a/docs/src/rules/no-reserved-keys.md
+++ b/docs/src/rules/no-reserved-keys.md
@@ -2,7 +2,7 @@
 title: no-reserved-keys
 
 further_reading:
-- https://kangax.github.io/compat-table/es5/#Reserved_words_as_property_names
+- https://compat-table.github.io/compat-table/es5/#test-Object/array_literal_extensions_Reserved_words_as_property_names
 ---
 
 Disallows unquoted reserved words as property names in object literals.

--- a/docs/src/rules/quote-props.md
+++ b/docs/src/rules/quote-props.md
@@ -2,7 +2,7 @@
 title: quote-props
 rule_type: suggestion
 further_reading:
-- https://kangax.github.io/compat-table/es5/#Reserved_words_as_property_names
+- https://compat-table.github.io/compat-table/es5/#test-Object/array_literal_extensions_Reserved_words_as_property_names
 - https://mathiasbynens.be/notes/javascript-properties
 ---
 Object literal property names can be defined in two ways: using literals or using strings. For example, these two objects are equivalent:


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

The compat-table project moved from the `kangax` GitHub organization to
`compat-table`, and two old URLs in Further Reading sections no longer work.

`https://kangax.github.io/compat-table/es5/` returns a 404 with no redirect
of any kind. It is used in `quote-props.md` and `no-reserved-keys.md`.

`https://kangax.github.io/es5-compat-table/es6/` still responds, but only to
serve a meta refresh to `http://kangax.github.io/compat-table/es6`, which
itself returns a 404. It is used in `no-iterator.md`.

I pointed all three entries at the new `compat-table.github.io` URLs and
regenerated `further_reading_links.json`.

#### Is there anything you'd like reviewers to focus on?

Two things worth a look.

The ES5 anchor changed on the new site. The old `#Reserved_words_as_property_names`
is now `#test-Object/array_literal_extensions_Reserved_words_as_property_names`,
which I verified exists on the page.

The ES6 page has no equivalent of the old `#Iterators` anchor. I could not find
a matching section, so that entry now links to the page without a fragment.
Happy to point it somewhere more specific if you know a better target.

<!-- markdownlint-disable-file MD004 -->