### PR TITLE
docs: use eslint.config.* wherever config file names are listed

### DIFF
--- a/docs/src/use/command-line-interface.md
+++ b/docs/src/use/command-line-interface.md
@@ -86,8 +86,8 @@ You can view all the CLI options by running `npx eslint -h`.
 eslint [options] file.js [file.js] [dir]
 
 Basic configuration:
-  --no-config-lookup               Disable look up for eslint.config.js
-  -c, --config path::String        Use this configuration instead of eslint.config.js, eslint.config.mjs, or eslint.config.cjs
+  --no-config-lookup               Disable look up for eslint.config.*
+  -c, --config path::String        Use this configuration instead of eslint.config.* look up
   --inspect-config                 Open the config inspector with the current configuration
   --ext [String]                   Specify additional file extensions to lint
   --global [String]                Define global variables

--- a/lib/config/config-loader.js
+++ b/lib/config/config-loader.js
@@ -316,7 +316,7 @@ class ConfigLoader {
 	 * Determines which config file to use. This is determined by seeing if an
 	 * override config file was specified, and if so, using it; otherwise, as long
 	 * as override config file is not explicitly set to `false`, it will search
-	 * upwards from `fromDirectory` for a file named `eslint.config.js`.
+	 * upwards from `fromDirectory` for an `eslint.config.*` file.
 	 * @param {string} fromDirectory The directory from which to start searching.
 	 * @returns {Promise<{configFilePath:string|undefined,basePath:string}>} Location information for
 	 *      the config file.
@@ -514,7 +514,7 @@ class ConfigLoader {
 	 * Determines which config file to use. This is determined by seeing if an
 	 * override config file was specified, and if so, using it; otherwise, as long
 	 * as override config file is not explicitly set to `false`, it will search
-	 * upwards from `fromDirectory` for a file named `eslint.config.js`.
+	 * upwards from `fromDirectory` for an `eslint.config.*` file.
 	 * This method is exposed internally for testing purposes.
 	 * @param {Object} [options] the options object
 	 * @param {string|false|undefined} options.useConfigFile The path to the config file to use.

--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -230,7 +230,7 @@ function compareResultsByFilePath(a, b) {
  * Determines which config file to use. This is determined by seeing if an
  * override config file was passed, and if so, using it; otherwise, as long
  * as override config file is not explicitly set to `false`, it will search
- * upwards from the cwd for a file named `eslint.config.js`.
+ * upwards from the cwd for an `eslint.config.*` file.
  *
  * This function is used primarily by the `--inspect-config` option. For now,
  * we will maintain the existing behavior, which is to search up from the cwd.

--- a/lib/options.js
+++ b/lib/options.js
@@ -90,14 +90,14 @@ module.exports = function () {
 				option: "config-lookup",
 				type: "Boolean",
 				default: "true",
-				description: "Disable look up for eslint.config.js",
+				description: "Disable look up for eslint.config.*",
 			},
 			{
 				option: "config",
 				alias: "c",
 				type: "path::String",
 				description:
-					"Use this configuration instead of eslint.config.js, eslint.config.mjs, or eslint.config.cjs",
+					"Use this configuration instead of eslint.config.* look up",
 			},
 			{
 				option: "inspect-config",

--- a/messages/config-file-missing.js
+++ b/messages/config-file-missing.js
@@ -2,9 +2,9 @@
 
 module.exports = function () {
 	return `
-ESLint couldn't find an eslint.config.(js|mjs|cjs) file.
+ESLint couldn't find an eslint.config.* file.
 
-From ESLint v9.0.0, the default configuration file is now eslint.config.js.
+From ESLint v9.0.0, the default configuration file is now eslint.config.*.
 If you are using a .eslintrc.* file, please follow the migration guide
 to update your configuration file to the new format:
 

--- a/tests/messages/messages.js
+++ b/tests/messages/messages.js
@@ -42,7 +42,7 @@ describe("messages", () => {
 
 			assert.include(
 				message,
-				"ESLint couldn't find an eslint.config.(js|mjs|cjs) file.",
+				"ESLint couldn't find an eslint.config.* file.",
 			);
 			assert.include(
 				message,


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix
[ ] New rule
[ ] Changes an existing rule
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #21111

#### What changes did you make? (Give an overview)

`FLAT_CONFIG_FILENAMES` has covered all six config file names for a while, but two user-facing strings still list only the three JavaScript ones. This replaces both with the `eslint.config.*` glob.

**CLI help** (`lib/options.js`, mirrored in `docs/src/use/command-line-interface.md`)

```diff
- --no-config-lookup               Disable look up for eslint.config.js
- -c, --config path::String        Use this configuration instead of eslint.config.js, eslint.config.mjs, or eslint.config.cjs
+ --no-config-lookup               Disable look up for eslint.config.*
+ -c, --config path::String        Use this configuration instead of eslint.config.* look up
```

This is the wording @mdjermanovic proposed in https://github.com/eslint/eslint/issues/21111#issuecomment-5202337435, following @DMartens's point that the file names should not be enumerated. For `-c` the wording is "instead of eslint.config.* look up" rather than "instead of eslint.config.*", since multiple default config files can apply in a single run and `-c` disables that lookup rather than replacing one file.

**Missing-config error** (`messages/config-file-missing.js`)

```diff
- ESLint couldn't find an eslint.config.(js|mjs|cjs) file.
+ ESLint couldn't find an eslint.config.* file.

- From ESLint v9.0.0, the default configuration file is now eslint.config.js.
+ From ESLint v9.0.0, the default configuration file is now eslint.config.*.
```

This is the message a user sees when no config file is found, so someone with a TypeScript config is told their file does not count. `tests/messages/messages.js` asserts the string and is updated with it.

The JSDoc comments in `lib/config/config-loader.js` and `lib/eslint/eslint.js` that describe the same lookup as searching for `eslint.config.js` are updated to match.

#### Is there anything you'd like reviewers to focus on?

The issue is written around the `--config` help text, and the error message is the same gap in another place. Happy to split it into a separate issue and PR if you would rather keep this one to the help text.

The help block in `docs/src/use/command-line-interface.md` is hand-maintained. Nothing generates or verifies it against `eslint -h`, so it can drift. I confirmed both lines match the actual output of `node bin/eslint.js -h` on this branch.

-------
Disclosure: I'm a participant of [open source contribution program OSSCA](https://github.com/eslint-ossca)
