### PR TITLE
fix: use-isnan should detect globalThis.NaN

### DIFF
--- a/lib/rules/use-isnan.js
+++ b/lib/rules/use-isnan.js
@@ -37,6 +37,10 @@ function isNaNIdentifier(node, sourceCode) {
 		const objectNode = astUtils.skipChainExpression(nodeToCheck).object;
 		return sourceCode.isGlobalReference(objectNode);
 	}
+	if (astUtils.isSpecificMemberAccess(nodeToCheck, "globalThis", "NaN")) {
+		const objectNode = astUtils.skipChainExpression(nodeToCheck).object;
+		return sourceCode.isGlobalReference(objectNode);
+	}
 
 	return false;
 }

--- a/tests/lib/rules/use-isnan.js
+++ b/tests/lib/rules/use-isnan.js
@@ -39,6 +39,9 @@ ruleTester.run("use-isnan", rule, {
 		"foo(2 / NaN)",
 		"var x; if (x = NaN) { }",
 		"var x = Number.NaN;",
+		"var x = globalThis.NaN;",
+		"isNaN(globalThis.NaN) === true;",
+		"Number.isNaN(globalThis.NaN) === true;",
 		"isNaN(Number.NaN) === true;",
 		"Number.isNaN(Number.NaN) === true;",
 		"foo(Number.NaN + 1);",
@@ -663,6 +666,20 @@ ruleTester.run("use-isnan", rule, {
 		},
 		{
 			code: "123 === Number.NaN;",
+			errors: [
+				{
+					...comparisonError,
+					suggestions: [
+						{
+							messageId: "replaceWithIsNaN",
+							output: "Number.isNaN(123);",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "123 === globalThis.NaN;",
 			errors: [
 				{
 					...comparisonError,


### PR DESCRIPTION
## What is the purpose of this change?

The `use-isnan` rule now reports comparisons with `globalThis.NaN`, matching the existing behavior for `Number.NaN`.

Previously, `globalThis.NaN` was completely ignored by the rule, resulting in a false negative. Since `globalThis.NaN` is the exact same built-in global `NaN` value (accessed via the standardized ES2020 static reference), comparisons like `foo === globalThis.NaN` suffer from the same language pitfall as `foo === NaN` and `foo === Number.NaN`.

## What changes did you make?

- Added a check for `globalThis.NaN` in the `isNaNIdentifier()` function in `lib/rules/use-isnan.js`
- Added valid test cases for `globalThis.NaN` in safe contexts
- Added an invalid test case for `123 === globalThis.NaN`

## Related Issues

Fixes #20854