### PR TITLE
fix: detect globalThis.NaN in use-isnan rule

### DIFF
--- a/docs/src/rules/use-isnan.md
+++ b/docs/src/rules/use-isnan.md
@@ -40,6 +40,14 @@ if (foo == Number.NaN) {
 if (foo != Number.NaN) {
     // ...
 }
+
+if (foo == globalThis.NaN) {
+    // ...
+}
+
+if (foo != globalThis.NaN) {
+    // ...
+}
 ```
 
 :::
@@ -120,6 +128,26 @@ switch (Number.NaN) {
         break;
     // ...
 }
+
+switch (foo) {
+    case globalThis.NaN:
+        bar();
+        break;
+    case 1:
+        baz();
+        break;
+    // ...
+}
+
+switch (globalThis.NaN) {
+    case a:
+        bar();
+        break;
+    case b:
+        baz();
+        break;
+    // ...
+}
 ```
 
 :::
@@ -189,6 +217,26 @@ switch (foo) {
 }
 
 switch (Number.NaN) {
+    case a:
+        bar();
+        break;
+    case b:
+        baz();
+        break;
+    // ...
+}
+
+switch (foo) {
+    case globalThis.NaN:
+        bar();
+        break;
+    case 1:
+        baz();
+        break;
+    // ...
+}
+
+switch (globalThis.NaN) {
     case a:
         bar();
         break;

--- a/lib/rules/use-isnan.js
+++ b/lib/rules/use-isnan.js
@@ -33,7 +33,10 @@ function isNaNIdentifier(node, sourceCode) {
 		return sourceCode.isGlobalReference(nodeToCheck);
 	}
 
-	if (astUtils.isSpecificMemberAccess(nodeToCheck, "Number", "NaN")) {
+	if (
+		astUtils.isSpecificMemberAccess(nodeToCheck, "Number", "NaN") ||
+		astUtils.isSpecificMemberAccess(nodeToCheck, "globalThis", "NaN")
+	) {
 		const objectNode = astUtils.skipChainExpression(nodeToCheck).object;
 		return sourceCode.isGlobalReference(objectNode);
 	}

--- a/tests/lib/rules/use-isnan.js
+++ b/tests/lib/rules/use-isnan.js
@@ -50,10 +50,24 @@ ruleTester.run("use-isnan", rule, {
 		"foo(Number.NaN / 2)",
 		"foo(2 / Number.NaN)",
 		"var x; if (x = Number.NaN) { }",
+		"var x = globalThis.NaN;",
+		"isNaN(globalThis.NaN) === true;",
+		"Number.isNaN(globalThis.NaN) === true;",
+		"foo(globalThis.NaN + 1);",
+		"foo(1 + globalThis.NaN);",
+		"foo(globalThis.NaN - 1)",
+		"foo(1 - globalThis.NaN)",
+		"foo(globalThis.NaN * 2)",
+		"foo(2 * globalThis.NaN)",
+		"foo(globalThis.NaN / 2)",
+		"foo(2 / globalThis.NaN)",
+		"var x; if (x = globalThis.NaN) { }",
 		"x === Number[NaN];",
 		"x === (NaN, 1)",
 		"x === (doStuff(), NaN, 1)",
 		"x === (doStuff(), Number.NaN, 1)",
+		"x === (globalThis.NaN, 1)",
+		"x === (doStuff(), globalThis.NaN, 1)",
 
 		//------------------------------------------------------------------------------
 		// enforceForSwitchCase
@@ -187,6 +201,34 @@ ruleTester.run("use-isnan", rule, {
 			code: "switch((Number.NaN, doStuff(), 1)) {}",
 			options: [{ enforceForSwitchCase: true }],
 		},
+		{
+			code: "switch(globalThis.NaN) { case foo: break; }",
+			options: [{ enforceForSwitchCase: false }],
+		},
+		{
+			code: "switch(foo) { case globalThis.NaN: break; }",
+			options: [{ enforceForSwitchCase: false }],
+		},
+		{
+			code: "switch(foo) { case bar: globalThis.NaN; }",
+			options: [{ enforceForSwitchCase: true }],
+		},
+		{
+			code: "switch(foo) { default: globalThis.NaN; }",
+			options: [{ enforceForSwitchCase: true }],
+		},
+		{
+			code: "switch(foo.globalThis.NaN) {}",
+			options: [{ enforceForSwitchCase: true }],
+		},
+		{
+			code: "switch(foo) { case foo.globalThis.NaN: break }",
+			options: [{ enforceForSwitchCase: true }],
+		},
+		{
+			code: "switch((globalThis.NaN, doStuff(), 1)) {}",
+			options: [{ enforceForSwitchCase: true }],
+		},
 
 		//------------------------------------------------------------------------------
 		// enforceForIndexOf
@@ -196,6 +238,8 @@ ruleTester.run("use-isnan", rule, {
 		"foo.lastIndexOf(NaN)",
 		"foo.indexOf(Number.NaN)",
 		"foo.lastIndexOf(Number.NaN)",
+		"foo.indexOf(globalThis.NaN)",
+		"foo.lastIndexOf(globalThis.NaN)",
 		{
 			code: "foo.indexOf(NaN)",
 			options: [{}],
@@ -374,6 +418,26 @@ ruleTester.run("use-isnan", rule, {
 			code: "foo.lastIndexOf((Number.NaN, 1))",
 			options: [{ enforceForIndexOf: true }],
 		},
+		{
+			code: "foo.indexOf(globalThis.NaN)",
+			options: [{ enforceForIndexOf: false }],
+		},
+		{
+			code: "foo.lastIndexOf(globalThis.NaN)",
+			options: [{ enforceForIndexOf: false }],
+		},
+		{
+			code: "indexOf(globalThis.NaN)",
+			options: [{ enforceForIndexOf: true }],
+		},
+		{
+			code: "foo.indexOf(a, globalThis.NaN)",
+			options: [{ enforceForIndexOf: true }],
+		},
+		{
+			code: "foo.indexOf((globalThis.NaN, 1))",
+			options: [{ enforceForIndexOf: true }],
+		},
 
 		//------------------------------------------------------------------------------
 		// Shadowed NaN / Number.NaN
@@ -439,6 +503,33 @@ ruleTester.run("use-isnan", rule, {
 		},
 		{
 			code: "function foo(Number) { return arr.lastIndexOf(Number?.NaN); }",
+			options: [{ enforceForIndexOf: true }],
+		},
+		"let globalThis; if (x === globalThis.NaN) {}",
+		"function f(globalThis) { return x === globalThis.NaN; }",
+		{
+			code: "if (x === globalThis.NaN) {}",
+			languageOptions: { globals: { globalThis: "off" } },
+		},
+		{
+			code: "let globalThis; switch (foo) { case globalThis.NaN: break; }",
+			options: [{ enforceForSwitchCase: true }],
+		},
+		{
+			code: "let globalThis; switch (globalThis.NaN) { case a: break; }",
+			options: [{ enforceForSwitchCase: true }],
+		},
+		{
+			code: "function foo(globalThis) { return arr.indexOf(globalThis.NaN); }",
+			options: [{ enforceForIndexOf: true }],
+		},
+		{
+			code: "function foo(globalThis) { return arr.lastIndexOf(globalThis.NaN); }",
+			options: [{ enforceForIndexOf: true }],
+		},
+		"let globalThis; if (x === globalThis?.NaN) {}",
+		{
+			code: "function foo(globalThis) { return arr.indexOf(globalThis?.NaN); }",
 			options: [{ enforceForIndexOf: true }],
 		},
 	],
@@ -953,6 +1044,154 @@ ruleTester.run("use-isnan", rule, {
 				},
 			],
 		},
+		{
+			code: "foo === globalThis.NaN;",
+			errors: [
+				{
+					...comparisonError,
+					suggestions: [
+						{
+							messageId: "replaceWithIsNaN",
+							output: "Number.isNaN(foo);",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "123 == globalThis.NaN;",
+			errors: [
+				{
+					...comparisonError,
+					suggestions: [
+						{
+							messageId: "replaceWithIsNaN",
+							output: "Number.isNaN(123);",
+						},
+						{
+							messageId: "replaceWithCastingAndIsNaN",
+							output: "Number.isNaN(Number(123));",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "123 === globalThis.NaN;",
+			errors: [
+				{
+					...comparisonError,
+					suggestions: [
+						{
+							messageId: "replaceWithIsNaN",
+							output: "Number.isNaN(123);",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "123 != globalThis.NaN;",
+			errors: [
+				{
+					...comparisonError,
+					suggestions: [
+						{
+							messageId: "replaceWithIsNaN",
+							output: "!Number.isNaN(123);",
+						},
+						{
+							messageId: "replaceWithCastingAndIsNaN",
+							output: "!Number.isNaN(Number(123));",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "123 !== globalThis.NaN;",
+			errors: [
+				{
+					...comparisonError,
+					suggestions: [
+						{
+							messageId: "replaceWithIsNaN",
+							output: "!Number.isNaN(123);",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "globalThis.NaN === foo;",
+			errors: [
+				{
+					...comparisonError,
+					suggestions: [
+						{
+							messageId: "replaceWithIsNaN",
+							output: "Number.isNaN(foo);",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "globalThis.NaN < 'abc';",
+			errors: [
+				{
+					...comparisonError,
+					suggestions: [],
+				},
+			],
+		},
+		{
+			code: "'abc' > globalThis.NaN;",
+			errors: [
+				{
+					...comparisonError,
+					suggestions: [],
+				},
+			],
+		},
+		{
+			code: "x === globalThis?.NaN;",
+			languageOptions: { ecmaVersion: 2020 },
+			errors: [
+				{
+					...comparisonError,
+					suggestions: [
+						{
+							messageId: "replaceWithIsNaN",
+							output: "Number.isNaN(x);",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "x === globalThis['NaN'];",
+			errors: [
+				{
+					...comparisonError,
+					suggestions: [
+						{
+							messageId: "replaceWithIsNaN",
+							output: "Number.isNaN(x);",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "x === (doStuff(), globalThis.NaN);",
+			errors: [
+				{
+					...comparisonError,
+					suggestions: [],
+				},
+			],
+		},
 
 		//------------------------------------------------------------------------------
 		// enforceForSwitchCase
@@ -1282,6 +1521,78 @@ ruleTester.run("use-isnan", rule, {
 		},
 		{
 			code: "switch((doStuff(), Number.NaN)) {}",
+			options: [{ enforceForSwitchCase: true }],
+			errors: [
+				{
+					messageId: "switchNaN",
+					column: 1,
+				},
+			],
+		},
+		{
+			code: "switch(globalThis.NaN) { case foo: break; }",
+			errors: [
+				{
+					messageId: "switchNaN",
+					column: 1,
+				},
+			],
+		},
+		{
+			code: "switch(foo) { case globalThis.NaN: break; }",
+			errors: [
+				{
+					messageId: "caseNaN",
+					column: 15,
+				},
+			],
+		},
+		{
+			code: "switch(globalThis.NaN) { case foo: break; }",
+			options: [{ enforceForSwitchCase: true }],
+			errors: [
+				{
+					messageId: "switchNaN",
+					column: 1,
+				},
+			],
+		},
+		{
+			code: "switch(foo) { case globalThis.NaN: break; }",
+			options: [{ enforceForSwitchCase: true }],
+			errors: [
+				{
+					messageId: "caseNaN",
+					column: 15,
+				},
+			],
+		},
+		{
+			code: "switch(foo) { case bar: break; case globalThis.NaN: break; default: break; }",
+			options: [{ enforceForSwitchCase: true }],
+			errors: [
+				{
+					messageId: "caseNaN",
+					column: 32,
+				},
+			],
+		},
+		{
+			code: "switch(globalThis.NaN) { case globalThis.NaN: break; }",
+			options: [{ enforceForSwitchCase: true }],
+			errors: [
+				{
+					messageId: "switchNaN",
+					column: 1,
+				},
+				{
+					messageId: "caseNaN",
+					column: 26,
+				},
+			],
+		},
+		{
+			code: "switch((doStuff(), globalThis.NaN)) {}",
 			options: [{ enforceForSwitchCase: true }],
 			errors: [
 				{
@@ -1758,6 +2069,81 @@ ruleTester.run("use-isnan", rule, {
 		},
 		{
 			code: "foo.indexOf((1, NaN), 1)",
+			options: [{ enforceForIndexOf: true }],
+			languageOptions: { ecmaVersion: 2020 },
+			errors: [
+				{
+					messageId: "indexOfNaN",
+					data: { methodName: "indexOf" },
+					suggestions: [],
+				},
+			],
+		},
+		{
+			code: "[1, 2, 3].indexOf(globalThis.NaN)",
+			options: [{ enforceForIndexOf: true }],
+			errors: [
+				{
+					messageId: "indexOfNaN",
+					data: { methodName: "indexOf" },
+					suggestions: [
+						{
+							messageId: "replaceWithFindIndex",
+							data: { methodName: "findIndex" },
+							output: "[1, 2, 3].findIndex(Number.isNaN)",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "foo.indexOf(globalThis.NaN)",
+			options: [{ enforceForIndexOf: true }],
+			errors: [
+				{
+					messageId: "indexOfNaN",
+					data: { methodName: "indexOf" },
+					suggestions: [
+						{
+							messageId: "replaceWithFindIndex",
+							data: { methodName: "findIndex" },
+							output: "foo.findIndex(Number.isNaN)",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "foo.lastIndexOf(globalThis.NaN)",
+			options: [{ enforceForIndexOf: true }],
+			errors: [
+				{
+					messageId: "indexOfNaN",
+					data: { methodName: "lastIndexOf" },
+					suggestions: [
+						{
+							messageId: "replaceWithFindIndex",
+							data: { methodName: "findLastIndex" },
+							output: "foo.findLastIndex(Number.isNaN)",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "foo.indexOf((1, globalThis.NaN))",
+			options: [{ enforceForIndexOf: true }],
+			languageOptions: { ecmaVersion: 2020 },
+			errors: [
+				{
+					messageId: "indexOfNaN",
+					data: { methodName: "indexOf" },
+					suggestions: [],
+				},
+			],
+		},
+		{
+			code: "foo.indexOf(globalThis.NaN, b)",
 			options: [{ enforceForIndexOf: true }],
 			languageOptions: { ecmaVersion: 2020 },
 			errors: [


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

This PR was written with AI assistance and reviewed by me.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #20854

#### What changes did you make? (Give an overview)

`use-isnan` already treats `NaN` and `Number.NaN` as NaN. `globalThis.NaN` is the same global value, so comparisons, `switch`, and `indexOf`/`lastIndexOf` now detect it the same way, but only when `globalThis` is a global reference.

Docs include `globalThis.NaN` examples next to the existing `Number.NaN` examples.

#### Is there anything you'd like reviewers to focus on?

Shadowed or missing `globalThis` is still ignored, matching the `Number.NaN` behavior.