### PR TITLE
feat: report references inside IIFEs in `no-use-before-define`

### DIFF
--- a/docs/src/rules/no-use-before-define.md
+++ b/docs/src/rules/no-use-before-define.md
@@ -229,6 +229,13 @@ class A {
     }
     class D {}
 }
+
+{
+    (() => {
+        new E();
+    })();
+    class E {}
+}
 ```
 
 :::
@@ -245,6 +252,11 @@ function foo() {
 }
 
 class A {
+}
+
+{
+    (() => () => new B())();
+    class B {}
 }
 ```
 
@@ -289,6 +301,11 @@ const g = function() {};
     }
     const foo = 1;
 }
+
+(() => {
+    console.log(bar);
+})();
+const bar = 1;
 ```
 
 :::
@@ -319,6 +336,10 @@ const g = function() {}
     }
     const foo = 1;
 }
+
+// the IIFE runs immediately, but the returned inner function is deferred
+const h = (() => () => bar)();
+const bar = 1;
 ```
 
 :::

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -94,6 +94,19 @@ function isClassStaticInitializerScope(scope) {
 }
 
 /**
+ * Checks whether a given scope is an IIFE (Immediately Invoked Function Expression) scope.
+ * @param {Scope} scope A scope to check.
+ * @returns {boolean} `true` if the scope is an IIFE scope.
+ */
+function isIIFEScope(scope) {
+	return (
+		scope.type === "function" &&
+		scope.block.parent.type === "CallExpression" &&
+		scope.block.parent.callee === scope.block
+	);
+}
+
+/**
  * Checks whether a given reference is evaluated in an execution context
  * that isn't the one where the variable it refers to is defined.
  * Execution contexts are:
@@ -103,12 +116,16 @@ function isClassStaticInitializerScope(scope) {
  * - class static blocks (implicit functions)
  * Static class field initializers and class static blocks are automatically run during the class definition evaluation,
  * and therefore we'll consider them as a part of the parent execution context.
+ * The same applies to immediately invoked function expressions (IIFEs), which are run
+ * at the point where they appear.
  * Example:
  *
  *   const x = 1;
  *
  *   x; // returns `false`
  *   () => x; // returns `true`
+ *   (() => x)(); // returns `false`
+ *   (() => () => x)(); // returns `true`, the inner function is deferred
  *
  *   class C {
  *       field = x; // returns `true`
@@ -135,7 +152,10 @@ function isFromSeparateExecutionContext(reference) {
 
 	// Scope#variableScope represents execution context
 	while (variable.scope.variableScope !== scope.variableScope) {
-		if (isClassStaticInitializerScope(scope.variableScope)) {
+		if (
+			isClassStaticInitializerScope(scope.variableScope) ||
+			isIIFEScope(scope.variableScope)
+		) {
 			scope = scope.variableScope.upper;
 		} else {
 			return true;

--- a/tests/lib/rules/no-use-before-define.js
+++ b/tests/lib/rules/no-use-before-define.js
@@ -453,6 +453,50 @@ ruleTester.run("no-use-before-define", rule, {
 				parserOptions: { ecmaFeatures: { jsx: true } },
 			},
 		},
+
+		/**
+		 * https://github.com/eslint/eslint/issues/21224
+		 * Functions that are not immediately invoked run in a separate execution
+		 * context, so they remain exempt with `variables: false`/`classes: false`.
+		 */
+		{
+			code: "const f = () => { alert(a); }; const a = 5; f();",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			// the IIFE runs immediately, but the returned inner function is deferred
+			code: "(() => () => a)(); const a = 5;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			// `.call()`/`.apply()` are not syntactically immediately invoked
+			code: "(function () { alert(a); }).call(null); const a = 5;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "(function () { alert(a); }).apply(null); const a = 5;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			// the reference resolves to the parameter, not the outer variable
+			code: "(a => { alert(a); })(1); const a = 5;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "(() => { const a = 1; alert(a); })(); const a = 5;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 6 },
+		},
+		{
+			code: "const a = 5; (() => { alert(a); })();",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 6 },
+		},
 	],
 	invalid: [
 		{
@@ -1711,6 +1755,102 @@ ruleTester.run("no-use-before-define", rule, {
 					column: 2,
 					endLine: 1,
 					endColumn: 5,
+				},
+			],
+		},
+
+		/**
+		 * https://github.com/eslint/eslint/issues/21224
+		 * An IIFE body runs in the same execution context as the code around it,
+		 * so references in it are not exempt with `variables: false`/`classes: false`.
+		 */
+		{
+			code: "(() => { alert(a); })(); const a = 5;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "usedBeforeDefined",
+					data: { name: "a" },
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 17,
+				},
+			],
+		},
+		{
+			code: "(function () { alert(a); })(); const a = 5;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "usedBeforeDefined",
+					data: { name: "a" },
+					line: 1,
+					column: 22,
+					endLine: 1,
+					endColumn: 23,
+				},
+			],
+		},
+		{
+			code: "await (async () => { alert(a); })(); const a = 5;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+			errors: [
+				{
+					messageId: "usedBeforeDefined",
+					data: { name: "a" },
+					line: 1,
+					column: 28,
+					endLine: 1,
+					endColumn: 29,
+				},
+			],
+		},
+		{
+			code: "(() => { (() => { alert(a); })(); })(); const a = 5;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "usedBeforeDefined",
+					data: { name: "a" },
+					line: 1,
+					column: 25,
+					endLine: 1,
+					endColumn: 26,
+				},
+			],
+		},
+		{
+			code: "(() => { new C(); })(); class C {}",
+			options: [{ classes: false }],
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "usedBeforeDefined",
+					data: { name: "C" },
+					line: 1,
+					column: 14,
+					endLine: 1,
+					endColumn: 15,
+				},
+			],
+		},
+		{
+			// an IIFE in a variable's own initializer is evaluated during initialization
+			code: "const b = (() => b)();",
+			languageOptions: { ecmaVersion: 6 },
+			errors: [
+				{
+					messageId: "usedBeforeDefined",
+					data: { name: "b" },
+					line: 1,
+					column: 18,
+					endLine: 1,
+					endColumn: 19,
 				},
 			],
 		},


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [ ] Bug fix ([template](https://githubusercontent.com))
- [ ] New rule ([template](https://githubusercontent.com))
- [X] Changes an existing rule ([template](https://githubusercontent.com))
- [ ] Add autofix to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

**What rule do you want to change?**

`no-use-before-define`

**What change do you want to make (place an "X" next to just one item)?**

- [X] Generate more warnings
- [ ] Generate fewer warnings
- [ ] Implement autofix
- [ ] Implement suggestions

**How will the change be implemented (place an "X" next to just one item)?**

- [ ] A new option
- [X] A new default behavior
- [ ] Other

---

#### Please provide some example code that this change will affect:

```js
/*eslint no-use-before-define: ["error", { "variables": false }]*/

(() => {
    console.log(a);
})();

const a = 5;
```

**What does the rule currently do for this code?**

Nothing is reported, even though the IIFE body runs before `a` is initialized, so this throws `ReferenceError: Cannot access 'a' before initialization` at runtime.

**What will the rule do after it's changed?**

The reference to `a` is reported, consistent with how the rule already treats class static initializers, which are also provably executed immediately.

---

#### What changes did you make? (Give an overview)

Fixes #21224.

`isFromSeparateExecutionContext()` decides whether a reference may be exempt under `variables: false` / `classes: false`. It already walks out of class static initializer scopes, because those run during the class definition evaluation and therefore belong to the parent execution context. IIFEs are immediate in exactly the same sense, but were not handled.

**Modified Files:**
* `lib/rules/no-use-before-define.js`
  * Added `isIIFEScope()`
  * Updated the scope walk in `isFromSeparateExecutionContext()` to also walk out of IIFE scopes.
  * Updated the JSDoc of `isFromSeparateExecutionContext()`.
* `tests/lib/rules/no-use-before-define.js` — 6 invalid and 7 valid cases.
* `docs/src/rules/no-use-before-define.md` — Examples added in the `classes` and `variables` sections.

Because the walk stops at the first scope that is not immediately invoked, deferred functions are unaffected and nested or mixed cases fall out of the existing loop without extra handling:

```js
/*eslint no-use-before-define: ["error", { "variables": false }]*/

const f = () => { console.log(a); };  // still not reported
const a = 5;
f();
```

```js
/*eslint no-use-before-define: ["error", { "variables": false }]*/

(() => () => b)();                    // still not reported, inner fn is deferred
const b = 5;
```

```js
/*eslint no-use-before-define: ["error", { "variables": false }]*/

(() => { (() => { console.log(c); })(); })();  // reported, walks out twice
const c = 5;
```

##### Verification:

| Check | Result |
| :--- | :--- |
| `npx mocha tests/lib/rules/no-use-before-define.js` | 367 passing (was 354) |
| the same, with the rule change reverted | 6 failing — the 6 new invalid cases |
| `npx mocha "tests/lib/rules/**/*.js"` | 34,769 passing |
| `node bin/eslint.js lib/ tools/` | clean |
| `node Makefile.js checkRuleExamples` | passes |

---

#### Is there anything you'd like reviewers to focus on?

Two points were left open in the issue. I implemented the narrower reading of each and can change either one.

##### 1. This also changes behavior under the default options.

An IIFE in a variable's own initializer reaches `isFromSeparateExecutionContext()` through `isEvaluatedDuringInitialization()` rather than through the options gate, so it changes regardless of the options:

```js
/*eslint no-use-before-define: "error"*/

const b = (() => b)();   // not reported before, reported after
```

**Measured before and after the change:**

| Code | Options | Before | After |
| :--- | :--- | :--- | :--- |
| `const b = (() => b)();` | (default) | not reported | **reported** |
| `const b = (() => b)();` | `{ variables: false }` | not reported | **reported** |
| `const a = foo(() => a);` | `{ variables: false }` | not reported | not reported |
| `const x = () => x;` | `{ variables: false }` | not reported | not reported |
| `const c = { get self() { return c; } };` | `{ variables: false }` | not reported | not reported |

This is the provably-immediate subset of #20014, and the closed draft #200 also had it as an invalid case. The rest of #20014 — callbacks whose immediacy cannot be proven, such as `const a = foo(() => a)` — is not affected. The circular-getter pattern raised in that discussion is not affected either.

I added a test documenting the new behavior. If you would rather keep this PR strictly to references outside initializers, that would need an extra guard. This also seems relevant to the semver classification discussed in the issue.

##### 2. `.call()` / `.apply()` are not included.

They are not syntactically IIFEs, so they keep the current behavior:

```js
/*eslint no-use-before-define: ["error", { "variables": false }]*/

(function () { console.log(a); }).call(null);   // not reported
const a = 5;
```

I added them as valid tests to pin the current scope. If the team wants them covered, I can extend `isIIFEScope()` and move those tests.
