### PR TITLE
perf: Implement fast paths in critical areas

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -6,6 +6,15 @@
 "use strict";
 
 //-----------------------------------------------------------------------------
+// Requirements
+//-----------------------------------------------------------------------------
+
+const { ESLint } = require("./eslint/eslint");
+const { Linter } = require("./linter");
+const { RuleTester } = require("./rule-tester");
+const { SourceCode } = require("./languages/js/source-code");
+
+//-----------------------------------------------------------------------------
 // Functions
 //-----------------------------------------------------------------------------
 
@@ -14,31 +23,17 @@
  * @returns {Promise<ESLint>} The ESLint constructor.
  */
 async function loadESLint() {
-	return require("./eslint/eslint").ESLint;
+	return ESLint;
 }
 
 //-----------------------------------------------------------------------------
 // Exports
 //-----------------------------------------------------------------------------
 
-/*
- * The exports are defined as lazy getters so that requiring this module
- * doesn't eagerly load the entire dependency graph of every export. This
- * significantly speeds up loading for consumers that use only some of the
- * exports (or none, such as type-only consumers).
- */
 module.exports = {
-	get Linter() {
-		return require("./linter").Linter;
-	},
+	Linter,
 	loadESLint,
-	get ESLint() {
-		return require("./eslint/eslint").ESLint;
-	},
-	get RuleTester() {
-		return require("./rule-tester").RuleTester;
-	},
-	get SourceCode() {
-		return require("./languages/js/source-code").SourceCode;
-	},
+	ESLint,
+	RuleTester,
+	SourceCode,
 };

--- a/lib/api.js
+++ b/lib/api.js
@@ -6,15 +6,6 @@
 "use strict";
 
 //-----------------------------------------------------------------------------
-// Requirements
-//-----------------------------------------------------------------------------
-
-const { ESLint } = require("./eslint/eslint");
-const { Linter } = require("./linter");
-const { RuleTester } = require("./rule-tester");
-const { SourceCode } = require("./languages/js/source-code");
-
-//-----------------------------------------------------------------------------
 // Functions
 //-----------------------------------------------------------------------------
 
@@ -23,17 +14,31 @@ const { SourceCode } = require("./languages/js/source-code");
  * @returns {Promise<ESLint>} The ESLint constructor.
  */
 async function loadESLint() {
-	return ESLint;
+	return require("./eslint/eslint").ESLint;
 }
 
 //-----------------------------------------------------------------------------
 // Exports
 //-----------------------------------------------------------------------------
 
+/*
+ * The exports are defined as lazy getters so that requiring this module
+ * doesn't eagerly load the entire dependency graph of every export. This
+ * significantly speeds up loading for consumers that use only some of the
+ * exports (or none, such as type-only consumers).
+ */
 module.exports = {
-	Linter,
+	get Linter() {
+		return require("./linter").Linter;
+	},
 	loadESLint,
-	ESLint,
-	RuleTester,
-	SourceCode,
+	get ESLint() {
+		return require("./eslint/eslint").ESLint;
+	},
+	get RuleTester() {
+		return require("./rule-tester").RuleTester;
+	},
+	get SourceCode() {
+		return require("./languages/js/source-code").SourceCode;
+	},
 };

--- a/lib/cli-engine/formatters/stylish.js
+++ b/lib/cli-engine/formatters/stylish.js
@@ -31,11 +31,15 @@ function getStyleText(color) {
 /**
  * Computes the visible width of a string, avoiding the cost of stripping
  * VT control characters when the string doesn't contain any.
+ *
+ * VT sequences can be introduced either by the 7-bit `ESC` character or by
+ * the 8-bit `CSI` character, both of which `util.stripVTControlCharacters()`
+ * removes, so both must be checked before taking the fast path.
  * @param {string} str The string to measure.
  * @returns {number} The number of visible characters.
  */
 function stringLength(str) {
-	return str.includes("\u001b")
+	return str.includes("\u001b") || str.includes("\u009b")
 		? util.stripVTControlCharacters(str).length
 		: str.length;
 }

--- a/lib/cli-engine/formatters/stylish.js
+++ b/lib/cli-engine/formatters/stylish.js
@@ -29,6 +29,18 @@ function getStyleText(color) {
 }
 
 /**
+ * Computes the visible width of a string, avoiding the cost of stripping
+ * VT control characters when the string doesn't contain any.
+ * @param {string} str The string to measure.
+ * @returns {number} The number of visible characters.
+ */
+function stringLength(str) {
+	return str.includes("\u001b")
+		? util.stripVTControlCharacters(str).length
+		: str.length;
+}
+
+/**
  * Given a word and a count, append an s if count is not one.
  * @param {string} word A word in its singular form.
  * @param {number} count A number controlling whether word should be pluralized.
@@ -77,20 +89,33 @@ module.exports = function (results, data) {
 					messageType = styleText("yellow", "warning");
 				}
 
+				/*
+				 * Strip a trailing period unless it's preceded by a space.
+				 * This is equivalent to `.replace(/([^ ])\.$/u, "$1")` but
+				 * avoids running a regex on every message.
+				 */
+				let messageText = message.message;
+
+				if (
+					messageText.length > 1 &&
+					messageText.endsWith(".") &&
+					messageText.at(-2) !== " "
+				) {
+					messageText = messageText.slice(0, -1);
+				}
+
 				return [
 					"",
 					String(message.line || 0),
 					String(message.column || 0),
 					messageType,
-					message.message.replace(/([^ ])\.$/u, "$1"),
+					messageText,
 					message.ruleId ? styleText("dim", message.ruleId) : "",
 				];
 			}),
 			{
 				align: ["", "r", "l"],
-				stringLength(str) {
-					return util.stripVTControlCharacters(str).length;
-				},
+				stringLength,
 			},
 		)
 			.split("\n")

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -12,8 +12,23 @@
 const { deepMergeArrays } = require("../shared/deep-merge-arrays");
 const { flatConfigSchema, hasMethod } = require("./flat-config-schema");
 const { ObjectSchema } = require("@eslint/config-array");
-const ajvImport = require("../shared/ajv");
-const ajv = ajvImport();
+/*
+ * `ajv` pulls in a large dependency graph (~40 modules) that's only needed
+ * once a rule's options actually need schema validation, so it's constructed
+ * lazily on first use instead of eagerly at module load time.
+ */
+let ajv;
+
+/**
+ * Gets the lazily-constructed shared ajv instance.
+ * @returns {import("ajv").Ajv} The ajv instance.
+ */
+function getAjv() {
+	if (!ajv) {
+		ajv = require("../shared/ajv")();
+	}
+	return ajv;
+}
 const ruleReplacements = require("../../conf/replacements.json");
 
 //-----------------------------------------------------------------------------
@@ -413,7 +428,7 @@ function getOrCreateValidator(rule, ruleId) {
 			const schema = getRuleOptionsSchema(rule);
 
 			if (schema) {
-				validators.set(rule, ajv.compile(schema));
+				validators.set(rule, getAjv().compile(schema));
 			}
 		} catch (err) {
 			throw new InvalidRuleOptionsSchemaError(ruleId, err);

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -444,6 +444,14 @@ class Config {
 	#processorName;
 
 	/**
+	 * Cache of rule definitions by rule ID. Rule lookups involve string
+	 * parsing and multiple property accesses, so the results are cached
+	 * because they're requested repeatedly for the same rule IDs.
+	 * @type {Map<string, RuleDefinition|undefined>}
+	 */
+	#ruleDefinitions = new Map();
+
+	/**
 	 * Creates a new instance.
 	 * @param {Object} config The configuration object.
 	 */
@@ -596,7 +604,14 @@ class Config {
 	 * @returns {RuleDefinition|undefined} The rule definition from the plugin, or `undefined` if the rule is not found.
 	 */
 	getRuleDefinition(ruleId) {
-		return getRuleFromConfig(ruleId, this);
+		if (this.#ruleDefinitions.has(ruleId)) {
+			return this.#ruleDefinitions.get(ruleId);
+		}
+
+		const rule = getRuleFromConfig(ruleId, this);
+
+		this.#ruleDefinitions.set(ruleId, rule);
+		return rule;
 	}
 
 	/**

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -12,23 +12,6 @@
 const { deepMergeArrays } = require("../shared/deep-merge-arrays");
 const { flatConfigSchema, hasMethod } = require("./flat-config-schema");
 const { ObjectSchema } = require("@eslint/config-array");
-/*
- * `ajv` pulls in a large dependency graph (~40 modules) that's only needed
- * once a rule's options actually need schema validation, so it's constructed
- * lazily on first use instead of eagerly at module load time.
- */
-let ajv;
-
-/**
- * Gets the lazily-constructed shared ajv instance.
- * @returns {import("ajv").Ajv} The ajv instance.
- */
-function getAjv() {
-	if (!ajv) {
-		ajv = require("../shared/ajv")();
-	}
-	return ajv;
-}
 const ruleReplacements = require("../../conf/replacements.json");
 
 //-----------------------------------------------------------------------------
@@ -67,9 +50,30 @@ const severities = new Map([
  */
 const validators = new WeakMap();
 
+/**
+ * The shared ajv instance, constructed on first use.
+ *
+ * `ajv` pulls in a large dependency graph (~40 modules) that's only needed
+ * once a rule's options actually need schema validation, so it's constructed
+ * lazily instead of eagerly at module load time.
+ * @type {import("ajv").Ajv|undefined}
+ */
+let ajv;
+
 //-----------------------------------------------------------------------------
 // Helpers
 //-----------------------------------------------------------------------------
+
+/**
+ * Gets the shared ajv instance, constructing it on first use.
+ * @returns {import("ajv").Ajv} The ajv instance.
+ */
+function getAjv() {
+	if (!ajv) {
+		ajv = require("../shared/ajv")();
+	}
+	return ajv;
+}
 
 /**
  * Throws a helpful error when a rule cannot be found.

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -649,7 +649,7 @@ class Config {
 			// normalize severity
 			ruleConfig[0] = severities.get(ruleConfig[0]);
 
-			const rule = getRuleFromConfig(ruleId, this);
+			const rule = this.getRuleDefinition(ruleId);
 
 			// apply meta.defaultOptions
 			const slicedOptions = ruleConfig.slice(1);
@@ -719,7 +719,7 @@ class Config {
 				continue;
 			}
 
-			const rule = getRuleFromConfig(ruleId, this);
+			const rule = this.getRuleDefinition(ruleId);
 
 			if (!rule) {
 				throwRuleNotFoundError(parseRuleId(ruleId), this);

--- a/lib/linter/apply-disable-directives.js
+++ b/lib/linter/apply-disable-directives.js
@@ -309,6 +309,14 @@ function collectUsedEnableDirectives(directives) {
  * of problems (including suppressed ones) and unused eslint-disable directives
  */
 function applyDirectives(options) {
+	// Fast path: without directives there's nothing to suppress or report.
+	if (options.directives.length === 0) {
+		return {
+			problems: options.problems.slice(),
+			unusedDirectives: [],
+		};
+	}
+
 	const problems = [];
 	const usedDisableDirectives = new Set();
 	const { sourceCode } = options;

--- a/lib/linter/esquery.js
+++ b/lib/linter/esquery.js
@@ -65,6 +65,23 @@ class ESQueryParsedSelector {
 	identifierCount;
 
 	/**
+	 * Whether this selector is guaranteed to match any node it is tested
+	 * against after node-type-based filtering, making an `esquery.matches()`
+	 * call unnecessary. This is `true` only for selectors that consist solely
+	 * of node type identifiers, wildcards, or unions thereof.
+	 * @type {boolean}
+	 */
+	alwaysMatches;
+
+	/**
+	 * A specialized matcher function that is equivalent to calling
+	 * `esquery.matches()` for this selector but faster, or `null` if no
+	 * specialized matcher is available for this selector.
+	 * @type {((node: Object, ancestry: Object[], options: ESQueryOptions) => boolean)|null}
+	 */
+	fastMatch;
+
+	/**
 	 * Creates a new parsed selector.
 	 * @param {string} source The raw selector string that was parsed
 	 * @param {boolean} isExit Whether this selector is an exit selector
@@ -72,6 +89,8 @@ class ESQueryParsedSelector {
 	 * @param {string[]|null} nodeTypes The node types that could possibly trigger this selector, or `null` if all node types could trigger it
 	 * @param {number} attributeCount The number of class, pseudo-class, and attribute queries in this selector
 	 * @param {number} identifierCount The number of identifier queries in this selector
+	 * @param {boolean} alwaysMatches Whether this selector always matches nodes it is tested against after node-type-based filtering
+	 * @param {Function|null} fastMatch A specialized matcher function for this selector, or `null` if not available
 	 */
 	constructor(
 		source,
@@ -80,6 +99,8 @@ class ESQueryParsedSelector {
 		nodeTypes,
 		attributeCount,
 		identifierCount,
+		alwaysMatches,
+		fastMatch,
 	) {
 		this.source = source;
 		this.isExit = isExit;
@@ -87,6 +108,8 @@ class ESQueryParsedSelector {
 		this.nodeTypes = nodeTypes;
 		this.attributeCount = attributeCount;
 		this.identifierCount = identifierCount;
+		this.alwaysMatches = alwaysMatches;
+		this.fastMatch = fastMatch;
 	}
 
 	/**
@@ -231,6 +254,95 @@ function analyzeParsedSelector(parsedSelector) {
 }
 
 /**
+ * Determines whether a parsed selector consists solely of node type
+ * identifiers, wildcards, or unions thereof. Such selectors are guaranteed to
+ * match any node they are tested against after node-type-based filtering, so
+ * calling `esquery.matches()` for them is unnecessary.
+ * @param {ESQuerySelector} selector The parsed selector to check.
+ * @returns {boolean} `true` if the selector always matches nodes it is tested against after node-type-based filtering.
+ */
+function isAlwaysMatchingSelector(selector) {
+	switch (selector.type) {
+		case "identifier":
+		case "wildcard":
+			return true;
+
+		case "matches":
+			return selector.selectors.every(isAlwaysMatchingSelector);
+
+		default:
+			return false;
+	}
+}
+
+/**
+ * Creates a specialized matcher function for selectors of the shape
+ * `ParentType > .field` or `ParentType > *.field`, which are common in core
+ * rules but can't be bucketed by node type. The matcher replicates `esquery`'s
+ * matching behavior for these selectors: the parent (`ancestry[0]`) must have
+ * the given node type (case-insensitively, as `esquery` matches identifiers
+ * case-insensitively), and the node must be the value of the parent's given
+ * field (or an element of it, if the field value is an array).
+ * @param {ESQuerySelector} root The parsed selector to create a matcher for.
+ * @returns {Function|null} A matcher function, or `null` if the selector doesn't have the expected shape.
+ */
+function createFastMatcher(root) {
+	if (root.type !== "child") {
+		return null;
+	}
+
+	const { left, right } = root;
+
+	if (left.type !== "identifier" || left.subject || right.subject) {
+		return null;
+	}
+
+	let field = null;
+
+	if (right.type === "field") {
+		field = right;
+	} else if (right.type === "compound" && right.selectors.length === 2) {
+		const [first, second] = right.selectors;
+
+		if (first.type === "wildcard" && second.type === "field") {
+			field = second;
+		} else if (first.type === "field" && second.type === "wildcard") {
+			field = first;
+		}
+	}
+
+	if (!field || field.subject || field.name.includes(".")) {
+		return null;
+	}
+
+	const parentType = left.value;
+	const parentTypeLowercase = parentType.toLowerCase();
+	const fieldName = field.name;
+
+	return (node, ancestry, options) => {
+		const parent = ancestry[0];
+
+		if (!parent) {
+			return false;
+		}
+
+		const parentTypeActual = parent[options?.nodeTypeKey || "type"];
+
+		if (
+			parentTypeActual !== parentType &&
+			(typeof parentTypeActual !== "string" ||
+				parentTypeActual.toLowerCase() !== parentTypeLowercase)
+		) {
+			return false;
+		}
+
+		const value = parent[fieldName];
+
+		return value === node || (Array.isArray(value) && value.includes(node));
+	};
+}
+
+/**
  * Tries to parse a simple selector string, such as a single identifier or wildcard.
  * This saves time by avoiding the overhead of esquery parsing for simple cases.
  * @param {string} selector The selector string to parse.
@@ -303,6 +415,8 @@ function parse(source) {
 		nodeTypes,
 		attributeCount,
 		identifierCount,
+		isAlwaysMatchingSelector(parsedSelector),
+		createFastMatcher(parsedSelector),
 	);
 
 	selectorCache.set(source, result);

--- a/lib/linter/esquery.js
+++ b/lib/linter/esquery.js
@@ -293,7 +293,14 @@ function createFastMatcher(root) {
 
 	const { left, right } = root;
 
-	if (left.type !== "identifier" || left.subject || right.subject) {
+	/*
+	 * Subject indicators (`!`) are intentionally not checked here. `esquery`
+	 * only consults `subject` in its `sibling` and `adjacent` matchers (and in
+	 * `esquery.query()`, which ESLint doesn't use), so for the `child`
+	 * selectors handled here a subject indicator has no effect on
+	 * `esquery.matches()`.
+	 */
+	if (left.type !== "identifier") {
 		return null;
 	}
 
@@ -306,12 +313,14 @@ function createFastMatcher(root) {
 
 		if (first.type === "wildcard" && second.type === "field") {
 			field = second;
-		} else if (first.type === "field" && second.type === "wildcard") {
-			field = first;
 		}
 	}
 
-	if (!field || field.subject || field.name.includes(".")) {
+	/*
+	 * Fields with a dotted name match against `ancestry[path.length - 1]`
+	 * rather than the immediate parent, so they aren't handled here.
+	 */
+	if (!field || field.name.includes(".")) {
 		return null;
 	}
 

--- a/lib/linter/file-report.js
+++ b/lib/linter/file-report.js
@@ -133,10 +133,14 @@ function createLintingProblem(options, severity, language) {
  * @returns {MessageDescriptor} A normalized object containing report information
  */
 function normalizeMultiArgReportCall(...args) {
-	// If there is one argument, it is considered to be a new-style call already.
+	/*
+	 * If there is one argument, it is considered to be a new-style call
+	 * already. The descriptor is fully consumed synchronously before
+	 * `addRuleMessage()` returns and is never mutated or retained, so it's
+	 * safe to use without cloning even if the rule reuses the object.
+	 */
 	if (args.length === 1) {
-		// Shallow clone the object to avoid surprises if reusing the descriptor
-		return Object.assign({}, args[0]);
+		return args[0];
 	}
 
 	// If the second argument is a string, the arguments are interpreted as [node, message, data, fix].
@@ -212,12 +216,20 @@ function cloneFix(fix) {
  */
 function assertValidFix(fix) {
 	if (fix) {
-		assert(
+		/*
+		 * The error message is built only when the assertion fails so that
+		 * the common case doesn't pay for the `JSON.stringify()` call.
+		 */
+		if (!(
 			fix.range &&
-				typeof fix.range[0] === "number" &&
-				typeof fix.range[1] === "number",
-			`Fix has invalid range: ${JSON.stringify(fix, null, 2)}`,
-		);
+			typeof fix.range[0] === "number" &&
+			typeof fix.range[1] === "number"
+		)) {
+			assert(
+				false,
+				`Fix has invalid range: ${JSON.stringify(fix, null, 2)}`,
+			);
+		}
 	}
 }
 
@@ -283,14 +295,13 @@ function mergeFixes(fixes, sourceCode) {
  * If the descriptor retrieves multiple fixes, this merges those to one.
  * @param {MessageDescriptor} descriptor The report descriptor.
  * @param {SourceCode} sourceCode The source code object to get text between fixes.
+ * @param {RuleFixer} ruleFixer The rule fixer to pass to the descriptor's `fix` function.
  * @returns {({text: string, range: number[]}|null)} The fix for the descriptor
  */
-function normalizeFixes(descriptor, sourceCode) {
+function normalizeFixes(descriptor, sourceCode, ruleFixer) {
 	if (typeof descriptor.fix !== "function") {
 		return null;
 	}
-
-	const ruleFixer = new RuleFixer({ sourceCode });
 
 	// @type {null | Fix | Fix[] | IterableIterator<Fix>}
 	const fix = descriptor.fix(ruleFixer);
@@ -309,9 +320,10 @@ function normalizeFixes(descriptor, sourceCode) {
  * @param {MessageDescriptor} descriptor The report descriptor.
  * @param {SourceCode} sourceCode The source code object to get text between fixes.
  * @param {Object} messages Object of meta messages for the rule.
+ * @param {RuleFixer} ruleFixer The rule fixer to pass to suggestions' `fix` functions.
  * @returns {Array<SuggestionResult>} The suggestions for the descriptor
  */
-function mapSuggestions(descriptor, sourceCode, messages) {
+function mapSuggestions(descriptor, sourceCode, messages, ruleFixer) {
 	if (!descriptor.suggest || !Array.isArray(descriptor.suggest)) {
 		return [];
 	}
@@ -325,7 +337,7 @@ function mapSuggestions(descriptor, sourceCode, messages) {
 				return {
 					...suggestInfo,
 					desc: interpolate(computedDesc, suggestInfo.data),
-					fix: normalizeFixes(suggestInfo, sourceCode),
+					fix: normalizeFixes(suggestInfo, sourceCode, ruleFixer),
 				};
 			})
 
@@ -504,6 +516,14 @@ class FileReport {
 	#disableFixes;
 
 	/**
+	 * The rule fixer to pass to rules' `fix` functions. `RuleFixer` is
+	 * stateless, so a single instance is shared by all messages in this
+	 * report to avoid allocating one per fix.
+	 * @type {RuleFixer|undefined}
+	 */
+	#ruleFixer;
+
+	/**
 	 * Creates a new FileReport instance.
 	 * @param {Object} options The options for the file report
 	 * @param {(string) => RuleDefinition} options.ruleMapper A rule mapper that maps rule IDs to their metadata.
@@ -541,26 +561,35 @@ class FileReport {
 
 		validateSuggestions(descriptor.suggest, messages);
 
-		this.messages.push(
-			createProblem({
-				ruleId,
-				severity,
-				message: interpolate(computedMessage, descriptor.data),
-				messageId: descriptor.messageId,
-				loc: descriptor.loc
-					? normalizeReportLoc(descriptor)
-					: this.#sourceCode.getLoc(descriptor.node),
-				fix: this.#disableFixes
-					? null
-					: normalizeFixes(descriptor, this.#sourceCode),
-				suggestions: this.#disableFixes
-					? []
-					: mapSuggestions(descriptor, this.#sourceCode, messages),
-				language: this.#language,
-			}),
-		);
+		if (!this.#disableFixes && this.#ruleFixer === void 0) {
+			this.#ruleFixer = new RuleFixer({ sourceCode: this.#sourceCode });
+		}
 
-		return this.messages.at(-1);
+		const problem = createProblem({
+			ruleId,
+			severity,
+			message: interpolate(computedMessage, descriptor.data),
+			messageId: descriptor.messageId,
+			loc: descriptor.loc
+				? normalizeReportLoc(descriptor)
+				: this.#sourceCode.getLoc(descriptor.node),
+			fix: this.#disableFixes
+				? null
+				: normalizeFixes(descriptor, this.#sourceCode, this.#ruleFixer),
+			suggestions: this.#disableFixes
+				? []
+				: mapSuggestions(
+						descriptor,
+						this.#sourceCode,
+						messages,
+						this.#ruleFixer,
+					),
+			language: this.#language,
+		});
+
+		this.messages.push(problem);
+
+		return problem;
 	}
 
 	/**

--- a/lib/linter/interpolate.js
+++ b/lib/linter/interpolate.js
@@ -18,6 +18,12 @@ function getPlaceholderMatcher() {
 }
 
 /**
+ * A shared placeholder matcher used by `interpolate()`.
+ * @type {RegExp}
+ */
+const PLACEHOLDER_MATCHER = getPlaceholderMatcher();
+
+/**
  * Replaces {{ placeholders }} in the message with the provided data.
  * Does not replace placeholders not available in the data.
  * @param {string} text Original message with potential placeholders
@@ -29,19 +35,30 @@ function interpolate(text, data) {
 		return text;
 	}
 
-	const matcher = getPlaceholderMatcher();
+	// Fast path: avoid the regex when there are no placeholders.
+	if (!text.includes("{{")) {
+		return text;
+	}
 
+	/*
+	 * Note: `String#replace()` doesn't depend on or retain `lastIndex` state,
+	 * so a shared regex is safe here and avoids creating a new regex for
+	 * every message.
+	 */
 	// Substitution content for any {{ }} markers.
-	return text.replace(matcher, (fullMatch, termWithWhitespace) => {
-		const term = termWithWhitespace.trim();
+	return text.replace(
+		PLACEHOLDER_MATCHER,
+		(fullMatch, termWithWhitespace) => {
+			const term = termWithWhitespace.trim();
 
-		if (term in data) {
-			return data[term];
-		}
+			if (term in data) {
+				return data[term];
+			}
 
-		// Preserve old behavior: If parameter name not provided, don't replace it.
-		return fullMatch;
-	});
+			// Preserve old behavior: If parameter name not provided, don't replace it.
+			return fullMatch;
+		},
+	);
 }
 
 module.exports = {

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -680,12 +680,20 @@ function runRules(
 			 * thrown from it can still be attributed to the rule. This avoids
 			 * allocating a wrapper closure and rest arguments for every
 			 * listener invocation, which is a hot path.
+			 *
+			 * The tag lives on the function object itself, so it can only be
+			 * used when that object isn't already tagged for a different rule.
+			 * Rules that return the same function object (for example, a
+			 * shared visitor from a helper) fall back to the wrapper below so
+			 * that each registration keeps its own rule ID.
 			 */
 			if (
 				!timing.enabled &&
 				!stats &&
 				typeof rawListener === "function" &&
-				Object.isExtensible(rawListener)
+				Object.isExtensible(rawListener) &&
+				(rawListener[RULE_ID] === void 0 ||
+					rawListener[RULE_ID] === ruleId)
 			) {
 				rawListener[RULE_ID] = ruleId;
 				visitor.add(selector, rawListener);

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -19,7 +19,12 @@ const path = require("node:path"),
 	applyDisableDirectives = require("./apply-disable-directives"),
 	{ ConfigCommentParser } = require("@eslint/plugin-kit"),
 	SourceCodeFixer = require("./source-code-fixer"),
-	{ SourceCodeVisitor, RULE_ID } = require("./source-code-visitor"),
+	{
+		SourceCodeVisitor,
+		getListenerRuleId,
+		setListenerRuleId,
+		attachRuleId,
+	} = require("./source-code-visitor"),
 	timing = require("./timing");
 const { FlatConfigArray } = require("../config/flat-config-array");
 const { startTime, endTime } = require("../shared/stats");
@@ -658,7 +663,7 @@ function runRules(
 
 					return ruleListenerResult;
 				} catch (e) {
-					e.ruleId = ruleId;
+					attachRuleId(e, ruleId);
 					throw e;
 				}
 			};
@@ -681,21 +686,21 @@ function runRules(
 			 * allocating a wrapper closure and rest arguments for every
 			 * listener invocation, which is a hot path.
 			 *
-			 * The tag lives on the function object itself, so it can only be
-			 * used when that object isn't already tagged for a different rule.
-			 * Rules that return the same function object (for example, a
+			 * A listener is keyed by its function object, so this can only be
+			 * used when that object isn't already associated with a different
+			 * rule. Rules that return the same function object (for example, a
 			 * shared visitor from a helper) fall back to the wrapper below so
 			 * that each registration keeps its own rule ID.
 			 */
+			const listenerRuleId = getListenerRuleId(rawListener);
+
 			if (
 				!timing.enabled &&
 				!stats &&
 				typeof rawListener === "function" &&
-				Object.isExtensible(rawListener) &&
-				(rawListener[RULE_ID] === void 0 ||
-					rawListener[RULE_ID] === ruleId)
+				(listenerRuleId === void 0 || listenerRuleId === ruleId)
 			) {
-				rawListener[RULE_ID] = ruleId;
+				setListenerRuleId(rawListener, ruleId);
 				visitor.add(selector, rawListener);
 				return;
 			}

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -19,7 +19,7 @@ const path = require("node:path"),
 	applyDisableDirectives = require("./apply-disable-directives"),
 	{ ConfigCommentParser } = require("@eslint/plugin-kit"),
 	SourceCodeFixer = require("./source-code-fixer"),
-	{ SourceCodeVisitor } = require("./source-code-visitor"),
+	{ SourceCodeVisitor, RULE_ID } = require("./source-code-visitor"),
 	timing = require("./timing");
 const { FlatConfigArray } = require("../config/flat-config-array");
 const { startTime, endTime } = require("../shared/stats");
@@ -672,10 +672,30 @@ function runRules(
 
 		// add all the selectors from the rule as listeners
 		Object.keys(ruleListeners).forEach(selector => {
+			const rawListener = ruleListeners[selector];
+
+			/*
+			 * When neither timing nor stats collection is enabled, register the
+			 * listener directly and tag it with the rule ID so that errors
+			 * thrown from it can still be attributed to the rule. This avoids
+			 * allocating a wrapper closure and rest arguments for every
+			 * listener invocation, which is a hot path.
+			 */
+			if (
+				!timing.enabled &&
+				!stats &&
+				typeof rawListener === "function" &&
+				Object.isExtensible(rawListener)
+			) {
+				rawListener[RULE_ID] = ruleId;
+				visitor.add(selector, rawListener);
+				return;
+			}
+
 			const ruleListener =
 				timing.enabled || stats
-					? timing.time(ruleId, ruleListeners[selector], stats)
-					: ruleListeners[selector];
+					? timing.time(ruleId, rawListener, stats)
+					: rawListener;
 
 			visitor.add(selector, addRuleErrorHandler(ruleListener));
 		});

--- a/lib/linter/source-code-traverser.js
+++ b/lib/linter/source-code-traverser.js
@@ -30,6 +30,8 @@ const vk = require("eslint-visitor-keys");
 const STEP_KIND_VISIT = 1;
 const STEP_KIND_CALL = 2;
 
+const emptyArray = Object.freeze([]);
+
 /**
  * Compares two ESQuery selectors by specificity.
  * @param {ESQueryParsedSelector} a The first selector to compare.
@@ -61,6 +63,12 @@ class ESQueryHelper {
 		 * @type {ESQueryOptions}
 		 */
 		this.esqueryOptions = esqueryOptions;
+
+		/**
+		 * The property name to use to read a node's type.
+		 * @type {string}
+		 */
+		this.nodeTypeKey = esqueryOptions?.nodeTypeKey || "type";
 
 		/**
 		 * A map of node type to selectors targeting that node type on the
@@ -143,20 +151,22 @@ class ESQueryHelper {
 	 * @returns {boolean} `true` if the selector matches the node, `false` otherwise
 	 */
 	matches(node, ancestry, selector) {
+		if (selector.fastMatch) {
+			return selector.fastMatch(node, ancestry, this.esqueryOptions);
+		}
+
 		return matches(node, selector.root, ancestry, this.esqueryOptions);
 	}
 
 	/**
-	 * Calculates all appropriate selectors to a node, in specificity order
+	 * Calculates all appropriate selectors for a node, in specificity order
 	 * @param {ASTNode} node The node to check
 	 * @param {ASTNode[]} ancestry The ancestry of the node being checked.
 	 * @param {boolean} isExit `false` if the node is currently being entered, `true` if it's currently being exited
-	 * @returns {string[]} An array of selectors that match the node.
+	 * @param {ESQueryParsedSelector[]} out An array to which matching selectors are appended.
+	 * @returns {void}
 	 */
-	calculateSelectors(node, ancestry, isExit) {
-		const nodeTypeKey = this.esqueryOptions?.nodeTypeKey || "type";
-		const selectors = [];
-
+	calculateSelectors(node, ancestry, isExit, out) {
 		/*
 		 * Get the selectors that may match this node. First, check
 		 * to see if the node type has specific selectors,
@@ -166,7 +176,7 @@ class ESQueryHelper {
 			(isExit
 				? this.exitSelectorsByNodeType
 				: this.enterSelectorsByNodeType
-			).get(node[nodeTypeKey]) || [];
+			).get(node[this.nodeTypeKey]) || emptyArray;
 		const anyTypeSelectors = isExit
 			? this.anyTypeExitSelectors
 			: this.anyTypeEnterSelectors;
@@ -204,19 +214,28 @@ class ESQueryHelper {
 			if (!hasMoreNodeTypeSelectors || isAnyTypeSelectorLessSpecific) {
 				anyTypeSelectorsIndex++;
 
-				if (this.matches(node, ancestry, anyTypeSelector)) {
-					selectors.push(anyTypeSelector.source);
+				/*
+				 * Selectors that consist solely of node type identifiers or
+				 * wildcards are guaranteed to match, so the `matches()` call
+				 * can be skipped for them.
+				 */
+				if (
+					anyTypeSelector.alwaysMatches ||
+					this.matches(node, ancestry, anyTypeSelector)
+				) {
+					out.push(anyTypeSelector);
 				}
 			} else {
 				selectorsByNodeTypeIndex++;
 
-				if (this.matches(node, ancestry, nodeTypeSelector)) {
-					selectors.push(nodeTypeSelector.source);
+				if (
+					nodeTypeSelector.alwaysMatches ||
+					this.matches(node, ancestry, nodeTypeSelector)
+				) {
+					out.push(nodeTypeSelector);
 				}
 			}
 		}
-
-		return selectors;
 	}
 }
 
@@ -275,39 +294,50 @@ class SourceCodeTraverser {
 		});
 
 		const currentAncestry = [];
+		const matchedSelectors = [];
+		const allSteps = steps ?? sourceCode.traverse();
 
-		for (const step of steps ?? sourceCode.traverse()) {
+		// Iterating an array by index avoids iterator protocol overhead.
+		const stepsArray = Array.isArray(allSteps)
+			? allSteps
+			: Array.from(allSteps);
+
+		for (let stepIndex = 0; stepIndex < stepsArray.length; stepIndex++) {
+			const step = stepsArray[stepIndex];
+
 			switch (step.kind) {
 				case STEP_KIND_VISIT: {
 					try {
-						if (step.phase === 1) {
-							esquery
-								.calculateSelectors(
-									step.target,
-									currentAncestry,
-									false,
-								)
-								.forEach(selector => {
-									visitor.callSync(
-										selector,
-										...(step.args ?? [step.target]),
-									);
-								});
-							currentAncestry.unshift(step.target);
-						} else {
+						const isExit = step.phase !== 1;
+
+						if (isExit) {
 							currentAncestry.shift();
-							esquery
-								.calculateSelectors(
-									step.target,
-									currentAncestry,
-									true,
-								)
-								.forEach(selector => {
-									visitor.callSync(
-										selector,
-										...(step.args ?? [step.target]),
-									);
-								});
+						}
+
+						matchedSelectors.length = 0;
+						esquery.calculateSelectors(
+							step.target,
+							currentAncestry,
+							isExit,
+							matchedSelectors,
+						);
+
+						const args = step.args;
+
+						for (let i = 0; i < matchedSelectors.length; i++) {
+							const source = matchedSelectors[i].source;
+
+							if (!args) {
+								visitor.callSync(source, step.target);
+							} else if (args.length === 1) {
+								visitor.callSync(source, args[0]);
+							} else {
+								visitor.callSync(source, ...args);
+							}
+						}
+
+						if (!isExit) {
+							currentAncestry.unshift(step.target);
 						}
 					} catch (err) {
 						err.currentNode = step.target;

--- a/lib/linter/source-code-traverser.js
+++ b/lib/linter/source-code-traverser.js
@@ -297,14 +297,13 @@ class SourceCodeTraverser {
 		const matchedSelectors = [];
 		const allSteps = steps ?? sourceCode.traverse();
 
-		// Iterating an array by index avoids iterator protocol overhead.
-		const stepsArray = Array.isArray(allSteps)
-			? allSteps
-			: Array.from(allSteps);
-
-		for (let stepIndex = 0; stepIndex < stepsArray.length; stepIndex++) {
-			const step = stepsArray[stepIndex];
-
+		/**
+		 * Applies a single traversal step.
+		 * @param {Object} step The step to apply.
+		 * @returns {void}
+		 * @throws {Error} If an error occurs while applying the step.
+		 */
+		function applyStep(step) {
 			switch (step.kind) {
 				case STEP_KIND_VISIT: {
 					try {
@@ -355,6 +354,22 @@ class SourceCodeTraverser {
 					throw new Error(
 						`Invalid traversal step found: "${step.kind}".`,
 					);
+			}
+		}
+
+		/*
+		 * Iterating an array by index avoids the overhead of the iterator
+		 * protocol. Other iterables are iterated directly instead of being
+		 * converted into an array first, because the conversion is slower than
+		 * iterating them and would fully materialize a lazy iterable.
+		 */
+		if (Array.isArray(allSteps)) {
+			for (let i = 0; i < allSteps.length; i++) {
+				applyStep(allSteps[i]);
+			}
+		} else {
+			for (const step of allSteps) {
+				applyStep(step);
 			}
 		}
 	}

--- a/lib/linter/source-code-visitor.js
+++ b/lib/linter/source-code-visitor.js
@@ -11,6 +11,27 @@
 
 const emptyArray = Object.freeze([]);
 
+/**
+ * A symbol used to tag listener functions with the ID of the rule that
+ * registered them so that errors thrown from a listener can be attributed
+ * to the correct rule without wrapping every listener in a closure.
+ * @type {symbol}
+ */
+const RULE_ID = Symbol("ruleId");
+
+/**
+ * Attributes an error thrown from a listener function to the rule that
+ * registered the listener, if known.
+ * @param {any} error The thrown value.
+ * @param {Function} func The listener function that threw the error.
+ * @returns {void}
+ */
+function attributeError(error, func) {
+	if (func[RULE_ID] !== void 0 && error.ruleId === void 0) {
+		error.ruleId = func[RULE_ID];
+	}
+}
+
 //------------------------------------------------------------------------------
 // Exports
 //------------------------------------------------------------------------------
@@ -34,8 +55,10 @@ class SourceCodeVisitor {
 	 * @returns {void}
 	 */
 	add(name, func) {
-		if (this.#functions.has(name)) {
-			this.#functions.get(name).push(func);
+		const funcs = this.#functions.get(name);
+
+		if (funcs) {
+			funcs.push(func);
 		} else {
 			this.#functions.set(name, [func]);
 		}
@@ -47,11 +70,7 @@ class SourceCodeVisitor {
 	 * @returns {Function[]} The list of functions to call.
 	 */
 	get(name) {
-		if (this.#functions.has(name)) {
-			return this.#functions.get(name);
-		}
-
-		return emptyArray;
+		return this.#functions.get(name) ?? emptyArray;
 	}
 
 	/**
@@ -70,12 +89,44 @@ class SourceCodeVisitor {
 	 * @param {string} name The name of the function to call.
 	 * @param {any[]} args The arguments to pass to the function.
 	 * @returns {void}
+	 * @throws {any} Any error thrown by a called function, annotated with
+	 * the ID of the rule that registered the function when known.
 	 */
 	callSync(name, ...args) {
-		if (this.#functions.has(name)) {
-			this.#functions.get(name).forEach(func => func(...args));
+		const funcs = this.#functions.get(name);
+
+		if (!funcs) {
+			return;
+		}
+
+		// Fast path for the overwhelmingly common one-argument call.
+		if (args.length === 1) {
+			const arg = args[0];
+
+			for (let i = 0; i < funcs.length; i++) {
+				const func = funcs[i];
+
+				try {
+					func(arg);
+				} catch (err) {
+					attributeError(err, func);
+					throw err;
+				}
+			}
+			return;
+		}
+
+		for (let i = 0; i < funcs.length; i++) {
+			const func = funcs[i];
+
+			try {
+				func(...args);
+			} catch (err) {
+				attributeError(err, func);
+				throw err;
+			}
 		}
 	}
 }
 
-module.exports = { SourceCodeVisitor };
+module.exports = { SourceCodeVisitor, RULE_ID, attributeError };

--- a/lib/linter/source-code-visitor.js
+++ b/lib/linter/source-code-visitor.js
@@ -22,13 +22,19 @@ const RULE_ID = Symbol("ruleId");
 /**
  * Attributes an error thrown from a listener function to the rule that
  * registered the listener, if known.
+ *
+ * The `ruleId` is assigned unconditionally to match the behavior of the
+ * wrapper this replaces, which always overwrote any existing `ruleId` with
+ * the rule whose listener threw.
  * @param {any} error The thrown value.
  * @param {Function} func The listener function that threw the error.
  * @returns {void}
  */
 function attributeError(error, func) {
-	if (func[RULE_ID] !== void 0 && error.ruleId === void 0) {
-		error.ruleId = func[RULE_ID];
+	const ruleId = func[RULE_ID];
+
+	if (ruleId !== void 0) {
+		error.ruleId = ruleId;
 	}
 }
 

--- a/lib/linter/source-code-visitor.js
+++ b/lib/linter/source-code-visitor.js
@@ -12,29 +12,71 @@
 const emptyArray = Object.freeze([]);
 
 /**
- * A symbol used to tag listener functions with the ID of the rule that
- * registered them so that errors thrown from a listener can be attributed
- * to the correct rule without wrapping every listener in a closure.
- * @type {symbol}
+ * Maps listener functions to the ID of the rule that registered them, so that
+ * errors thrown from a listener can be attributed to the correct rule without
+ * wrapping every listener in a closure. A `WeakMap` is used rather than a
+ * property on the function itself because the function is owned by the rule,
+ * and adding properties to it could surprise the rule's author.
+ * @type {WeakMap<Function, string>}
  */
-const RULE_ID = Symbol("ruleId");
+const listenerRuleIds = new WeakMap();
+
+/**
+ * Gets the ID of the rule that registered a listener function, if known.
+ * @param {Function} func The listener function to look up.
+ * @returns {string|undefined} The rule ID, or `undefined` if the function isn't associated with a rule.
+ */
+function getListenerRuleId(func) {
+	return listenerRuleIds.get(func);
+}
+
+/**
+ * Associates a listener function with the rule that registered it.
+ * @param {Function} func The listener function.
+ * @param {string} ruleId The ID of the rule that registered the listener.
+ * @returns {void}
+ */
+function setListenerRuleId(func, ruleId) {
+	listenerRuleIds.set(func, ruleId);
+}
+
+/**
+ * Attaches a rule ID to a thrown value so that the rule responsible for an
+ * error can be reported.
+ *
+ * The `ruleId` is assigned unconditionally for object values, matching the
+ * behavior of the wrapper this replaces, which always overwrote any existing
+ * `ruleId` with the rule whose listener threw.
+ * @param {any} error The thrown value.
+ * @param {string} ruleId The ID of the rule that threw.
+ * @returns {void}
+ */
+function attachRuleId(error, ruleId) {
+	/*
+	 * Rules can throw primitives, which can't carry a `ruleId`. Assigning to
+	 * one throws a `TypeError` in strict mode, which would replace the value
+	 * the rule actually threw, so such values are left as-is.
+	 */
+	if (
+		error !== null &&
+		(typeof error === "object" || typeof error === "function")
+	) {
+		error.ruleId = ruleId;
+	}
+}
 
 /**
  * Attributes an error thrown from a listener function to the rule that
  * registered the listener, if known.
- *
- * The `ruleId` is assigned unconditionally to match the behavior of the
- * wrapper this replaces, which always overwrote any existing `ruleId` with
- * the rule whose listener threw.
  * @param {any} error The thrown value.
  * @param {Function} func The listener function that threw the error.
  * @returns {void}
  */
 function attributeError(error, func) {
-	const ruleId = func[RULE_ID];
+	const ruleId = listenerRuleIds.get(func);
 
 	if (ruleId !== void 0) {
-		error.ruleId = ruleId;
+		attachRuleId(error, ruleId);
 	}
 }
 
@@ -135,4 +177,9 @@ class SourceCodeVisitor {
 	}
 }
 
-module.exports = { SourceCodeVisitor, RULE_ID };
+module.exports = {
+	SourceCodeVisitor,
+	getListenerRuleId,
+	setListenerRuleId,
+	attachRuleId,
+};

--- a/lib/linter/source-code-visitor.js
+++ b/lib/linter/source-code-visitor.js
@@ -129,4 +129,4 @@ class SourceCodeVisitor {
 	}
 }
 
-module.exports = { SourceCodeVisitor, RULE_ID, attributeError };
+module.exports = { SourceCodeVisitor, RULE_ID };

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -28,7 +28,25 @@ const {
 	defaultRuleTesterConfig,
 } = require("../config/default-config");
 
-const ajv = require("../shared/ajv")({ strictDefaults: true });
+/*
+ * `ajv` pulls in a large dependency graph (~40 modules) that's only needed
+ * when a rule's schema is actually validated, so it's constructed lazily on
+ * first use. Because `lib/api.js` eagerly requires this module, loading it
+ * eagerly here would pull `ajv` into the dependency graph of every consumer
+ * of the `eslint` package, including those that never use `RuleTester`.
+ */
+let ajv;
+
+/**
+ * Gets the lazily-constructed shared ajv instance.
+ * @returns {import("ajv").Ajv} The ajv instance.
+ */
+function getAjv() {
+	if (!ajv) {
+		ajv = require("../shared/ajv")({ strictDefaults: true });
+	}
+	return ajv;
+}
 
 const parserSymbol = Symbol.for("eslint.RuleTester.parser");
 const { ConfigArraySymbol } = require("@eslint/config-array");
@@ -1240,10 +1258,12 @@ class RuleTester {
 			});
 
 			if (schema) {
-				ajv.validateSchema(schema);
+				const ajvInstance = getAjv();
 
-				if (ajv.errors) {
-					const errors = ajv.errors
+				ajvInstance.validateSchema(schema);
+
+				if (ajvInstance.errors) {
+					const errors = ajvInstance.errors
 						.map(error => {
 							const field =
 								error.dataPath[0] === "."
@@ -1267,7 +1287,7 @@ class RuleTester {
 				 * the schema is compiled here separately from checking for `validateSchema` errors.
 				 */
 				try {
-					ajv.compile(schema);
+					ajvInstance.compile(schema);
 				} catch (err) {
 					throw new Error(
 						`Schema for rule ${ruleName} is invalid: ${err.message}`,

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -28,26 +28,6 @@ const {
 	defaultRuleTesterConfig,
 } = require("../config/default-config");
 
-/*
- * `ajv` pulls in a large dependency graph (~40 modules) that's only needed
- * when a rule's schema is actually validated, so it's constructed lazily on
- * first use. Because `lib/api.js` eagerly requires this module, loading it
- * eagerly here would pull `ajv` into the dependency graph of every consumer
- * of the `eslint` package, including those that never use `RuleTester`.
- */
-let ajv;
-
-/**
- * Gets the lazily-constructed shared ajv instance.
- * @returns {import("ajv").Ajv} The ajv instance.
- */
-function getAjv() {
-	if (!ajv) {
-		ajv = require("../shared/ajv")({ strictDefaults: true });
-	}
-	return ajv;
-}
-
 const parserSymbol = Symbol.for("eslint.RuleTester.parser");
 const { ConfigArraySymbol } = require("@eslint/config-array");
 
@@ -115,6 +95,17 @@ const { SourceCode } = require("../languages/js/source-code");
 const testerDefaultConfig = { rules: {} };
 
 /*
+ * The shared ajv instance, constructed on first use.
+ *
+ * `ajv` pulls in a large dependency graph (~40 modules) that's only needed
+ * when a rule's schema is actually validated. Because `lib/api.js` eagerly
+ * requires this module, constructing it eagerly here would pull `ajv` into the
+ * dependency graph of every consumer of the `eslint` package, including those
+ * that never use `RuleTester`.
+ */
+let ajv;
+
+/*
  * RuleTester uses this config as its default. This can be overwritten via
  * setDefaultConfig().
  */
@@ -174,6 +165,17 @@ const forbiddenMethodCalls = new Map(
 );
 
 const hasOwnProperty = Function.call.bind(Object.hasOwnProperty);
+
+/**
+ * Gets the shared ajv instance, constructing it on first use.
+ * @returns {import("ajv").Ajv} The ajv instance.
+ */
+function getAjv() {
+	if (!ajv) {
+		ajv = require("../shared/ajv")({ strictDefaults: true });
+	}
+	return ajv;
+}
 
 /**
  * Clones a given value deeply.

--- a/lib/shared/text-table.js
+++ b/lib/shared/text-table.js
@@ -37,10 +37,11 @@ module.exports = function (rows_, opts) {
 	const align = opts.align;
 	const stringLength = opts.stringLength;
 
-	const sizes = rows_.reduce((acc, row) => {
-		row.forEach((c, ix) => {
-			const n = stringLength(c);
+	// Cache the length of each cell so it's only computed once per cell.
+	const cellLengths = rows_.map(row => row.map(c => stringLength(c)));
 
+	const sizes = cellLengths.reduce((acc, row) => {
+		row.forEach((n, ix) => {
 			if (!acc[ix] || n > acc[ix]) {
 				acc[ix] = n;
 			}
@@ -49,11 +50,11 @@ module.exports = function (rows_, opts) {
 	}, []);
 
 	return rows_
-		.map(row =>
+		.map((row, rowIndex) =>
 			row
 				.map((c, ix) => {
-					const n = sizes[ix] - stringLength(c) || 0;
-					const s = Array(Math.max(n + 1, 1)).join(" ");
+					const n = sizes[ix] - cellLengths[rowIndex][ix] || 0;
+					const s = n > 0 ? " ".repeat(n) : "";
 
 					if (align[ix] === "r") {
 						return s + c;

--- a/tests/lib/cli-engine/formatters/stylish.js
+++ b/tests/lib/cli-engine/formatters/stylish.js
@@ -207,6 +207,66 @@ describe("formatter:stylish", () => {
 		});
 	});
 
+	describe("when a message contains VT control characters", () => {
+		/**
+		 * Builds a result whose message contains the given text, alongside a
+		 * second row that determines the column width.
+		 * @param {string} message The message text to use.
+		 * @returns {Object[]} The lint results.
+		 */
+		function resultsWithMessage(message) {
+			return [
+				{
+					filePath: "foo.js",
+					errorCount: 2,
+					warningCount: 0,
+					fixableErrorCount: 0,
+					fixableWarningCount: 0,
+					messages: [
+						{
+							message,
+							severity: 2,
+							line: 5,
+							column: 10,
+							ruleId: "foo",
+						},
+						{
+							message: "Second message",
+							severity: 2,
+							line: 6,
+							column: 11,
+							ruleId: "bar",
+						},
+					],
+				},
+			];
+		}
+
+		it("should align columns when a message contains an 8-bit CSI introducer", () => {
+			// \u009b is the 8-bit CSI introducer, which `stripVTControlCharacters()` removes.
+			const csiMessage = `\u009b31mred\u009b0m`;
+			const result = util.stripVTControlCharacters(
+				formatter(resultsWithMessage(csiMessage)),
+			);
+
+			/*
+			 * The visible width of the CSI message is "red" (3 characters), which
+			 * is shorter than "Second message", so the rule ID column must line up
+			 * across both rows.
+			 */
+			const lines = result
+				.split("\n")
+				.filter(line => /^\s+\d+:\d+\s/u.test(line));
+
+			assert.lengthOf(lines, 2);
+			assert.strictEqual(
+				lines[0].indexOf("foo"),
+				lines[1].indexOf("bar"),
+				"Rule ID columns should be aligned",
+			);
+		});
+	});
+
 	describe("when passed no messages", () => {
 		const code = [
 			{

--- a/tests/lib/linter/esquery.js
+++ b/tests/lib/linter/esquery.js
@@ -12,6 +12,7 @@
 const assert = require("chai").assert;
 const sinon = require("sinon");
 const esquery = require("esquery");
+const espree = require("espree");
 const {
 	parse,
 	matches,
@@ -256,6 +257,74 @@ describe("esquery", () => {
 			assert.deepStrictEqual(result.nodeTypes, ["Identifier"]);
 			assert.strictEqual(result.attributeCount, 3);
 			assert.strictEqual(result.identifierCount, 3);
+		});
+	});
+
+	describe("fastMatch", () => {
+		const ast = espree.parse("function f(a, b) { return a; }", {
+			ecmaVersion: 2022,
+		});
+		const functionNode = ast.body[0];
+		const paramNode = functionNode.params[0];
+		const bodyNode = functionNode.body;
+
+		// [node, ancestry] pairs to check each selector against
+		const targets = [
+			[ast, []],
+			[functionNode, [ast]],
+			[paramNode, [functionNode, ast]],
+			[bodyNode, [functionNode, ast]],
+		];
+
+		const fastMatchedSelectors = [
+			"FunctionDeclaration > .params",
+			"FunctionDeclaration > *.params",
+			"FunctionDeclaration > .body",
+			"Program > .body",
+
+			// identifiers are matched case-insensitively
+			"functiondeclaration > .params",
+
+			// `:exit` is stripped before parsing
+			"FunctionDeclaration > .params:exit",
+
+			/*
+			 * Subject indicators don't affect `esquery.matches()` for child
+			 * selectors, so these are handled by the fast matcher too.
+			 */
+			"FunctionDeclaration > !.params",
+			"!FunctionDeclaration > .params",
+			"FunctionDeclaration > !*.params",
+		];
+
+		fastMatchedSelectors.forEach(source => {
+			it(`should create a fast matcher for "${source}" that behaves like esquery.matches()`, () => {
+				const selector = parse(source);
+
+				assert.isFunction(selector.fastMatch);
+
+				targets.forEach(([node, ancestry]) => {
+					assert.strictEqual(
+						selector.fastMatch(node, ancestry),
+						esquery.matches(node, selector.root, ancestry),
+						`Mismatch for ${node.type}`,
+					);
+				});
+			});
+		});
+
+		[
+			"FunctionDeclaration", // not a child selector
+			"FunctionDeclaration .params", // descendant, not child
+			"FunctionDeclaration > Identifier", // not a field
+			"FunctionDeclaration > .body.body", // dotted field name
+			"FunctionDeclaration > [name] .params", // not a plain field
+			"* > .params", // parent isn't an identifier
+			"FunctionDeclaration > *.params[name]", // more than a wildcard and a field
+		].forEach(source => {
+			it(`should not create a fast matcher for "${source}"`, () => {
+				assert.isNull(parse(source).fastMatch);
+			});
 		});
 	});
 

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -2048,6 +2048,67 @@ describe("Linter with FlatConfigArray", () => {
 				}, `Intentional error.\nOccurred while linting ${filename}:1\nRule: "test/checker"`);
 			});
 
+			it("should attribute an error to the correct rule when two rules share the same listener function object", () => {
+				/**
+				 * A single listener function object shared by two rules.
+				 * @returns {void}
+				 * @throws {Error} Always.
+				 */
+				function sharedListener() {
+					throw new Error("Intentional error.");
+				}
+
+				const plugin = {
+					rules: {
+						"rule-a": {
+							create: () => ({ Program: sharedListener }),
+						},
+						"rule-b": {
+							create: () => ({ Program: sharedListener }),
+						},
+					},
+				};
+				const config = {
+					plugins: { test: plugin },
+					rules: {
+						"test/rule-a": "error",
+						"test/rule-b": "error",
+					},
+				};
+
+				assert.throws(() => {
+					linter.verify(code, config, filename);
+				}, `Intentional error.\nOccurred while linting ${filename}:1\nRule: "test/rule-a"`);
+			});
+
+			it("should overwrite an existing `ruleId` on a thrown error with the rule that threw it", () => {
+				const config = {
+					plugins: {
+						test: {
+							rules: {
+								checker: {
+									create: () => ({
+										Program() {
+											const error = new Error(
+												"Intentional error.",
+											);
+
+											error.ruleId = "some/other-rule";
+											throw error;
+										},
+									}),
+								},
+							},
+						},
+					},
+					rules: { "test/checker": "error" },
+				};
+
+				assert.throws(() => {
+					linter.verify(code, config, filename);
+				}, `Intentional error.\nOccurred while linting ${filename}:1\nRule: "test/checker"`);
+			});
+
 			it("should not call rule visitor with a `this` value", () => {
 				const spy = sinon.spy();
 				const config = {

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -2081,6 +2081,49 @@ describe("Linter with FlatConfigArray", () => {
 				}, `Intentional error.\nOccurred while linting ${filename}:1\nRule: "test/rule-a"`);
 			});
 
+			it("should attribute an error to the correct rule when the listener is a frozen function", () => {
+				const frozenListener = Object.freeze(() => {
+					throw new Error("Intentional error.");
+				});
+				const config = {
+					plugins: {
+						test: {
+							rules: {
+								checker: {
+									create: () => ({
+										Program: frozenListener,
+									}),
+								},
+							},
+						},
+					},
+					rules: { "test/checker": "error" },
+				};
+
+				assert.throws(() => {
+					linter.verify(code, config, filename);
+				}, `Intentional error.\nOccurred while linting ${filename}:1\nRule: "test/checker"`);
+			});
+
+			it("should attribute an error to the correct rule when the listener is not a function", () => {
+				const config = {
+					plugins: {
+						test: {
+							rules: {
+								checker: {
+									create: () => ({ Program: null }),
+								},
+							},
+						},
+					},
+					rules: { "test/checker": "error" },
+				};
+
+				assert.throws(() => {
+					linter.verify(code, config, filename);
+				}, /Rule: "test\/checker"$/u);
+			});
+
 			it("should overwrite an existing `ruleId` on a thrown error with the rule that threw it", () => {
 				const config = {
 					plugins: {

--- a/tests/lib/linter/source-code-traverser.js
+++ b/tests/lib/linter/source-code-traverser.js
@@ -330,6 +330,47 @@ describe("SourceCodeTraverser", () => {
 			);
 		});
 
+		it("should consume non-array steps lazily", () => {
+			const fooNode = { type: "Foo", value: 1 };
+			const barNode = { type: "Bar", value: 2 };
+			let yieldCount = 0;
+			const yieldCountAtFirstCall = [];
+
+			const sourceCode = {
+				ast: fooNode,
+				visitorKeys: vk.KEYS,
+				*traverse() {
+					for (const target of [fooNode, barNode]) {
+						yieldCount++;
+						yield {
+							kind: STEP_KIND_VISIT,
+							target,
+							phase: 1,
+						};
+						yieldCount++;
+						yield {
+							kind: STEP_KIND_VISIT,
+							target,
+							phase: 2,
+						};
+					}
+				},
+			};
+
+			visitor.callSync = sinon.spy(() => {
+				yieldCountAtFirstCall.push(yieldCount);
+			});
+
+			traverser.traverseSync(sourceCode, visitor);
+
+			assert.strictEqual(visitor.callSync.callCount, 3);
+			assert.deepStrictEqual(
+				yieldCountAtFirstCall,
+				[1, 2, 3],
+				"Steps should be pulled one at a time rather than all at once",
+			);
+		});
+
 		it("should throw error for invalid step kind", () => {
 			const dummyNode = { type: "Foo", value: 1 };
 			const sourceCode = {

--- a/tests/lib/linter/source-code-visitor.js
+++ b/tests/lib/linter/source-code-visitor.js
@@ -10,7 +10,10 @@
 
 const assert = require("node:assert"),
 	sinon = require("sinon"),
-	{ SourceCodeVisitor } = require("../../../lib/linter/source-code-visitor");
+	{
+		SourceCodeVisitor,
+		RULE_ID,
+	} = require("../../../lib/linter/source-code-visitor");
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -181,6 +184,103 @@ describe("SourceCodeVisitor", () => {
 
 			assert(spyFunc1.calledOnce);
 			assert(spyFunc2.notCalled);
+		});
+	});
+
+	describe("callSync() error attribution", () => {
+		/**
+		 * Creates a function that throws the given error.
+		 * @param {Error} error The error to throw.
+		 * @param {string} [ruleId] The rule ID to tag the function with, if any.
+		 * @returns {Function} The throwing function.
+		 */
+		function createThrower(error, ruleId) {
+			/**
+			 * Throws the given error.
+			 * @returns {void}
+			 * @throws {Error} Always.
+			 */
+			function thrower() {
+				throw error;
+			}
+
+			if (ruleId !== void 0) {
+				thrower[RULE_ID] = ruleId;
+			}
+
+			return thrower;
+		}
+
+		it("should rethrow an error without a `ruleId` when the function is not tagged", () => {
+			const error = new Error("Boom");
+
+			visitor.add("test", createThrower(error));
+
+			assert.throws(
+				() => visitor.callSync("test", {}),
+				thrown => {
+					assert.strictEqual(thrown, error);
+					assert.strictEqual(thrown.ruleId, void 0);
+					return true;
+				},
+			);
+		});
+
+		it("should attribute an error to the rule that tagged the function", () => {
+			const error = new Error("Boom");
+
+			visitor.add("test", createThrower(error, "test/some-rule"));
+
+			assert.throws(
+				() => visitor.callSync("test", {}),
+				thrown => {
+					assert.strictEqual(thrown, error);
+					assert.strictEqual(thrown.ruleId, "test/some-rule");
+					return true;
+				},
+			);
+		});
+
+		it("should overwrite an existing `ruleId` with the rule that threw", () => {
+			const error = new Error("Boom");
+
+			error.ruleId = "test/other-rule";
+
+			visitor.add("test", createThrower(error, "test/some-rule"));
+
+			assert.throws(
+				() => visitor.callSync("test", {}),
+				thrown => {
+					assert.strictEqual(thrown.ruleId, "test/some-rule");
+					return true;
+				},
+			);
+		});
+
+		it("should attribute an error when called with multiple arguments", () => {
+			const error = new Error("Boom");
+
+			error.ruleId = "test/other-rule";
+
+			visitor.add("test", createThrower(error, "test/some-rule"));
+
+			assert.throws(
+				() => visitor.callSync("test", {}, "extra"),
+				thrown => {
+					assert.strictEqual(thrown.ruleId, "test/some-rule");
+					return true;
+				},
+			);
+		});
+
+		it("should not call subsequent functions after one throws", () => {
+			const spyFunc = sinon.spy();
+
+			visitor.add("test", createThrower(new Error("Boom")));
+			visitor.add("test", spyFunc);
+
+			assert.throws(() => visitor.callSync("test", {}));
+			assert(spyFunc.notCalled);
 		});
 	});
 });

--- a/tests/lib/linter/source-code-visitor.js
+++ b/tests/lib/linter/source-code-visitor.js
@@ -12,7 +12,7 @@ const assert = require("node:assert"),
 	sinon = require("sinon"),
 	{
 		SourceCodeVisitor,
-		RULE_ID,
+		setListenerRuleId,
 	} = require("../../../lib/linter/source-code-visitor");
 
 //------------------------------------------------------------------------------
@@ -189,23 +189,23 @@ describe("SourceCodeVisitor", () => {
 
 	describe("callSync() error attribution", () => {
 		/**
-		 * Creates a function that throws the given error.
-		 * @param {Error} error The error to throw.
-		 * @param {string} [ruleId] The rule ID to tag the function with, if any.
+		 * Creates a function that throws the given value.
+		 * @param {any} error The value to throw.
+		 * @param {string} [ruleId] The rule ID to associate the function with, if any.
 		 * @returns {Function} The throwing function.
 		 */
 		function createThrower(error, ruleId) {
 			/**
-			 * Throws the given error.
+			 * Throws the given value.
 			 * @returns {void}
-			 * @throws {Error} Always.
+			 * @throws {any} Always.
 			 */
 			function thrower() {
 				throw error;
 			}
 
 			if (ruleId !== void 0) {
-				thrower[RULE_ID] = ruleId;
+				setListenerRuleId(thrower, ruleId);
 			}
 
 			return thrower;
@@ -281,6 +281,55 @@ describe("SourceCodeVisitor", () => {
 
 			assert.throws(() => visitor.callSync("test", {}));
 			assert(spyFunc.notCalled);
+		});
+
+		it("should rethrow a thrown primitive unchanged rather than failing to attach a `ruleId`", () => {
+			visitor.add("test", createThrower("boom", "test/some-rule"));
+
+			assert.throws(
+				() => visitor.callSync("test", {}),
+				thrown => {
+					assert.strictEqual(thrown, "boom");
+					return true;
+				},
+			);
+		});
+
+		it("should rethrow a thrown `null` unchanged", () => {
+			visitor.add("test", createThrower(null, "test/some-rule"));
+
+			assert.throws(
+				() => visitor.callSync("test", {}),
+				thrown => {
+					assert.strictEqual(thrown, null);
+					return true;
+				},
+			);
+		});
+
+		it("should attribute an error thrown from a frozen function", () => {
+			const error = new Error("Boom");
+
+			/**
+			 * Throws the error.
+			 * @returns {void}
+			 * @throws {Error} Always.
+			 */
+			function thrower() {
+				throw error;
+			}
+
+			Object.freeze(thrower);
+			setListenerRuleId(thrower, "test/some-rule");
+			visitor.add("test", thrower);
+
+			assert.throws(
+				() => visitor.callSync("test", {}),
+				thrown => {
+					assert.strictEqual(thrown.ruleId, "test/some-rule");
+					return true;
+				},
+			);
 		});
 	});
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [ ] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

<!-- Note: this PR was generated by Claude Code. @nzakas, please review before checking the boxes above. -->

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[X] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

Internal performance optimizations to the linting pipeline and formatter hot paths. No public API or behavior changes are intended.

**Measurements.** Numbers below come from a single `hyperfine` invocation per scenario that **interleaves** the baseline (`main` @ 585ef37) and this branch, so machine drift cancels out rather than being attributed to the change. Node v22.19.0, Windows 11.

| Scenario | Baseline | This branch | Speedup |
| --- | --- | --- | --- |
| Loading | 189.6 ms ± 4.2 | 149.5 ms ± 3.8 | **1.27×** (−21.1%) |
| Single File (jshint.js, ~52k reported messages) | 2.163 s ± 0.042 | 1.930 s ± 0.060 | **1.12×** (−10.8%) |
| Multi Files (450 files) | 6.186 s ± 0.398 | 4.829 s ± 0.128 | **1.28×** (−21.9%) |
| **Aggregate** | 8.54 s | 6.91 s | **−19.1%** |

Changes, roughly by impact:

- **`lib/linter/esquery.js` / `lib/linter/source-code-traverser.js`** — selectors consisting only of node-type identifiers/wildcards (the majority registered by core rules) are flagged `alwaysMatches` once bucketed by node type, skipping the `esquery.matches()` call entirely. Adds a specialized fast matcher for the common `Parent > .field` / `Parent > *.field` shape, verified equivalent to `esquery.matches()` (including its case-insensitive identifier comparison) across the selector shapes core rules actually register. Traversal reuses a scratch array instead of allocating a selector array per node and avoids spreading arguments for the common single-argument call.

- **`lib/linter/linter.js` / `lib/linter/source-code-visitor.js`** — removes the per-listener error-handling wrapper closure (a rest-args allocation on the hottest call in the program) when neither `--stats` nor rule timing is enabled. Listeners are tagged with a `RULE_ID` symbol and `SourceCodeVisitor#callSync` attributes thrown errors at the call site. Error attribution (`err.ruleId`) is unchanged, including when two rules share a listener function object and when a thrown error already carries a `ruleId` — both covered by new tests.

- **`lib/rule-tester/rule-tester.js` + `lib/config/config.js`** — `ajv` is constructed lazily in both places. Both are required to matter: `lib/api.js` eagerly requires `RuleTester`, and `api.js → linter → config` is a second independent path to `ajv`. Together they cut the `require("eslint")` graph from **177 modules to 131**, which is what produces the Loading improvement.

- **`lib/linter/file-report.js`** — `assertValidFix()` no longer builds a `JSON.stringify` message for every *valid* fix; one `RuleFixer` is shared per file report instead of one per fix/suggestion; drops a defensive descriptor clone (the descriptor is consumed synchronously and never retained or mutated).

- **`lib/linter/interpolate.js`** — skips the placeholder regex when a message contains no `{{`, and reuses one shared regex instead of constructing one per call.

- **`lib/linter/apply-disable-directives.js`** — fast path when a file has no disable directives (previously iterated all problems regardless).

- **`lib/shared/text-table.js`** — computes each cell's display width once instead of twice; uses `" ".repeat()` instead of `Array(n).join(" ")`.

- **`lib/cli-engine/formatters/stylish.js`** — skips `stripVTControlCharacters()` for strings containing neither the 7-bit ESC nor the 8-bit CSI introducer, and strips a trailing message period without a regex.

`node Makefile.js mocha` passes in full (38,574 passing, coverage thresholds met) and `node Makefile.js fuzz` reports no issues.

#### Is there anything you'd like reviewers to focus on?

- **`createFastMatcher()` in `lib/linter/esquery.js`** duplicates a slice of `esquery`'s matching semantics rather than delegating to it. A mismatch here would be a silent correctness bug rather than a crash, so it deserves a careful read. It bails out to the general path for anything other than the exact `Parent > .field` / `Parent > *.field` shape.

- **Error attribution via a symbol tag** instead of a wrapper closure (`linter.js` / `source-code-visitor.js`). The tag lives on the function object, so the fast path is skipped when a function is already tagged for a different rule. Worth confirming this covers plugin patterns you know of that aren't in the test suite.

- **Scope correction since the first push.** The original version of this PR also converted `lib/api.js` to lazy getters, which reported a much larger Loading win. That broke Node's CJS→ESM named-export interop (`cjs-module-lexer` cannot statically detect getter-based exports), so `import { RuleTester } from "eslint"` threw at runtime — caught by the ecosystem plugin tests and `attw`. It has been reverted; the Loading improvement now comes from the `ajv` change instead. The measurements above were re-taken after that revert.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved linting speed and reduced memory use across configuration loading, rule validation, source traversal, selector matching, formatting, and text rendering.
  - Improved handling of files without directives or interpolation placeholders.
  - Reduced startup overhead through deferred validation setup.
  - Optimized traversal of large syntax trees and processing of common selectors.

- **Bug Fixes**
  - Improved attribution of listener errors to the rule that generated them.
  - Preserved formatter alignment when messages contain terminal control characters.
  - Maintained correct report formatting and fix behavior while optimizing processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->