### PR TITLE
fix: prefer-template invalid autofix creates a tagged template call

### DIFF
--- a/lib/rules/prefer-template.js
+++ b/lib/rules/prefer-template.js
@@ -299,9 +299,15 @@ module.exports = {
 				return null;
 			}
 
+			const prefix =
+				astUtils.isStartOfExpressionStatement(topBinaryExpr) &&
+				astUtils.needsPrecedingSemicolon(sourceCode, topBinaryExpr)
+					? ";"
+					: "";
+
 			return fixer.replaceText(
 				topBinaryExpr,
-				getTemplateLiteral(topBinaryExpr, null, null),
+				`${prefix}${getTemplateLiteral(topBinaryExpr, null, null)}`,
 			);
 		}
 

--- a/tests/lib/rules/prefer-template.js
+++ b/tests/lib/rules/prefer-template.js
@@ -419,5 +419,54 @@ ruleTester.run("prefer-template", rule, {
 			output: `\`${"\\".repeat(1_000_000)}\${  test}\``,
 			errors,
 		},
+
+		// preceding semicolon needed
+		{
+			code: "foo\n'bar' + baz",
+			output: "foo\n;`bar${  baz}`",
+			errors,
+		},
+		{
+			code: "foo()\n'bar' + baz",
+			output: "foo()\n;`bar${  baz}`",
+			errors,
+		},
+		{
+			code: "foo[0]\n'bar' + baz",
+			output: "foo[0]\n;`bar${  baz}`",
+			errors,
+		},
+		{
+			code: "`template`\n'bar' + baz",
+			output: "`template`\n;`bar${  baz}`",
+			errors,
+		},
+		{
+			code: "'qux'\n'bar' + baz",
+			output: "'qux'\n;`bar${  baz}`",
+			errors,
+		},
+
+		// preceding semicolon not needed
+		{
+			code: "foo;\n'bar' + baz",
+			output: "foo;\n`bar${  baz}`",
+			errors,
+		},
+		{
+			code: "if (foo) {}\n'bar' + baz",
+			output: "if (foo) {}\n`bar${  baz}`",
+			errors,
+		},
+		{
+			code: "'bar' + baz",
+			output: "`bar${  baz}`",
+			errors,
+		},
+		{
+			code: "foo\nconsole.log('bar' + baz)", // not at the start of an expression statement
+			output: "foo\nconsole.log(`bar${  baz}`)",
+			errors,
+		},
 	],
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

prefer-template's autofix replaces string concatenation with a template literal, and the result always starts with a backtick. 
If the statement before it has no semicolon, the backtick can continue it as a tagged template call instead of starting a new statement.

```js
tag
"hello" + 1
// after --fix: tag`hello${1}` -- calls tag as a tag function, not two statements
```

Added a semicolon before the fix in that case, using isStartOfExpressionStatement and needsPrecedingSemicolon from ast-utils.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
