### PR TITLE
docs: note that --cache can serve stale results for cross-file rules

### DIFF
--- a/docs/src/use/command-line-interface.md
+++ b/docs/src/use/command-line-interface.md
@@ -712,6 +712,14 @@ If you run ESLint with `--cache` and then run ESLint without `--cache`, the `.es
 
 Autofixed files are not placed in the cache. Subsequent linting that does not trigger an autofix will place it in the cache.
 
+::: warning
+
+A cache entry is keyed on a file's own contents (or metadata) and the configuration, so a rule whose result depends on _other_ files can report a stale result. Type-aware rules and rules that resolve imports across modules are the common cases: editing one module can change the correct result for the files that import it, but because their own contents did not change, they are served from the cache. Upgrading a dependency whose types change has the same effect.
+
+Run ESLint without `--cache`, or delete the cache file, after a change that can affect other files. See [Can I use ESLint's `--cache` with typescript-eslint?](https://typescript-eslint.io/troubleshooting/faqs/eslint/#can-i-use-eslints---cache-with-typescript-eslint) for more detail.
+
+:::
+
 ##### `--cache` example
 
 {{ npx_tabs ({


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update
[ ] Bug fix
[ ] New rule
[ ] Changes an existing rule
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Refs #21219

#### What changes did you make? (Give an overview)

Added a warning to the `--cache` section noting that a cache entry is keyed on a file's own contents and the config, so a rule whose result depends on other files can report a stale result.

The section currently reads as purely a performance option. Its only correctness note is about deleting `.eslintcache` when running without the flag, so nothing tells you that cross-file rules are outside what the cache tracks.

`LintResultCache#getCachedLintResults` decides freshness from exactly two things:

```js
const changed =
    fileDescriptor.changed ||
    fileDescriptor.meta.hashOfConfig !== hashOfConfig;
```

`fileDescriptor.changed` is that one file's own content or metadata, and `hashOfConfig` covers the config, ESLint version and Node version. A rule reading another file is not represented in either, so neither `--cache-strategy` helps.

I checked it with a local rule rather than taking it on faith, so the note describes core behaviour and not a plugin quirk. The rule reports on `consumer.js` based on the contents of `dep.js`:

```js
Program(node) {
    const dep = readFileSync(resolve(import.meta.dirname, "dep.js"), "utf8");
    if (dep.includes("async")) {
        context.report({ node, message: "dep.js exports an async function" });
    }
}
```

Lint `consumer.js` clean with `--cache --cache-strategy content`, change only `dep.js` to export an async function, then lint again: it still exits 0 and reports nothing. Deleting the cache and linting the same tree reports the error. Reverting `dep.js` gets the mirror image, where the cache keeps reporting an error that no longer exists.

This is documenting current behaviour, not asking for a change. #19869 already closed the "make the cache aware of other files" direction as not planned, and this is the caveat that follows from that. The typescript-eslint FAQ link gives readers the detail for the type-aware case.

#### Is there anything you'd like reviewers to focus on?

The wording of the second paragraph. I went with "after a change that can affect other files" to keep it actionable without implying `--cache` is unsafe in general, but if you'd rather it name the concrete situations (upgrading a dependency, changing a module's exported types) I'm happy to make it more specific.
