### PR TITLE
feat: add merge-friendly suppressions format

### DIFF
--- a/docs/src/use/command-line-interface.md
+++ b/docs/src/use/command-line-interface.md
@@ -136,6 +136,7 @@ Suppressing Violations:
   --suppress-all                   Suppress all violations - default: false
   --suppress-rule [String]         Suppress specific rules
   --suppressions-location path::String  Specify the location of the suppressions file
+  --suppressions-format String     Specify the format used to write the suppressions file - either: pretty or merge-friendly
   --prune-suppressions             Prune unused suppressions - default: false
   --pass-on-unpruned-suppressions  Ignore unused suppressions - default: false
 
@@ -803,6 +804,23 @@ Specify the path to the suppressions location. Can be a file or a directory.
 {{ npx_tabs ({
     package: "eslint",
     args: ["\"src/**/*.js\"", "--suppressions-location", "\".eslint-suppressions-example.json\""]
+}) }}
+
+#### `--suppressions-format`
+
+Specify the format ESLint uses when writing the suppressions file with `--suppress-all`, `--suppress-rule`, or `--prune-suppressions`.
+
+- **Argument Type**: String. One of `pretty` or `merge-friendly`.
+- **Multiple Arguments**: No
+- **Default Value**: `pretty` for new suppressions files. If an existing file uses the `merge-friendly` format, ESLint preserves that format.
+
+The `merge-friendly` format stores each file entry on a separate line. It can be used with Git's built-in `union` merge driver to reduce conflicts when multiple branches update suppressions. See [Merge-Friendly Suppressions Files](./suppressions#merge-friendly-suppressions-files) for setup instructions and limitations.
+
+##### `--suppressions-format` example
+
+{{ npx_tabs ({
+    package: "eslint",
+    args: ["\"src/**/*.js\"", "--prune-suppressions", "--suppressions-format", "merge-friendly"]
 }) }}
 
 #### `--prune-suppressions`

--- a/docs/src/use/suppressions.md
+++ b/docs/src/use/suppressions.md
@@ -45,6 +45,28 @@ If necessary, you can change the location of the suppressions file by using the 
 eslint --suppressions-location .github/.eslint-suppressions
 ```
 
+### Merge-Friendly Suppressions Files
+
+When multiple branches update the suppressions file, you can use the `merge-friendly` format together with Git's built-in `union` merge driver to reduce content merge conflicts. Convert an existing suppressions file by running:
+
+```bash
+eslint --prune-suppressions --suppressions-format merge-friendly
+```
+
+Then add the suppressions file to `.gitattributes`:
+
+```text
+eslint-suppressions.json text eol=lf merge=union
+```
+
+Adjust the path if you use `--suppressions-location`. The format keeps each source file entry on a separate line, and ESLint preserves it during subsequent suppression updates even when `--suppressions-format` is omitted.
+
+Commit the format conversion and `.gitattributes` change before relying on union merges. Branches that still use the `pretty` representation may require a one-time conflict resolution.
+
+A union merge can retain multiple entries for the same source file. The result remains valid JSON, and the next `--prune-suppressions`, `--suppress-all`, or `--suppress-rule` run rewrites it in canonical form. Run `--prune-suppressions` after a union merge to reconcile suppression counts. Avoid formatting the suppressions file with a general-purpose JSON formatter, because that removes the line-oriented structure.
+
+The union merge driver resolves content changes only. Deleting or renaming the suppressions file while another branch modifies it can still produce a merge conflict.
+
 ## Resolving Suppressions
 
 You can address any of the reported violations by making the necessary changes to the code as usual. If you run ESLint again you will notice that it exits with a non-zero exit code and an error is reported about unused suppressions. This is because the violations have been resolved but the suppressions are still in place.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -424,6 +424,7 @@ const cli = {
 				const suppressions = new SuppressionsService({
 					filePath: suppressionsFileLocation,
 					cwd: process.cwd(),
+					format: options.suppressionsFormat,
 				});
 
 				if (options.suppressAll || options.suppressRule) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -58,6 +58,7 @@ const optionator = require("optionator");
  * @property {boolean} stdin Lint code provided on <STDIN>
  * @property {string} [stdinFilename] Specify filename to process STDIN as
  * @property {boolean} [suppressAll] Suppress all error violations
+ * @property {"pretty" | "merge-friendly"} [suppressionsFormat] Format used when writing the suppressions file
  * @property {string} [suppressionsLocation] Path to the suppressions file or directory
  * @property {string[]} [suppressRule] Suppress specific rules
  * @property {boolean} [version] Output the version number
@@ -311,6 +312,13 @@ module.exports = function () {
 				option: "suppressions-location",
 				type: "path::String",
 				description: "Specify the location of the suppressions file",
+			},
+			{
+				option: "suppressions-format",
+				type: "String",
+				enum: ["pretty", "merge-friendly"],
+				description:
+					"Specify the format used to write the suppressions file",
 			},
 			{
 				option: "prune-suppressions",

--- a/lib/services/suppressions-service.js
+++ b/lib/services/suppressions-service.js
@@ -22,6 +22,30 @@ const stringify = require("json-stable-stringify-without-jsonify");
 /** @typedef {import("../types").Linter.LintMessage} LintMessage */
 /** @typedef {import("../types").ESLint.LintResult} LintResult */
 /** @typedef {Record<string, Record<string, { count: number; }>>} SuppressedViolations */
+/** @typedef {"pretty" | "merge-friendly"} SuppressionsFormat */
+
+// A NUL character cannot occur in a file path, so this cannot collide with a suppression entry.
+const MERGE_FRIENDLY_SENTINEL = "\0eslint-suppressions";
+
+/**
+ * Serializes suppressions with one file per line. Each file entry starts with a
+ * comma so duplicate lines produced by Git's union merge remain valid JSON.
+ * @param {SuppressedViolations} suppressions The suppressions to serialize.
+ * @returns {string} The serialized suppressions.
+ */
+function stringifyMergeFriendly(suppressions) {
+	const entries = Object.keys(suppressions)
+		.filter(file => file !== MERGE_FRIENDLY_SENTINEL)
+		.sort()
+		.map(
+			file =>
+				`, ${JSON.stringify(file)}: ${stringify(suppressions[file])}`,
+		);
+
+	return `{
+  ${JSON.stringify(MERGE_FRIENDLY_SENTINEL)}: {}${entries.length ? `\n${entries.join("\n")}` : ""}
+}`;
+}
 
 //-----------------------------------------------------------------------------
 // Exports
@@ -35,16 +59,20 @@ class SuppressionsService {
 
 	filePath = "";
 	cwd = "";
+	/** @type {SuppressionsFormat | undefined} */
+	format;
 
 	/**
 	 * Creates a new instance of SuppressionsService.
 	 * @param {Object} options The options.
 	 * @param {string} [options.filePath] The location of the suppressions file.
 	 * @param {string} [options.cwd] The current working directory.
+	 * @param {SuppressionsFormat} [options.format] The suppressions file format.
 	 */
-	constructor({ filePath, cwd }) {
+	constructor({ filePath, cwd, format }) {
 		this.filePath = filePath;
 		this.cwd = cwd;
+		this.format = format;
 	}
 
 	/**
@@ -215,8 +243,14 @@ class SuppressionsService {
 	async load() {
 		try {
 			const data = await fs.promises.readFile(this.filePath, "utf8");
+			const suppressions = JSON.parse(data);
 
-			return JSON.parse(data);
+			if (Object.hasOwn(suppressions, MERGE_FRIENDLY_SENTINEL)) {
+				delete suppressions[MERGE_FRIENDLY_SENTINEL];
+				this.format ??= "merge-friendly";
+			}
+
+			return suppressions;
 		} catch (err) {
 			if (err.code === "ENOENT") {
 				return {};
@@ -239,7 +273,9 @@ class SuppressionsService {
 	save(suppressions) {
 		return fs.promises.writeFile(
 			this.filePath,
-			stringify(suppressions, { space: 2 }),
+			this.format === "merge-friendly"
+				? stringifyMergeFriendly(suppressions)
+				: stringify(suppressions, { space: 2 }),
 		);
 	}
 

--- a/tests/bin/eslint.js
+++ b/tests/bin/eslint.js
@@ -840,6 +840,29 @@ describe("bin/eslint.js", () => {
 
 				return Promise.all([exitCodeAssertion, outputAssertion]);
 			});
+
+			it("creates a merge-friendly suppressions file when requested", () => {
+				const child = runESLint(
+					ARGS_WITH_SUPPRESS_ALL.concat(
+						"--suppressions-format",
+						"merge-friendly",
+					),
+				);
+
+				return assertExitCode(child, 0).then(() => {
+					const contents = fs.readFileSync(SUPPRESSIONS_PATH, "utf8");
+
+					assert.deepStrictEqual(JSON.parse(contents), {
+						"\0eslint-suppressions": {},
+						...SUPPRESSIONS_FILE_ALL_ERRORS,
+					});
+					assert.match(
+						contents,
+						/^\{\n {2}"\\u0000eslint-suppressions": \{\}\n, /u,
+					);
+				});
+			});
+
 			it("creates the suppressions file when the --suppress-rule flag is used, and reports some violations", () => {
 				const child = runESLint(ARGS_WITH_SUPPRESS_RULE_INDENT);
 

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -77,6 +77,32 @@ describe("options", () => {
 		});
 	});
 
+	describe("--suppressions-format", () => {
+		it("should return the specified suppressions format", () => {
+			const currentOptions = options.parse(
+				"--suppressions-format merge-friendly",
+			);
+
+			assert.strictEqual(
+				currentOptions.suppressionsFormat,
+				"merge-friendly",
+			);
+		});
+
+		it("should be undefined when not passed", () => {
+			const currentOptions = options.parse("");
+
+			assert.isUndefined(currentOptions.suppressionsFormat);
+		});
+
+		it("should reject an invalid suppressions format", () => {
+			assert.throws(
+				() => options.parse("--suppressions-format invalid"),
+				/Option suppressions-format: 'invalid' not one of/u,
+			);
+		});
+	});
+
 	describe("-f", () => {
 		it("should return a string for .format when passed a string", () => {
 			const currentOptions = options.parse("-f json");

--- a/tests/lib/services/suppressions-service.js
+++ b/tests/lib/services/suppressions-service.js
@@ -79,6 +79,59 @@ describe("SuppressionsService", () => {
 			assert.deepStrictEqual(result, mockData);
 		});
 
+		it("should load merge-friendly JSON without exposing its sentinel", async () => {
+			const suppressionsService = new SuppressionsService({
+				filePath: "/project/eslint-suppressions.json",
+				cwd: "/project",
+			});
+			const writeStub = sinon.stub(fs.promises, "writeFile").resolves();
+
+			sinon.stub(fs.promises, "readFile").resolves(`{
+  "\\u0000eslint-suppressions": {}
+, "file.js": {"rule-id":{"count":1}}
+}`);
+
+			const result = await suppressionsService.load();
+
+			assert.deepStrictEqual(result, {
+				"file.js": { "rule-id": { count: 1 } },
+			});
+
+			await suppressionsService.save(result);
+
+			assert.match(
+				writeStub.firstCall.args[1],
+				/^\{\n {2}"\\u0000eslint-suppressions": \{\}/u,
+			);
+		});
+
+		it("should normalize duplicate file entries from merged JSON", async () => {
+			const suppressionsService = new SuppressionsService({
+				filePath: "/project/eslint-suppressions.json",
+				cwd: "/project",
+			});
+			const writeStub = sinon.stub(fs.promises, "writeFile").resolves();
+
+			sinon.stub(fs.promises, "readFile").resolves(`{
+  "\\u0000eslint-suppressions": {}
+, "file.js": {"rule-id":{"count":1}}
+, "file.js": {"rule-id":{"count":2}}
+}`);
+
+			const suppressions = await suppressionsService.load();
+
+			assert.deepStrictEqual(suppressions, {
+				"file.js": { "rule-id": { count: 2 } },
+			});
+
+			await suppressionsService.save(suppressions);
+
+			assert.strictEqual(
+				writeStub.firstCall.args[1].match(/"file\.js"/gu).length,
+				1,
+			);
+		});
+
 		it("should return an empty object when file does not exist (ENOENT)", async () => {
 			const suppressionsService = new SuppressionsService({
 				filePath: "/project/eslint-suppressions.json",
@@ -227,6 +280,79 @@ describe("SuppressionsService", () => {
 			assert.ok(
 				aIndex !== -1 && bIndex !== -1 && aIndex < bIndex,
 				"Expected keys to be sorted alphabetically (stable stringify)",
+			);
+		});
+
+		it("should write merge-friendly JSON with one sorted file per line", async () => {
+			const suppressionsService = new SuppressionsService({
+				filePath: "/project/eslint-suppressions.json",
+				cwd: "/project",
+				format: "merge-friendly",
+			});
+			const writeStub = sinon.stub(fs.promises, "writeFile").resolves();
+			const suppressions = {
+				"b-file.js": { "z-rule": { count: 1 } },
+				"a-file.js": {
+					"z-rule": { count: 2 },
+					"a-rule": { count: 1 },
+				},
+			};
+
+			await suppressionsService.save(suppressions);
+
+			assert.strictEqual(
+				writeStub.firstCall.args[1],
+				`{
+  "\\u0000eslint-suppressions": {}
+, "a-file.js": {"a-rule":{"count":1},"z-rule":{"count":2}}
+, "b-file.js": {"z-rule":{"count":1}}
+}`,
+			);
+		});
+
+		it("should write an empty merge-friendly suppressions file", async () => {
+			const suppressionsService = new SuppressionsService({
+				filePath: "/project/eslint-suppressions.json",
+				cwd: "/project",
+				format: "merge-friendly",
+			});
+			const writeStub = sinon.stub(fs.promises, "writeFile").resolves();
+
+			await suppressionsService.save({});
+
+			assert.strictEqual(
+				writeStub.firstCall.args[1],
+				`{
+  "\\u0000eslint-suppressions": {}
+}`,
+			);
+		});
+
+		it("should convert merge-friendly JSON to pretty JSON", async () => {
+			const suppressionsService = new SuppressionsService({
+				filePath: "/project/eslint-suppressions.json",
+				cwd: "/project",
+				format: "pretty",
+			});
+			const writeStub = sinon.stub(fs.promises, "writeFile").resolves();
+
+			sinon.stub(fs.promises, "readFile").resolves(`{
+  "\\u0000eslint-suppressions": {}
+, "file.js": {"rule-id":{"count":1}}
+}`);
+			const suppressions = await suppressionsService.load();
+
+			await suppressionsService.save(suppressions);
+
+			assert.strictEqual(
+				writeStub.firstCall.args[1],
+				`{
+  "file.js": {
+    "rule-id": {
+      "count": 1
+    }
+  }
+}`,
 			);
 		});
 	});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did *not* use AI to generate this PR.
- [X] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Add a CLI option

#### What changes did you make? (Give an overview)

This PR adds the `--suppressions-format` CLI option with two supported values:

- `pretty` preserves the existing suppression file format.
- `merge-friendly` writes each top-level file entry on a separate physical line.

The merge-friendly format uses a reserved NUL-prefixed sentinel as a stable first entry. This allows Git's built-in `union` merge driver to retain concurrent changes without producing conflict markers or invalid JSON.

ESLint automatically detects and preserves an existing merge-friendly file during subsequent `--suppress-all`, `--suppress-rule`, and `--prune-suppressions` runs. Passing `--suppressions-format pretty` converts it back on the next write.

This PR also:

- wires the new option through the CLI;
- documents the required `.gitattributes` configuration and its limitations;
- adds unit tests for parsing, serialization, format preservation, conversion, and duplicate entries;
- adds an end-to-end CLI test.

Validation completed:

- `npm test`: 38,592 passing, 11 pending;
- `npm run lint`;
- Prettier and Markdown checks;
- manual Git `union` merge scenarios.

#### Is there anything you'd like reviewers to focus on?

Please focus on:

- the `--suppressions-format` option name and values;
- the sentinel and leading-comma serialization approach;
- automatic format detection and preservation;
- duplicate file entries after a union merge.

Duplicate entries intentionally follow normal `JSON.parse()` behavior until the next suppression update canonicalizes the file. The format prevents textual merge conflicts; it does not attempt a semantic three-way merge.

The Git `union` driver only resolves content changes. Deleting or renaming the suppression file while another branch modifies it can still produce a conflict.

<!-- markdownlint-disable-file MD004 -->
