### PR TITLE
docs: warn that --cache can go stale if files change mid-run

### DIFF
--- a/docs/src/use/command-line-interface.md
+++ b/docs/src/use/command-line-interface.md
@@ -712,6 +712,10 @@ If you run ESLint with `--cache` and then run ESLint without `--cache`, the `.es
 
 Autofixed files are not placed in the cache. Subsequent linting that does not trigger an autofix will place it in the cache.
 
+::: warning
+`--cache` records each file's hash (or mtime) at the *end* of the run, together with the results from when that file was linted. If another process edits a file after ESLint has linted it but before the run finishes — for example an editor save, a formatter, or a git checkout — the cache can store the new content's fingerprint with the old results. Later `--cache` runs then keep serving those stale results until you delete the cache file. Delete the affected entries (or `.eslintcache`) after concurrent writes, or avoid `--cache` when other tools rewrite sources during a long lint.
+:::
+
 ##### `--cache` example
 
 {{ npx_tabs ({


### PR DESCRIPTION
## Description

`--cache` records each file's hash (or mtime) at the *end* of the run, together with the results from when that file was linted. If another process edits a file after ESLint has linted it but before the run finishes, the cache can store the new content's fingerprint with the old results. Later `--cache` runs then keep serving those stale results until the cache is deleted.

This documents that behavior on the Caching CLI page. No runtime change.

Fixes #21188

## What I Did

Added a warning under `--cache` describing the mid-run write race, when it happens (editor save, formatter, git checkout during a long lint), and the workaround (delete the affected cache entries / `.eslintcache`, or skip `--cache` when other tools rewrite sources during the run).

This matches the direction from the issue discussion: mention the behavior in the docs rather than changing cache invalidation.

## Checklist

- [x] Conventional Commits (`docs:`)
- [x] Docs only

Made with [Cursor](https://cursor.com)