### PR TITLE
docs: warn about cross-file rules with --cache

### DIFF
--- a/docs/src/use/command-line-interface.md
+++ b/docs/src/use/command-line-interface.md
@@ -710,6 +710,12 @@ The cache is stored in `.eslintcache` by default.
 
 If you run ESLint with `--cache` and then run ESLint without `--cache`, the `.eslintcache` file will be deleted. This is necessary because the results of the lint might change and make `.eslintcache` invalid. If you want to control when the cache file is deleted, then use `--cache-location` to specify an alternate location for the cache file.
 
+::: warning
+
+Caching operates on a per-file basis. If you use rules or plugins that perform cross-file analysis (where the lint results for one file depend on the contents of other files), `--cache` may return cached results for an unchanged file even if a dependent file has changed.
+
+:::
+
 Autofixed files are not placed in the cache. Subsequent linting that does not trigger an autofix will place it in the cache.
 
 ##### `--cache` example


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[x] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #21219

#### What changes did you make? (Give an overview)

Added a warning callout (`::: warning`) to the `#### --cache` subsection in `docs/src/use/command-line-interface.md`.

The note clarifies that ESLint caching operates on a per-file basis and warns users that rules or plugins performing cross-file analysis may return cached results for an unchanged file even if a dependent file has changed.

#### Is there anything you'd like reviewers to focus on?

Please review the clarity, wording, and placement of the warning callout inside the `--cache` section of the CLI documentation.
