### PR TITLE
docs: replace deprecated rules in config examples

### DIFF
--- a/docs/src/use/configure/configuration-files.md
+++ b/docs/src/use/configure/configuration-files.md
@@ -36,14 +36,14 @@ import { defineConfig } from "eslint/config";
 export default defineConfig([
 	{
 		rules: {
-			semi: "error",
+			eqeqeq: "error",
 			"prefer-const": "error",
 		},
 	},
 ]);
 ```
 
-In this example, the `defineConfig()` helper is used to define a configuration array with just one configuration object. The configuration object enables two rules: `semi` and `prefer-const`. These rules are applied to all of the files ESLint processes using this config file.
+In this example, the `defineConfig()` helper is used to define a configuration array with just one configuration object. The configuration object enables two rules: `eqeqeq` and `prefer-const`. These rules are applied to all of the files ESLint processes using this config file.
 
 If your project specifies `"type": "commonjs"` in its `package.json` file, then `eslint.config.js` must be in CommonJS format, such as:
 
@@ -54,7 +54,7 @@ const { defineConfig } = require("eslint/config");
 module.exports = defineConfig([
 	{
 		rules: {
-			semi: "error",
+			eqeqeq: "error",
 			"prefer-const": "error",
 		},
 	},
@@ -103,7 +103,7 @@ export default defineConfig([
 	{
 		files: ["**/*.js"],
 		rules: {
-			semi: "error",
+			eqeqeq: "error",
 		},
 	},
 
@@ -128,13 +128,13 @@ export default defineConfig([
 	// matches all files because it doesn't specify the `files` or `ignores` key
 	{
 		rules: {
-			semi: "error",
+			eqeqeq: "error",
 		},
 	},
 ]);
 ```
 
-With this configuration, the `semi` rule is enabled for all files that match the default files in ESLint. So if you pass `example.js` to ESLint, the `semi` rule is applied. If you pass a non-JavaScript file, like `example.txt`, the `semi` rule is not applied because there are no other configuration objects that match that filename. (ESLint outputs an error message letting you know that the file was ignored due to missing configuration.)
+With this configuration, the `eqeqeq` rule is enabled for all files that match the default files in ESLint. So if you pass `example.js` to ESLint, the `eqeqeq` rule is applied. If you pass a non-JavaScript file, like `example.txt`, the `eqeqeq` rule is not applied because there are no other configuration objects that match that filename. (ESLint outputs an error message letting you know that the file was ignored due to missing configuration.)
 
 ::: important
 By default, ESLint lints files that match the patterns `**/*.js`, `**/*.cjs`, and `**/*.mjs`. Those files are always matched unless you explicitly exclude them using [global ignores](#globally-ignore-files-with-ignores).
@@ -211,13 +211,13 @@ export default defineConfig([
 	{
 		files: ["src/**/*.js"],
 		rules: {
-			semi: "error",
+			eqeqeq: "error",
 		},
 	},
 ]);
 ```
 
-Here, only the JavaScript files in the `src` directory have the `semi` rule applied. If you run ESLint on files in another directory, this configuration object is skipped. By adding `ignores`, you can also remove some of the files in `src` from this configuration object:
+Here, only the JavaScript files in the `src` directory have the `eqeqeq` rule applied. If you run ESLint on files in another directory, this configuration object is skipped. By adding `ignores`, you can also remove some of the files in `src` from this configuration object:
 
 ```js
 // eslint.config.js
@@ -228,7 +228,7 @@ export default defineConfig([
 		files: ["src/**/*.js"],
 		ignores: ["**/*.config.js"],
 		rules: {
-			semi: "error",
+			eqeqeq: "error",
 		},
 	},
 ]);
@@ -245,13 +245,13 @@ export default defineConfig([
 		files: ["src/**/*.js"],
 		ignores: ["**/*.config.js", "!**/eslint.config.js"],
 		rules: {
-			semi: "error",
+			eqeqeq: "error",
 		},
 	},
 ]);
 ```
 
-Here, the configuration object excludes files ending with `.config.js` except for `eslint.config.js`. That file still has `semi` applied.
+Here, the configuration object excludes files ending with `.config.js` except for `eslint.config.js`. That file still has `eqeqeq` applied.
 
 Non-global `ignores` patterns can only match file names. A pattern like `"dir-to-exclude/"` will not ignore anything. To ignore everything in a particular directory, a pattern like `"dir-to-exclude/**"` should be used instead.
 
@@ -265,7 +265,7 @@ export default defineConfig([
 	{
 		ignores: ["**/*.config.js"],
 		rules: {
-			semi: "error",
+			eqeqeq: "error",
 		},
 	},
 ]);
@@ -462,7 +462,7 @@ Options specific to the linting process can be configured using the `linterOptio
 
 #### Disable Inline Configuration
 
-Inline configuration is implemented using an `/*eslint*/` comment, such as `/*eslint semi: error*/`. You can disallow inline configuration by setting `noInlineConfig` to `true`. When enabled, all inline configuration is ignored. Here's an example:
+Inline configuration is implemented using an `/*eslint*/` comment, such as `/*eslint eqeqeq: error*/`. You can disallow inline configuration by setting `noInlineConfig` to `true`. When enabled, all inline configuration is ignored. Here's an example:
 
 ```js
 // eslint.config.js
@@ -535,13 +535,13 @@ import { defineConfig } from "eslint/config";
 export default defineConfig([
 	{
 		rules: {
-			semi: "error",
+			eqeqeq: "error",
 		},
 	},
 ]);
 ```
 
-This configuration object specifies that the [`semi`](../../rules/semi) rule should be enabled with a severity of `"error"`. You can also provide options to a rule by specifying an array where the first item is the severity and each item after that is an option for the rule. For example, you can switch the `semi` rule to disallow semicolons by passing `"never"` as an option:
+This configuration object specifies that the [`eqeqeq`](../../rules/eqeqeq) rule should be enabled with a severity of `"error"`. You can also provide options to a rule by specifying an array where the first item is the severity and each item after that is an option for the rule. For example, you can configure the `eqeqeq` rule to use smart comparisons by passing `"smart"` as an option:
 
 ```js
 // eslint.config.js
@@ -550,7 +550,7 @@ import { defineConfig } from "eslint/config";
 export default defineConfig([
 	{
 		rules: {
-			semi: ["error", "never"],
+			eqeqeq: ["error", "smart"],
 		},
 	},
 ]);

--- a/docs/src/use/configure/rules.md
+++ b/docs/src/use/configure/rules.md
@@ -46,10 +46,10 @@ This example is the same as the last example, only it uses the numeric codes ins
 If a rule has additional options, you can specify them using array literal syntax, such as:
 
 ```js
-/* eslint quotes: ["error", "double"], curly: 2 */
+/* eslint no-unused-vars: ["error", { "args": "none" }], curly: 2 */
 ```
 
-This comment specifies the `"double"` option for the [`quotes`](../../rules/quotes) rule. The first item in the array is always the rule severity (number or string).
+This comment specifies the `{ "args": "none" }` option for the [`no-unused-vars`](../../rules/no-unused-vars) rule. The first item in the array is always the rule severity (number or string).
 
 #### Configuration Comment Descriptions
 
@@ -124,18 +124,18 @@ import { defineConfig } from "eslint/config";
 export default defineConfig([
 	{
 		rules: {
-			semi: ["error", "never"],
+			eqeqeq: ["error", "smart"],
 		},
 	},
 	{
 		rules: {
-			semi: ["warn", "always"],
+			eqeqeq: ["warn", "always"],
 		},
 	},
 ]);
 ```
 
-Using this configuration, the final rule configuration for `semi` is `["warn", "always"]` because it appears last in the array. The array indicates that the configuration is for the severity and any options. You can change just the severity by defining only a string or number, as in this example:
+Using this configuration, the final rule configuration for `eqeqeq` is `["warn", "always"]` because it appears last in the array. The array indicates that the configuration is for the severity and any options. You can change just the severity by defining only a string or number, as in this example:
 
 ```js
 import { defineConfig } from "eslint/config";
@@ -143,18 +143,18 @@ import { defineConfig } from "eslint/config";
 export default defineConfig([
 	{
 		rules: {
-			semi: ["error", "never"],
+			eqeqeq: ["error", "smart"],
 		},
 	},
 	{
 		rules: {
-			semi: "warn",
+			eqeqeq: "warn",
 		},
 	},
 ]);
 ```
 
-Here, the second configuration object only overrides the severity, so the final configuration for `semi` is `["warn", "never"]`.
+Here, the second configuration object only overrides the severity, so the final configuration for `eqeqeq` is `["warn", "smart"]`.
 
 ::: important
 Rules configured via configuration comments have the highest priority and are applied after all configuration files settings.
@@ -290,20 +290,20 @@ alert("foo");
 To disable multiple rules on a specific line:
 
 ```js
-alert("foo"); // eslint-disable-line no-alert, quotes, semi
+alert("foo"); // eslint-disable-line no-alert, eqeqeq, curly
 
-// eslint-disable-next-line no-alert, quotes, semi
+// eslint-disable-next-line no-alert, eqeqeq, curly
 alert("foo");
 
-alert("foo"); /* eslint-disable-line no-alert, quotes, semi */
+alert("foo"); /* eslint-disable-line no-alert, eqeqeq, curly */
 
-/* eslint-disable-next-line no-alert, quotes, semi */
+/* eslint-disable-next-line no-alert, eqeqeq, curly */
 alert("foo");
 
 /* eslint-disable-next-line
   no-alert,
-  quotes,
-  semi
+  eqeqeq,
+  curly
 */
 alert("foo");
 ```

--- a/docs/src/use/core-concepts/index.md
+++ b/docs/src/use/core-concepts/index.md
@@ -17,7 +17,7 @@ ESLint is a configurable JavaScript linter. It helps you find and fix problems i
 
 Rules are the core building block of ESLint. A rule validates if your code meets a certain expectation, and what to do if it does not meet that expectation. Rules can also contain additional configuration options specific to that rule.
 
-For example, the [`semi`](../../rules/semi) rule lets you specify whether or not JavaScript statements should end with a semicolon (`;`). You can set the rule to either always require semicolons or require that a statement never ends with a semicolon.
+For example, the [`eqeqeq`](../../rules/eqeqeq) rule lets you require the use of `===` and `!==` in place of the more error-prone `==` and `!=` equality operators.
 
 ESLint contains hundreds of built-in rules that you can use. You can also create custom rules or use rules that others have created with [plugins](#plugins).
 


### PR DESCRIPTION
## Summary
- Replace deprecated stylistic rules (`semi`, `quotes`) with non-deprecated examples (`eqeqeq`, `no-unused-vars`, `curly`) in the configuration docs and core concepts guide.
- Keeps pedagogical examples current with the Rules index, which marks those stylistic rules as deprecated.

Closes #20892

## Notes
@amareshsm was previously assigned; there was no open PR and several unanswered check-ins, so I offered to take this on in the issue thread and opened this PR to unblock the accepted docs fix.

## Checklist
- [x] Documentation-only change
- [x] Examples use non-deprecated built-in rules
