### PR TITLE
fix: make ESTree declarations portable under pnpm

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -368,6 +368,7 @@ module.exports = defineConfig([
 			parserOptions: {
 				project: [
 					"tests/lib/types/tsconfig.json",
+					"tests/pnpm/tsconfig.json",
 					"packages/js/tests/types/tsconfig.json",
 					"packages/eslint-config-eslint/tests/types/tsconfig.json",
 				],

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -77,6 +77,71 @@ import type {
 } from "@eslint/plugin-kit";
 
 //------------------------------------------------------------------------------
+// ESLint-specific ESTree types. Interfaces retain the names of object types
+// in emitted declarations. The intersections retain names for unions, which
+// cannot be extended by interfaces.
+//------------------------------------------------------------------------------
+
+/** @deprecated Internal to ESLint's declaration portability. Do not use directly. */
+export interface ESTreePosition extends ESTree.Position {}
+/** @deprecated Internal to ESLint's declaration portability. Do not use directly. */
+export interface ESTreeSourceLocation extends ESTree.SourceLocation {}
+/** @deprecated Internal to ESLint's declaration portability. Do not use directly. */
+export interface ESTreeBaseNode extends ESTree.BaseNode {}
+/** @deprecated Internal to ESLint's declaration portability. Do not use directly. */
+export type ESTreeNode = ESTree.Node & {};
+/** @deprecated Internal to ESLint's declaration portability. Do not use directly. */
+export interface ESTreeProgram extends ESTree.Program {
+	body: Array<ESTreeDirective | ESTreeStatement | ESTreeModuleDeclaration>;
+}
+/** @deprecated Internal to ESLint's declaration portability. Do not use directly. */
+export interface ESTreeDirective extends ESTree.Directive {}
+/** @deprecated Internal to ESLint's declaration portability. Do not use directly. */
+export type ESTreeStatement = ESTree.Statement & {};
+/** @deprecated Internal to ESLint's declaration portability. Do not use directly. */
+export type ESTreeModuleDeclaration = ESTree.ModuleDeclaration & {};
+/** @deprecated Internal to ESLint's declaration portability. Do not use directly. */
+export interface ESTreeComment extends ESTree.Comment {}
+/** @deprecated Internal to ESLint's declaration portability. Do not use directly. */
+export interface ESTreeIdentifier extends ESTree.Identifier {}
+/** @deprecated Internal to ESLint's declaration portability. Do not use directly. */
+export type ESTreeExpression = ESTree.Expression & {};
+/** @deprecated Internal to ESLint's declaration portability. Do not use directly. */
+export interface ESTreeCatchClause extends ESTree.CatchClause {}
+/** @deprecated Internal to ESLint's declaration portability. Do not use directly. */
+export interface ESTreeClassDeclaration extends ESTree.ClassDeclaration {}
+/** @deprecated Internal to ESLint's declaration portability. Do not use directly. */
+export interface ESTreeClassExpression extends ESTree.ClassExpression {}
+/** @deprecated Internal to ESLint's declaration portability. Do not use directly. */
+export interface ESTreeFunctionDeclaration extends ESTree.FunctionDeclaration {}
+/** @deprecated Internal to ESLint's declaration portability. Do not use directly. */
+export interface ESTreeFunctionExpression extends ESTree.FunctionExpression {}
+/** @deprecated Internal to ESLint's declaration portability. Do not use directly. */
+export interface ESTreeArrowFunctionExpression
+	extends ESTree.ArrowFunctionExpression {}
+/** @deprecated Internal to ESLint's declaration portability. Do not use directly. */
+export interface ESTreeAssignmentExpression
+	extends ESTree.AssignmentExpression {}
+/** @deprecated Internal to ESLint's declaration portability. Do not use directly. */
+export interface ESTreeForInStatement extends ESTree.ForInStatement {}
+/** @deprecated Internal to ESLint's declaration portability. Do not use directly. */
+export interface ESTreeForOfStatement extends ESTree.ForOfStatement {}
+/** @deprecated Internal to ESLint's declaration portability. Do not use directly. */
+export interface ESTreeImportDeclaration extends ESTree.ImportDeclaration {}
+/** @deprecated Internal to ESLint's declaration portability. Do not use directly. */
+export interface ESTreeImportSpecifier extends ESTree.ImportSpecifier {}
+/** @deprecated Internal to ESLint's declaration portability. Do not use directly. */
+export interface ESTreeImportDefaultSpecifier
+	extends ESTree.ImportDefaultSpecifier {}
+/** @deprecated Internal to ESLint's declaration portability. Do not use directly. */
+export interface ESTreeImportNamespaceSpecifier
+	extends ESTree.ImportNamespaceSpecifier {}
+/** @deprecated Internal to ESLint's declaration portability. Do not use directly. */
+export interface ESTreeVariableDeclaration extends ESTree.VariableDeclaration {}
+/** @deprecated Internal to ESLint's declaration portability. Do not use directly. */
+export interface ESTreeVariableDeclarator extends ESTree.VariableDeclarator {}
+
+//------------------------------------------------------------------------------
 // Exports
 //------------------------------------------------------------------------------
 
@@ -103,21 +168,21 @@ export namespace AST {
 	}
 
 	interface SourceLocation {
-		start: ESTree.Position;
-		end: ESTree.Position;
+		start: ESTreePosition;
+		end: ESTreePosition;
 	}
 
 	type Range = SourceRange;
 
-	interface Program extends ESTree.Program {
-		comments: ESTree.Comment[];
+	interface Program extends ESTreeProgram {
+		comments: ESTreeComment[];
 		tokens: Token[];
 		loc: SourceLocation;
 		range: Range;
 	}
 }
 
-interface JSXIdentifier extends ESTree.BaseNode {
+interface JSXIdentifier extends ESTreeBaseNode {
 	type: "JSXIdentifier";
 	name: string;
 }
@@ -127,9 +192,9 @@ export namespace Scope {
 		scopes: Scope[];
 		globalScope: Scope | null;
 
-		acquire(node: ESTree.Node, inner?: boolean): Scope | null;
+		acquire(node: ESTreeNode, inner?: boolean): Scope | null;
 
-		getDeclaredVariables(node: ESTree.Node): Variable[];
+		getDeclaredVariables(node: ESTreeNode): Variable[];
 
 		addGlobals(names: ReadonlyArray<string>): void;
 	}
@@ -152,7 +217,7 @@ export namespace Scope {
 		upper: Scope | null;
 		childScopes: Scope[];
 		variableScope: Scope;
-		block: ESTree.Node;
+		block: ESTreeNode;
 		variables: Variable[];
 		set: Map<string, Variable>;
 		references: Reference[];
@@ -167,16 +232,16 @@ export namespace Scope {
 	interface Variable {
 		name: string;
 		scope: Scope;
-		identifiers: ESTree.Identifier[];
+		identifiers: ESTreeIdentifier[];
 		references: Reference[];
 		defs: Definition[];
 	}
 
 	interface Reference {
-		identifier: ESTree.Identifier | JSXIdentifier;
+		identifier: ESTreeIdentifier | JSXIdentifier;
 		from: Scope;
 		resolved: Variable | null;
-		writeExpr?: ESTree.Expression | null;
+		writeExpr?: ESTreeExpression | null;
 		init?: boolean;
 
 		isWrite(): boolean;
@@ -191,48 +256,48 @@ export namespace Scope {
 	}
 
 	type DefinitionType =
-		| { type: "CatchClause"; node: ESTree.CatchClause; parent: null }
+		| { type: "CatchClause"; node: ESTreeCatchClause; parent: null }
 		| {
 				type: "ClassName";
-				node: ESTree.ClassDeclaration | ESTree.ClassExpression;
+				node: ESTreeClassDeclaration | ESTreeClassExpression;
 				parent: null;
 		  }
 		| {
 				type: "FunctionName";
-				node: ESTree.FunctionDeclaration | ESTree.FunctionExpression;
+				node: ESTreeFunctionDeclaration | ESTreeFunctionExpression;
 				parent: null;
 		  }
 		| {
 				type: "ImplicitGlobalVariable";
 				node:
-					| ESTree.AssignmentExpression
-					| ESTree.ForInStatement
-					| ESTree.ForOfStatement;
+					| ESTreeAssignmentExpression
+					| ESTreeForInStatement
+					| ESTreeForOfStatement;
 				parent: null;
 		  }
 		| {
 				type: "ImportBinding";
 				node:
-					| ESTree.ImportSpecifier
-					| ESTree.ImportDefaultSpecifier
-					| ESTree.ImportNamespaceSpecifier;
-				parent: ESTree.ImportDeclaration;
+					| ESTreeImportSpecifier
+					| ESTreeImportDefaultSpecifier
+					| ESTreeImportNamespaceSpecifier;
+				parent: ESTreeImportDeclaration;
 		  }
 		| {
 				type: "Parameter";
 				node:
-					| ESTree.FunctionDeclaration
-					| ESTree.FunctionExpression
-					| ESTree.ArrowFunctionExpression;
+					| ESTreeFunctionDeclaration
+					| ESTreeFunctionExpression
+					| ESTreeArrowFunctionExpression;
 				parent: null;
 		  }
 		| {
 				type: "Variable";
-				node: ESTree.VariableDeclarator;
-				parent: ESTree.VariableDeclaration;
+				node: ESTreeVariableDeclarator;
+				parent: ESTreeVariableDeclaration;
 		  };
 
-	type Definition = DefinitionType & { name: ESTree.Identifier };
+	type Definition = DefinitionType & { name: ESTreeIdentifier };
 }
 
 // #region SourceCode
@@ -240,8 +305,8 @@ export namespace Scope {
 export class SourceCode implements TextSourceCode<{
 	LangOptions: Linter.LanguageOptions;
 	RootNode: AST.Program;
-	SyntaxElementWithLoc: AST.Token | ESTree.Node;
-	ConfigNode: ESTree.Comment;
+	SyntaxElementWithLoc: AST.Token | ESTreeNode;
+	ConfigNode: ESTreeComment;
 }> {
 	text: string;
 	ast: AST.Program;
@@ -256,28 +321,28 @@ export class SourceCode implements TextSourceCode<{
 
 	static splitLines(text: string): string[];
 
-	getLoc(syntaxElement: AST.Token | ESTree.Node): ESTree.SourceLocation;
-	getRange(syntaxElement: AST.Token | ESTree.Node): SourceRange;
+	getLoc(syntaxElement: AST.Token | ESTreeNode): ESTreeSourceLocation;
+	getRange(syntaxElement: AST.Token | ESTreeNode): SourceRange;
 
 	getText(
-		node?: ESTree.Node,
+		node?: ESTreeNode,
 		beforeCount?: number,
 		afterCount?: number,
 	): string;
 
 	getLines(): string[];
 
-	getAllComments(): ESTree.Comment[];
+	getAllComments(): ESTreeComment[];
 
-	getAncestors(node: ESTree.Node): ESTree.Node[];
+	getAncestors(node: ESTreeNode): ESTreeNode[];
 
-	getDeclaredVariables(node: ESTree.Node): Scope.Variable[];
+	getDeclaredVariables(node: ESTreeNode): Scope.Variable[];
 
-	getNodeByRangeIndex(index: number): ESTree.Node | null;
+	getNodeByRangeIndex(index: number): ESTreeNode | null;
 
-	getLocFromIndex(index: number): ESTree.Position;
+	getLocFromIndex(index: number): ESTreePosition;
 
-	getIndexFromLoc(location: ESTree.Position): number;
+	getIndexFromLoc(location: ESTreePosition): number;
 
 	// Inherited methods from TokenStore
 	// ---------------------------------
@@ -289,7 +354,7 @@ export class SourceCode implements TextSourceCode<{
 	getTokenByRangeStart(
 		offset: number,
 		options: { includeComments: boolean },
-	): AST.Token | ESTree.Comment | null;
+	): AST.Token | ESTreeComment | null;
 
 	getFirstToken: SourceCode.UnaryNodeCursorWithSkipOptions;
 
@@ -318,33 +383,33 @@ export class SourceCode implements TextSourceCode<{
 	getTokensBetween: SourceCode.BinaryCursorWithCountOptions;
 
 	getTokens: ((
-		node: ESTree.Node,
+		node: ESTreeNode,
 		beforeCount?: number,
 		afterCount?: number,
 	) => AST.Token[]) &
 		SourceCode.UnaryNodeCursorWithCountOptions;
 
 	commentsExistBetween(
-		left: ESTree.Node | AST.Token | ESTree.Comment,
-		right: ESTree.Node | AST.Token | ESTree.Comment,
+		left: ESTreeNode | AST.Token | ESTreeComment,
+		right: ESTreeNode | AST.Token | ESTreeComment,
 	): boolean;
 
-	getCommentsBefore(nodeOrToken: ESTree.Node | AST.Token): ESTree.Comment[];
+	getCommentsBefore(nodeOrToken: ESTreeNode | AST.Token): ESTreeComment[];
 
-	getCommentsAfter(nodeOrToken: ESTree.Node | AST.Token): ESTree.Comment[];
+	getCommentsAfter(nodeOrToken: ESTreeNode | AST.Token): ESTreeComment[];
 
-	getCommentsInside(node: ESTree.Node): ESTree.Comment[];
+	getCommentsInside(node: ESTreeNode): ESTreeComment[];
 
-	getScope(node: ESTree.Node): Scope.Scope;
+	getScope(node: ESTreeNode): Scope.Scope;
 
 	isSpaceBetween(
-		first: ESTree.Node | AST.Token,
-		second: ESTree.Node | AST.Token,
+		first: ESTreeNode | AST.Token,
+		second: ESTreeNode | AST.Token,
 	): boolean;
 
-	isGlobalReference(node: ESTree.Identifier): boolean;
+	isGlobalReference(node: ESTreeIdentifier): boolean;
 
-	markVariableAsUsed(name: string, refNode?: ESTree.Node): boolean;
+	markVariableAsUsed(name: string, refNode?: ESTreeNode): boolean;
 
 	traverse(): Iterable<TraversalStep>;
 }
@@ -367,7 +432,7 @@ export namespace SourceCode {
 
 	interface UnaryNodeCursorWithSkipOptions {
 		<T extends AST.Token>(
-			node: ESTree.Node,
+			node: ESTreeNode,
 			options:
 				| ((token: AST.Token) => token is T)
 				| {
@@ -376,18 +441,18 @@ export namespace SourceCode {
 						skip?: number | undefined;
 				  },
 		): T | null;
-		<T extends AST.Token | ESTree.Comment>(
-			node: ESTree.Node,
+		<T extends AST.Token | ESTreeComment>(
+			node: ESTreeNode,
 			options: {
 				filter: (
-					tokenOrComment: AST.Token | ESTree.Comment,
+					tokenOrComment: AST.Token | ESTreeComment,
 				) => tokenOrComment is T;
 				includeComments: boolean;
 				skip?: number | undefined;
 			},
 		): T | null;
 		(
-			node: ESTree.Node,
+			node: ESTreeNode,
 			options?:
 				| {
 						filter?: ((token: AST.Token) => boolean) | undefined;
@@ -398,20 +463,19 @@ export namespace SourceCode {
 				| number,
 		): AST.Token | null;
 		(
-			node: ESTree.Node,
+			node: ESTreeNode,
 			options: {
 				filter?:
-					| ((token: AST.Token | ESTree.Comment) => boolean)
-					| undefined;
+					((token: AST.Token | ESTreeComment) => boolean) | undefined;
 				includeComments: boolean;
 				skip?: number | undefined;
 			},
-		): AST.Token | ESTree.Comment | null;
+		): AST.Token | ESTreeComment | null;
 	}
 
 	interface UnaryNodeCursorWithCountOptions {
 		<T extends AST.Token>(
-			node: ESTree.Node,
+			node: ESTreeNode,
 			options:
 				| ((token: AST.Token) => token is T)
 				| {
@@ -420,18 +484,18 @@ export namespace SourceCode {
 						count?: number | undefined;
 				  },
 		): T[];
-		<T extends AST.Token | ESTree.Comment>(
-			node: ESTree.Node,
+		<T extends AST.Token | ESTreeComment>(
+			node: ESTreeNode,
 			options: {
 				filter: (
-					tokenOrComment: AST.Token | ESTree.Comment,
+					tokenOrComment: AST.Token | ESTreeComment,
 				) => tokenOrComment is T;
 				includeComments: boolean;
 				count?: number | undefined;
 			},
 		): T[];
 		(
-			node: ESTree.Node,
+			node: ESTreeNode,
 			options?:
 				| {
 						filter?: ((token: AST.Token) => boolean) | undefined;
@@ -442,20 +506,19 @@ export namespace SourceCode {
 				| number,
 		): AST.Token[];
 		(
-			node: ESTree.Node,
+			node: ESTreeNode,
 			options: {
 				filter?:
-					| ((token: AST.Token | ESTree.Comment) => boolean)
-					| undefined;
+					((token: AST.Token | ESTreeComment) => boolean) | undefined;
 				includeComments: boolean;
 				count?: number | undefined;
 			},
-		): Array<AST.Token | ESTree.Comment>;
+		): Array<AST.Token | ESTreeComment>;
 	}
 
 	interface UnaryCursorWithSkipOptions {
 		<T extends AST.Token>(
-			node: ESTree.Node | AST.Token | ESTree.Comment,
+			node: ESTreeNode | AST.Token | ESTreeComment,
 			options:
 				| ((token: AST.Token) => token is T)
 				| {
@@ -464,18 +527,18 @@ export namespace SourceCode {
 						skip?: number | undefined;
 				  },
 		): T | null;
-		<T extends AST.Token | ESTree.Comment>(
-			node: ESTree.Node | AST.Token | ESTree.Comment,
+		<T extends AST.Token | ESTreeComment>(
+			node: ESTreeNode | AST.Token | ESTreeComment,
 			options: {
 				filter: (
-					tokenOrComment: AST.Token | ESTree.Comment,
+					tokenOrComment: AST.Token | ESTreeComment,
 				) => tokenOrComment is T;
 				includeComments: boolean;
 				skip?: number | undefined;
 			},
 		): T | null;
 		(
-			node: ESTree.Node | AST.Token | ESTree.Comment,
+			node: ESTreeNode | AST.Token | ESTreeComment,
 			options?:
 				| {
 						filter?: ((token: AST.Token) => boolean) | undefined;
@@ -486,20 +549,19 @@ export namespace SourceCode {
 				| number,
 		): AST.Token | null;
 		(
-			node: ESTree.Node | AST.Token | ESTree.Comment,
+			node: ESTreeNode | AST.Token | ESTreeComment,
 			options: {
 				filter?:
-					| ((token: AST.Token | ESTree.Comment) => boolean)
-					| undefined;
+					((token: AST.Token | ESTreeComment) => boolean) | undefined;
 				includeComments: boolean;
 				skip?: number | undefined;
 			},
-		): AST.Token | ESTree.Comment | null;
+		): AST.Token | ESTreeComment | null;
 	}
 
 	interface UnaryCursorWithCountOptions {
 		<T extends AST.Token>(
-			node: ESTree.Node | AST.Token | ESTree.Comment,
+			node: ESTreeNode | AST.Token | ESTreeComment,
 			options:
 				| ((token: AST.Token) => token is T)
 				| {
@@ -508,18 +570,18 @@ export namespace SourceCode {
 						count?: number | undefined;
 				  },
 		): T[];
-		<T extends AST.Token | ESTree.Comment>(
-			node: ESTree.Node | AST.Token | ESTree.Comment,
+		<T extends AST.Token | ESTreeComment>(
+			node: ESTreeNode | AST.Token | ESTreeComment,
 			options: {
 				filter: (
-					tokenOrComment: AST.Token | ESTree.Comment,
+					tokenOrComment: AST.Token | ESTreeComment,
 				) => tokenOrComment is T;
 				includeComments: boolean;
 				count?: number | undefined;
 			},
 		): T[];
 		(
-			node: ESTree.Node | AST.Token | ESTree.Comment,
+			node: ESTreeNode | AST.Token | ESTreeComment,
 			options?:
 				| {
 						filter?: ((token: AST.Token) => boolean) | undefined;
@@ -530,21 +592,20 @@ export namespace SourceCode {
 				| number,
 		): AST.Token[];
 		(
-			node: ESTree.Node | AST.Token | ESTree.Comment,
+			node: ESTreeNode | AST.Token | ESTreeComment,
 			options: {
 				filter?:
-					| ((token: AST.Token | ESTree.Comment) => boolean)
-					| undefined;
+					((token: AST.Token | ESTreeComment) => boolean) | undefined;
 				includeComments: boolean;
 				count?: number | undefined;
 			},
-		): Array<AST.Token | ESTree.Comment>;
+		): Array<AST.Token | ESTreeComment>;
 	}
 
 	interface BinaryCursorWithSkipOptions {
 		<T extends AST.Token>(
-			left: ESTree.Node | AST.Token | ESTree.Comment,
-			right: ESTree.Node | AST.Token | ESTree.Comment,
+			left: ESTreeNode | AST.Token | ESTreeComment,
+			right: ESTreeNode | AST.Token | ESTreeComment,
 			options:
 				| ((token: AST.Token) => token is T)
 				| {
@@ -553,20 +614,20 @@ export namespace SourceCode {
 						skip?: number | undefined;
 				  },
 		): T | null;
-		<T extends AST.Token | ESTree.Comment>(
-			left: ESTree.Node | AST.Token | ESTree.Comment,
-			right: ESTree.Node | AST.Token | ESTree.Comment,
+		<T extends AST.Token | ESTreeComment>(
+			left: ESTreeNode | AST.Token | ESTreeComment,
+			right: ESTreeNode | AST.Token | ESTreeComment,
 			options: {
 				filter: (
-					tokenOrComment: AST.Token | ESTree.Comment,
+					tokenOrComment: AST.Token | ESTreeComment,
 				) => tokenOrComment is T;
 				includeComments: boolean;
 				skip?: number | undefined;
 			},
 		): T | null;
 		(
-			left: ESTree.Node | AST.Token | ESTree.Comment,
-			right: ESTree.Node | AST.Token | ESTree.Comment,
+			left: ESTreeNode | AST.Token | ESTreeComment,
+			right: ESTreeNode | AST.Token | ESTreeComment,
 			options?:
 				| {
 						filter?: ((token: AST.Token) => boolean) | undefined;
@@ -577,22 +638,21 @@ export namespace SourceCode {
 				| number,
 		): AST.Token | null;
 		(
-			left: ESTree.Node | AST.Token | ESTree.Comment,
-			right: ESTree.Node | AST.Token | ESTree.Comment,
+			left: ESTreeNode | AST.Token | ESTreeComment,
+			right: ESTreeNode | AST.Token | ESTreeComment,
 			options: {
 				filter?:
-					| ((token: AST.Token | ESTree.Comment) => boolean)
-					| undefined;
+					((token: AST.Token | ESTreeComment) => boolean) | undefined;
 				includeComments: boolean;
 				skip?: number | undefined;
 			},
-		): AST.Token | ESTree.Comment | null;
+		): AST.Token | ESTreeComment | null;
 	}
 
 	interface BinaryCursorWithCountOptions {
 		<T extends AST.Token>(
-			left: ESTree.Node | AST.Token | ESTree.Comment,
-			right: ESTree.Node | AST.Token | ESTree.Comment,
+			left: ESTreeNode | AST.Token | ESTreeComment,
+			right: ESTreeNode | AST.Token | ESTreeComment,
 			options:
 				| ((token: AST.Token) => token is T)
 				| {
@@ -601,20 +661,20 @@ export namespace SourceCode {
 						count?: number | undefined;
 				  },
 		): T[];
-		<T extends AST.Token | ESTree.Comment>(
-			left: ESTree.Node | AST.Token | ESTree.Comment,
-			right: ESTree.Node | AST.Token | ESTree.Comment,
+		<T extends AST.Token | ESTreeComment>(
+			left: ESTreeNode | AST.Token | ESTreeComment,
+			right: ESTreeNode | AST.Token | ESTreeComment,
 			options: {
 				filter: (
-					tokenOrComment: AST.Token | ESTree.Comment,
+					tokenOrComment: AST.Token | ESTreeComment,
 				) => tokenOrComment is T;
 				includeComments: boolean;
 				count?: number | undefined;
 			},
 		): T[];
 		(
-			left: ESTree.Node | AST.Token | ESTree.Comment,
-			right: ESTree.Node | AST.Token | ESTree.Comment,
+			left: ESTreeNode | AST.Token | ESTreeComment,
+			right: ESTreeNode | AST.Token | ESTreeComment,
 			options?:
 				| {
 						filter?: ((token: AST.Token) => boolean) | undefined;
@@ -625,16 +685,15 @@ export namespace SourceCode {
 				| number,
 		): AST.Token[];
 		(
-			left: ESTree.Node | AST.Token | ESTree.Comment,
-			right: ESTree.Node | AST.Token | ESTree.Comment,
+			left: ESTreeNode | AST.Token | ESTreeComment,
+			right: ESTreeNode | AST.Token | ESTreeComment,
 			options: {
 				filter?:
-					| ((token: AST.Token | ESTree.Comment) => boolean)
-					| undefined;
+					((token: AST.Token | ESTreeComment) => boolean) | undefined;
 				includeComments: boolean;
 				count?: number | undefined;
 			},
-		): Array<AST.Token | ESTree.Comment>;
+		): Array<AST.Token | ESTreeComment>;
 	}
 }
 
@@ -642,7 +701,7 @@ export namespace SourceCode {
 
 export type JSSyntaxElement = {
 	type: string;
-	loc?: ESTree.SourceLocation | null | undefined;
+	loc?: ESTreeSourceLocation | null | undefined;
 };
 
 export namespace Rule {
@@ -658,7 +717,7 @@ export namespace Rule {
 		create(context: RuleContext): RuleListener;
 	}
 
-	type NodeTypes = ESTree.Node["type"];
+	type NodeTypes = ESTreeNode["type"];
 
 	interface NodeListener extends CustomRuleVisitorWithExit<
 		{
@@ -676,7 +735,7 @@ export namespace Rule {
 
 	type Node =
 		| (AST.Program & { parent: null })
-		| (Exclude<ESTree.Node, ESTree.Program> & NodeParentExtension);
+		| (Exclude<ESTreeNode, ESTreeProgram> & NodeParentExtension);
 
 	interface RuleListener extends NodeListener {
 		onCodePathStart?(codePath: CodePath, node: Node): void;
@@ -789,7 +848,7 @@ export namespace Rule {
 	type ReportDescriptorMessage = ViolationMessage;
 	type ReportDescriptorLocation = ViolationLocation<JSSyntaxElement>;
 
-	type RuleFixer = RuleTextEditor<ESTree.Node | AST.Token>;
+	type RuleFixer = RuleTextEditor<ESTreeNode | AST.Token>;
 	type Fix = RuleTextEdit;
 }
 

--- a/tests/lib/types/types.test.mts
+++ b/tests/lib/types/types.test.mts
@@ -167,9 +167,9 @@ loc.column; // $ExpectType number
 sourceCode.getIndexFromLoc({ line: 0, column: 0 });
 
 sourceCode.getTokenByRangeStart(0); // $ExpectType Token | null
-sourceCode.getTokenByRangeStart(0, { includeComments: true }); // $ExpectType Comment | Token | null
+sourceCode.getTokenByRangeStart(0, { includeComments: true }); // $ExpectType ESTreeComment | Token | null
 sourceCode.getTokenByRangeStart(0, { includeComments: false }); // $ExpectType Token | null
-sourceCode.getTokenByRangeStart(0, { includeComments: false as boolean }); // $ExpectType Comment | Token | null
+sourceCode.getTokenByRangeStart(0, { includeComments: false as boolean }); // $ExpectType ESTreeComment | Token | null
 
 sourceCode.getFirstToken(AST); // $ExpectType Token | null
 sourceCode.getFirstToken(AST, 0);
@@ -188,7 +188,7 @@ sourceCode.getFirstToken(AST, {
 	skip: 0,
 	filter: t => t.type === "Identifier",
 });
-sourceCode.getFirstToken(AST, { includeComments: true }); // $ExpectType Comment | Token | null
+sourceCode.getFirstToken(AST, { includeComments: true }); // $ExpectType ESTreeComment | Token | null
 sourceCode.getFirstToken(AST, { includeComments: true, skip: 0 });
 // prettier-ignore
 sourceCode.getFirstToken(AST, { // $ExpectType (Token & { type: "Identifier"; }) | null
@@ -352,7 +352,7 @@ sourceCode.getFirstTokenBetween(AST, AST, {
 	filter: (t): t is AST.Token & { type: "Identifier" } =>
 		t.type === "Identifier",
 });
-sourceCode.getFirstTokenBetween(AST, AST, { includeComments: true }); // $ExpectType Comment | Token | null
+sourceCode.getFirstTokenBetween(AST, AST, { includeComments: true }); // $ExpectType ESTreeComment | Token | null
 sourceCode.getFirstTokenBetween(AST, AST, { includeComments: true, skip: 0 });
 // prettier-ignore
 sourceCode.getFirstTokenBetween(AST, AST, { // $ExpectType (Token & { type: "Identifier"; }) | null
@@ -378,7 +378,7 @@ sourceCode.getFirstTokensBetween(AST, AST, {
 	count: 0,
 	filter: t => t.type === "Identifier",
 });
-sourceCode.getFirstTokensBetween(AST, AST, { includeComments: true }); // $ExpectType (Comment | Token)[]
+sourceCode.getFirstTokensBetween(AST, AST, { includeComments: true }); // $ExpectType (ESTreeComment | Token)[]
 sourceCode.getFirstTokensBetween(AST, AST, { includeComments: true, count: 0 });
 // prettier-ignore
 sourceCode.getFirstTokensBetween(AST, AST, { // $ExpectType (Token & { type: "Identifier"; })[]
@@ -441,7 +441,7 @@ sourceCode.getTokens(AST, {
 	filter: (t): t is AST.Token & { type: "Identifier" } =>
 		t.type === "Identifier",
 });
-sourceCode.getTokens(AST, { includeComments: true }); // $ExpectType (Comment | Token)[]
+sourceCode.getTokens(AST, { includeComments: true }); // $ExpectType (ESTreeComment | Token)[]
 // prettier-ignore
 sourceCode.getTokens(AST, { // $ExpectType (Token & { type: "Identifier"; })[]
 	includeComments: true,
@@ -465,7 +465,7 @@ sourceCode.markVariableAsUsed("foo", AST);
 
 sourceCode.getDeclaredVariables(AST); // $ExpectType Variable[]
 
-sourceCode.getAncestors(AST); // $ExpectType Node[]
+sourceCode.getAncestors(AST); // $ExpectType ESTreeNode[]
 
 // #endregion
 
@@ -520,35 +520,35 @@ reference.isWriteOnly();
 reference.isReadWrite();
 
 let catchDef!: Extract<Scope.DefinitionType, { type: "CatchClause" }>;
-catchDef.node; // $ExpectType CatchClause
+catchDef.node; // $ExpectType ESTreeCatchClause
 catchDef.parent; // $ExpectType null
 
 let classNameDef!: Extract<Scope.DefinitionType, { type: "ClassName" }>;
-classNameDef.node; // $ExpectType ClassDeclaration | ClassExpression
+classNameDef.node; // $ExpectType ESTreeClassDeclaration | ESTreeClassExpression
 classNameDef.parent; // $ExpectType null
 
 let functionNameDef!: Extract<Scope.DefinitionType, { type: "FunctionName" }>;
-functionNameDef.node; // $ExpectType FunctionDeclaration | FunctionExpression
+functionNameDef.node; // $ExpectType ESTreeFunctionDeclaration | ESTreeFunctionExpression
 functionNameDef.parent; // $ExpectType null
 
 let implicitGlobalVarDef!: Extract<
 	Scope.DefinitionType,
 	{ type: "ImplicitGlobalVariable" }
 >;
-implicitGlobalVarDef.node; // $ExpectType AssignmentExpression | ForInStatement | ForOfStatement
+implicitGlobalVarDef.node; // $ExpectType ESTreeAssignmentExpression | ESTreeForInStatement | ESTreeForOfStatement
 implicitGlobalVarDef.parent; // $ExpectType null
 
 let importBindingDef!: Extract<Scope.DefinitionType, { type: "ImportBinding" }>;
-importBindingDef.node; // $ExpectType ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier
-importBindingDef.parent; // $ExpectType ImportDeclaration
+importBindingDef.node; // $ExpectType ESTreeImportSpecifier | ESTreeImportDefaultSpecifier | ESTreeImportNamespaceSpecifier
+importBindingDef.parent; // $ExpectType ESTreeImportDeclaration
 
 let parameterDef!: Extract<Scope.DefinitionType, { type: "Parameter" }>;
-parameterDef.node; // $ExpectType FunctionDeclaration | FunctionExpression | ArrowFunctionExpression
+parameterDef.node; // $ExpectType ESTreeFunctionDeclaration | ESTreeFunctionExpression | ESTreeArrowFunctionExpression
 parameterDef.parent; // $ExpectType null
 
 let variableDef!: Extract<Scope.DefinitionType, { type: "Variable" }>;
-variableDef.node; // $ExpectType VariableDeclarator
-variableDef.parent; // $ExpectType VariableDeclaration
+variableDef.node; // $ExpectType ESTreeVariableDeclarator
+variableDef.parent; // $ExpectType ESTreeVariableDeclaration
 
 // #endregion
 

--- a/tests/pnpm/test-declaration-portability.ts
+++ b/tests/pnpm/test-declaration-portability.ts
@@ -1,0 +1,18 @@
+import type { AST, Scope, SourceCode } from "eslint";
+
+declare const sourceCode: SourceCode;
+declare const variable_: Scope.Variable;
+declare const reference: Scope.Reference;
+declare const definition: Scope.Definition;
+declare const program: AST.Program;
+
+export const location = sourceCode.getLoc(null as never);
+export const comments = sourceCode.getAllComments();
+export const position = sourceCode.getLocFromIndex(0);
+export const identifiers = variable_.identifiers;
+export const identifier = reference.identifier;
+export const definitionName = definition.name;
+export const definitionNode = definition.node;
+export const definitionParent = definition.parent;
+export const programComments = program.comments;
+export const programBody = program.body;

--- a/tests/pnpm/test-scope-manager.ts
+++ b/tests/pnpm/test-scope-manager.ts
@@ -1,0 +1,14 @@
+import type { Scope } from "eslint";
+
+export default {
+	scopes: [],
+	globalScope: null,
+	acquire(node) {
+		void node;
+		return null;
+	},
+	getDeclaredVariables() {
+		return [];
+	},
+	addGlobals() {},
+} satisfies Scope.ScopeManager;

--- a/tests/pnpm/tsconfig.json
+++ b/tests/pnpm/tsconfig.json
@@ -5,5 +5,9 @@
     "module": "nodenext",
     "noEmit": true
   },
-  "files": ["test-eslint.config.js"]
+  "files": [
+    "test-eslint.config.js",
+    "test-scope-manager.ts",
+    "test-declaration-portability.ts"
+  ]
 }


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
- [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
- [ ] Add autofix to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

Fixes https://github.com/eslint/eslint/issues/19418.

#### What changes did you make? (Give an overview)

Added deprecated, ESLint-owned ESTree type names for declaration portability under pnpm’s isolated dependency layout. Object-shaped ESTree types use exported interfaces to preserve their names during declaration emit; union types use intersections because unions cannot be extended by interfaces.

The change also routes `AST.Program.body` through portable `Directive`, `Statement`, and `ModuleDeclaration` names, without re-exporting the ESTree namespace or adding a direct consumer dependency on `@types/estree`.

Added pnpm regression fixtures that emit inferred declarations from `ScopeManager`, `SourceCode`, `Scope`, and `AST.Program` APIs. The fixtures run through the existing pnpm type-support CI job.

#### Is there anything you'd like reviewers to focus on?

Please focus on whether the deprecated top-level alias names and the interface-versus-union representation are the desired public compatibility surface. The remaining declaration-emission limitations for distributed Rule visitor node types and `@eslint/core`’s `LintMessage` are intentionally outside this change.