### PR TITLE
docs: include TypeScript config file names in --config CLI help

### DIFF
--- a/docs/src/use/command-line-interface.md
+++ b/docs/src/use/command-line-interface.md
@@ -86,8 +86,8 @@ You can view all the CLI options by running `npx eslint -h`.
 eslint [options] file.js [file.js] [dir]
 
 Basic configuration:
-  --no-config-lookup               Disable look up for eslint.config.js
-  -c, --config path::String        Use this configuration instead of eslint.config.js, eslint.config.mjs, or eslint.config.cjs
+  --no-config-lookup               Disable look up for eslint.config.*
+  -c, --config path::String        Use this configuration instead of eslint.config.*
   --inspect-config                 Open the config inspector with the current configuration
   --ext [String]                   Specify additional file extensions to lint
   --global [String]                Define global variables

--- a/lib/options.js
+++ b/lib/options.js
@@ -90,14 +90,14 @@ module.exports = function () {
 				option: "config-lookup",
 				type: "Boolean",
 				default: "true",
-				description: "Disable look up for eslint.config.js",
+				description: "Disable look up for eslint.config.*",
 			},
 			{
 				option: "config",
 				alias: "c",
 				type: "path::String",
 				description:
-					"Use this configuration instead of eslint.config.js, eslint.config.mjs, or eslint.config.cjs",
+					"Use this configuration instead of eslint.config.*",
 			},
 			{
 				option: "inspect-config",


### PR DESCRIPTION
## Summary

Updates the help text for `-c, --config` and `--no-config-lookup` in `lib/options.js` (and the corresponding line in `docs/src/use/command-line-interface.md`) so the descriptions cover all six supported flat-config filenames, not just the three JavaScript ones.

The current text reads `eslint.config.js, eslint.config.mjs, or eslint.config.cjs`, but ESLint also accepts `eslint.config.ts`, `eslint.config.mts`, and `eslint.config.cts` (see `lib/config/config-loader.js`). This change replaces the enumeration with the glob `eslint.config.*`, which is also what the `--no-config-lookup` description and the `eslint.config.*` pattern in `lib/options.js:27` already imply.

## What changes

- `lib/options.js` -- `--no-config-lookup` description: `Disable look up for eslint.config.js` to `Disable look up for eslint.config.*`
- `lib/options.js` -- `-c, --config` description: replaces the three-name enumeration with `Use this configuration instead of eslint.config.*`
- `docs/src/use/command-line-interface.md` -- mirrors both lines in the help-text block

## Why a glob

Two maintainer comments on #21111 (from @DMartens and @mdjermanovic) preferred not enumerating the file types. The glob is shorter, future-proof for any new flat-config extension, and matches the actual lookup set in `lib/config/config-loader.js`. The TypeScript-config caveat in the user-facing documentation is unchanged, so there is no risk of overpromising "works out of the box."

## Test plan

- `node -c lib/options.js` (syntax check)
- The existing `tests/lib/options.js` suite does not assert on help-text strings, and I have not added a new test for the same reason -- these are user-facing strings, not behaviour. Happy to add a snapshot test if reviewers want one.

## AI disclosure

Per the [ESLint AI Usage Policy](https://eslint.org/docs/latest/contribute/ai-policy): AI assistance (Claude, via OpenClaw) was used to identify the issue, draft the wording, and create this pull request. The change itself is a four-line text edit; the proposed wording is taken directly from the maintainer-suggested alternatives in the issue thread, and I have reviewed and tested the diff locally.

Closes #21111