### PR TITLE
fix: prevent unsafe `no-var` autofix with hoisted functions

### DIFF
--- a/lib/rules/no-var.js
+++ b/lib/rules/no-var.js
@@ -230,8 +230,7 @@ function hasReferenceBeforeDeclaration(variable) {
  */
 function hasUnsafeHoistedFunctionReference(variable) {
 	const declarationNode = variable.defs[0].node;
-	const declarationStatement = declarationNode.parent;
-	const declarationStart = declarationStatement.range[0];
+	const declarationStart = declarationNode.range[0];
 	const scopeBlock = variable.scope.block;
 
 	for (const reference of variable.references) {

--- a/lib/rules/no-var.js
+++ b/lib/rules/no-var.js
@@ -221,6 +221,58 @@ function hasReferenceBeforeDeclaration(variable) {
 	});
 }
 
+/**
+ * Checks whether a given variable is referenced inside a hoisted function
+ * declaration that is called before the variable's declaration.
+ * @param {Variable} variable The variable to check.
+ * @returns {boolean} `true` if the variable is referenced from a hoisted
+ *      function called before its declaration.
+ */
+function hasUnsafeHoistedFunctionReference(variable) {
+	const declarationNode = variable.defs[0].node;
+	const declarationStatement = declarationNode.parent;
+	const declarationStart = declarationStatement.range[0];
+	const scopeBlock = variable.scope.block;
+
+	for (const reference of variable.references) {
+		if (reference.init) {
+			continue;
+		}
+
+		if (reference.identifier.range[0] < declarationStart) {
+			continue;
+		}
+
+		let currentNode = reference.identifier.parent;
+
+		while (currentNode && currentNode !== scopeBlock) {
+			if (currentNode.type === "FunctionDeclaration" && currentNode.id) {
+				const funcName = currentNode.id.name;
+				const funcVariable = variable.scope.set.get(funcName);
+
+				if (funcVariable) {
+					for (const funcRef of funcVariable.references) {
+						const refId = funcRef.identifier;
+
+						if (
+							refId.parent.type === "CallExpression" &&
+							refId.parent.callee === refId &&
+							refId.range[0] < declarationStart
+						) {
+							return true;
+						}
+					}
+
+					break;
+				}
+			}
+			currentNode = currentNode.parent;
+		}
+	}
+
+	return false;
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -330,7 +382,8 @@ module.exports = {
 				variables.some(isRedeclared) ||
 				variables.some(isUsedFromOutsideOf(scopeNode)) ||
 				variables.some(hasNameDisallowedForLetDeclarations) ||
-				variables.some(hasReferenceBeforeDeclaration)
+				variables.some(hasReferenceBeforeDeclaration) ||
+				variables.some(hasUnsafeHoistedFunctionReference)
 			) {
 				return false;
 			}

--- a/lib/rules/no-var.js
+++ b/lib/rules/no-var.js
@@ -231,7 +231,6 @@ function hasReferenceBeforeDeclaration(variable) {
 function hasUnsafeHoistedFunctionReference(variable) {
 	const declarationNode = variable.defs[0].node;
 	const declarationStart = declarationNode.range[0];
-	const scopeBlock = variable.scope.block;
 
 	for (const reference of variable.references) {
 		if (reference.init) {
@@ -242,30 +241,30 @@ function hasUnsafeHoistedFunctionReference(variable) {
 			continue;
 		}
 
-		let currentNode = reference.identifier.parent;
+		let currentScope = reference.from.variableScope;
 
-		while (currentNode && currentNode !== scopeBlock) {
-			if (currentNode.type === "FunctionDeclaration" && currentNode.id) {
-				const funcName = currentNode.id.name;
-				const funcVariable = variable.scope.set.get(funcName);
+		while (currentScope !== variable.scope) {
+			if (
+				currentScope.block.type === "FunctionDeclaration" &&
+				currentScope.block.id
+			) {
+				const funcName = currentScope.block.id.name;
+				const funcVariable = currentScope.upper.set.get(funcName);
 
-				if (funcVariable) {
-					for (const funcRef of funcVariable.references) {
-						const refId = funcRef.identifier;
+				for (const funcRef of funcVariable.references) {
+					const refId = funcRef.identifier;
 
-						if (
-							refId.parent.type === "CallExpression" &&
-							refId.parent.callee === refId &&
-							refId.range[0] < declarationStart
-						) {
-							return true;
-						}
+					if (
+						refId.parent.type === "CallExpression" &&
+						refId.parent.callee === refId &&
+						refId.range[0] < declarationStart
+					) {
+						return true;
 					}
-
-					break;
 				}
 			}
-			currentNode = currentNode.parent;
+
+			currentScope = currentScope.upper.variableScope;
 		}
 	}
 

--- a/tests/lib/rules/no-var.js
+++ b/tests/lib/rules/no-var.js
@@ -572,6 +572,10 @@ ruleTester.run("no-var", rule, {
 			errors: [{ messageId: "unexpectedVar" }],
 		},
 		{
+			code: "function wrap() { var b = foo(), a = 1; function foo() { console.log(a); } }",
+			errors: [{ messageId: "unexpectedVar" }],
+		},
+		{
 			code: "function wrap() { foo(); var a = 1; var b = 2; function foo() { console.log(a); } }",
 			output: "function wrap() { foo(); var a = 1; let b = 2; function foo() { console.log(a); } }",
 			errors: [

--- a/tests/lib/rules/no-var.js
+++ b/tests/lib/rules/no-var.js
@@ -583,6 +583,11 @@ ruleTester.run("no-var", rule, {
 				{ messageId: "unexpectedVar" },
 			],
 		},
+		{
+			code: "function wrap() { function foo() {} foo(); if (bar) { var a = 1; function foo() { console.log(a); } foo (); } }",
+			output: "function wrap() { function foo() {} foo(); if (bar) { let a = 1; function foo() { console.log(a); } foo (); } }",
+			errors: [{ messageId: "unexpectedVar" }],
+		},
 	],
 });
 

--- a/tests/lib/rules/no-var.js
+++ b/tests/lib/rules/no-var.js
@@ -505,6 +505,27 @@ ruleTester.run("no-var", rule, {
 				{ messageId: "unexpectedVar" },
 			],
 		},
+		{
+			code: "function wrap() { foo(); var a = 1; function foo() { console.log(a); } }",
+			errors: [{ messageId: "unexpectedVar" }],
+		},
+		{
+			code: "function wrap() { var a = 1; foo(); function foo() { console.log(a); } }",
+			output: "function wrap() { let a = 1; foo(); function foo() { console.log(a); } }",
+			errors: [{ messageId: "unexpectedVar" }],
+		},
+		{
+			code: "function wrap() { bar(); var a = 1; function bar() { function inner() { console.log(a); } inner(); } }",
+			errors: [{ messageId: "unexpectedVar" }],
+		},
+		{
+			code: "function wrap() { foo(); var a = 1; var b = 2; function foo() { console.log(a); } }",
+			output: "function wrap() { foo(); var a = 1; let b = 2; function foo() { console.log(a); } }",
+			errors: [
+				{ messageId: "unexpectedVar" },
+				{ messageId: "unexpectedVar" },
+			],
+		},
 	],
 });
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR fixes a bug in the `no-var` rule where the autofixer would unsafely convert `var` to `let`, causing a `ReferenceError` if the variable was used inside a hoisted function that was executed before the variable's declaration.

Fixes #21193

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
