### PR TITLE
feat: handle underflow in no-loss-of-precision

### DIFF
--- a/lib/rules/no-loss-of-precision.js
+++ b/lib/rules/no-loss-of-precision.js
@@ -185,6 +185,10 @@ function baseTenLosesPrecision(node) {
 	);
 	const requestedPrecision = normalizedRawNumber.coefficient.length;
 
+	if (node.value === 0) {
+		return !/^0+$/u.test(normalizedRawNumber.coefficient);
+	}
+
 	if (requestedPrecision > 100) {
 		return true;
 	}
@@ -236,7 +240,11 @@ module.exports = {
 	create(context) {
 		return {
 			Literal(node) {
-				if (node.value && isNumber(node) && losesPrecision(node)) {
+				if (
+					node.value !== null &&
+					isNumber(node) &&
+					losesPrecision(node)
+				) {
 					context.report({
 						messageId: "noLossOfPrecision",
 						node,

--- a/lib/rules/no-loss-of-precision.js
+++ b/lib/rules/no-loss-of-precision.js
@@ -183,11 +183,12 @@ function baseTenLosesPrecision(node) {
 		rawNumber,
 		false,
 	);
-	const requestedPrecision = normalizedRawNumber.coefficient.length;
 
 	if (node.value === 0) {
 		return !/^0+$/u.test(normalizedRawNumber.coefficient);
 	}
+
+	const requestedPrecision = normalizedRawNumber.coefficient.length;
 
 	if (requestedPrecision > 100) {
 		return true;
@@ -240,11 +241,7 @@ module.exports = {
 	create(context) {
 		return {
 			Literal(node) {
-				if (
-					node.value !== null &&
-					isNumber(node) &&
-					losesPrecision(node)
-				) {
+				if (isNumber(node) && losesPrecision(node)) {
 					context.report({
 						messageId: "noLossOfPrecision",
 						node,

--- a/tests/lib/rules/no-loss-of-precision.js
+++ b/tests/lib/rules/no-loss-of-precision.js
@@ -61,6 +61,7 @@ ruleTester.run("no-loss-of-precision", rule, {
 		"var x = 00195",
 		"var x = 0008",
 		"var x = 0e5",
+		"var x = 5e-324",
 		"var x = .42",
 		"var x = 42.",
 
@@ -338,6 +339,18 @@ ruleTester.run("no-loss-of-precision", rule, {
 		{
 			code: "var x = 0X200000_0000000_1",
 			languageOptions: { ecmaVersion: 2021 },
+			errors: [{ messageId: "noLossOfPrecision" }],
+		},
+		{
+			code: "var x = 1e-350",
+			errors: [{ messageId: "noLossOfPrecision" }],
+		},
+		{
+			code: "var x = 1e-324",
+			errors: [{ messageId: "noLossOfPrecision" }],
+		},
+		{
+			code: "var x = -1e-350",
 			errors: [{ messageId: "noLossOfPrecision" }],
 		},
 	],


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Bug fix

#### What changes did you make? (Give an overview)

Fixed false negatives in the `no-loss-of-precision` rule for numeric literals that underflow IEEE 754 float64 limits to `0` or `-0` (such as `1e-350`, `1e-324`, and `-1e-350`).

- **Root Cause:** In `lib/rules/no-loss-of-precision.js`, the `Literal` visitor used `if (node.value && ...)` as an entry guard. Because `0` and `-0` are falsy in JavaScript, numeric literals evaluating to zero short-circuited before reaching precision analysis.
- **Fix:**
  1. Updated the `Literal` visitor guard to check `node.value !== null`, allowing numeric literals evaluating to `0` to enter precision checks.
  2. Updated `baseTenLosesPrecision` to inspect whether `node.value === 0` represents an actual mathematical zero (e.g., `0`, `0.0`, `0e10`) by checking if the normalized scientific coefficient contains only `'0'` digits (`/^0+$/u`). If non-zero digits are present (e.g., `1` in `1e-350`), the underflow to zero is correctly flagged as a loss of precision.
  3. Non-base-10 zero literals (`0x0`, `0b0`, `0o0`) and exact subnormal numbers (`5e-324`) remain valid as expected.
- Added regression unit tests to `tests/lib/rules/no-loss-of-precision.js`.

#### Is there anything you'd like reviewers to focus on?

Please review the handling of `node.value === 0` within `baseTenLosesPrecision()`, specifically ensuring that valid zero representations (`0`, `0.0`, `0e10`) and valid minimum subnormals (`5e-324`) remain valid while underflowing non-zero literals (`1e-350`, `1e-324`, `-1e-350`) are reported.
