### PR TITLE
feat: report references inside IIFEs in `no-use-before-define`

### DIFF
--- a/docs/src/rules/no-use-before-define.md
+++ b/docs/src/rules/no-use-before-define.md
@@ -229,6 +229,13 @@ class A {
     }
     class D {}
 }
+
+{
+    (() => {
+        new D();
+    })();
+    class D {}
+}
 ```
 
 :::
@@ -245,6 +252,13 @@ function foo() {
 }
 
 class A {
+}
+
+{
+    (function* () {
+        new D();
+    })();
+    class D {}
 }
 ```
 
@@ -289,6 +303,20 @@ const g = function() {};
     }
     const foo = 1;
 }
+
+{
+    (() => {
+        console.log(foo);
+    })();
+    const foo = 1;
+}
+
+{
+    (async () => {
+        console.log(foo);
+    })();
+    const foo = 1;
+}
 ```
 
 :::
@@ -317,6 +345,26 @@ const g = function() {}
     const C = class {
         x = foo;
     }
+    const foo = 1;
+}
+
+{
+    (() => () => foo)();
+    const foo = 1;
+}
+
+{
+    (function* () {
+        console.log(foo);
+    })();
+    const foo = 1;
+}
+
+{
+    (async () => {
+        await 0;
+        console.log(foo);
+    })();
     const foo = 1;
 }
 ```

--- a/docs/src/rules/no-use-before-define.md
+++ b/docs/src/rules/no-use-before-define.md
@@ -310,13 +310,6 @@ const g = function() {};
     })();
     const foo = 1;
 }
-
-{
-    (async () => {
-        console.log(foo);
-    })();
-    const foo = 1;
-}
 ```
 
 :::
@@ -362,7 +355,6 @@ const g = function() {}
 
 {
     (async () => {
-        await 0;
         console.log(foo);
     })();
     const foo = 1;

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -6,6 +6,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const Traverser = require("../shared/traverser");
+
+//------------------------------------------------------------------------------
 // Types
 //------------------------------------------------------------------------------
 
@@ -19,6 +25,8 @@
 const SENTINEL_TYPE =
 	/^(?:(?:Function|Class)(?:Declaration|Expression)|ArrowFunctionExpression|CatchClause|ImportDeclaration|ExportNamedDeclaration)$/u;
 const FOR_IN_OF_TYPE = /^For(?:In|Of)Statement$/u;
+const FUNCTION_TYPE =
+	/^(?:FunctionDeclaration|FunctionExpression|ArrowFunctionExpression)$/u;
 
 /**
  * Parses a given value as options.
@@ -94,6 +102,86 @@ function isClassStaticInitializerScope(scope) {
 }
 
 /**
+ * Cache for `canSuspend()`. The result depends only on the function node,
+ * so it's safe to reuse it for every reference in that function.
+ * @type {WeakMap<ASTNode, boolean>}
+ */
+const suspensionCache = new WeakMap();
+
+/**
+ * Checks whether a given async function can suspend its own execution,
+ * i.e. whether it contains an `await` that belongs to it.
+ * `await` in a nested function belongs to that function, so it's ignored.
+ * @param {ASTNode} node An async function node to check.
+ * @param {Object} visitorKeys The visitor keys to traverse child nodes with.
+ * @returns {boolean} `true` if the function can suspend its own execution.
+ */
+function canSuspend(node, visitorKeys) {
+	if (suspensionCache.has(node)) {
+		return suspensionCache.get(node);
+	}
+
+	let found = false;
+
+	Traverser.traverse(node.body, {
+		visitorKeys,
+		enter(child) {
+			if (
+				child.type === "AwaitExpression" ||
+				(child.type === "ForOfStatement" && child.await) ||
+				/*
+				 * `await using` declarations await the disposal of the resource
+				 * when the enclosing scope is exited.
+				 */
+				(child.type === "VariableDeclaration" &&
+					child.kind === "await using")
+			) {
+				found = true;
+				this.break();
+			} else if (FUNCTION_TYPE.test(child.type)) {
+				this.skip();
+			}
+		},
+	});
+
+	suspensionCache.set(node, found);
+
+	return found;
+}
+
+/**
+ * Checks whether a given scope is the scope of an immediately invoked function.
+ * The body of an immediately invoked function is evaluated where the function appears,
+ * so it belongs to the execution context that contains it.
+ *
+ * Generators are excluded because calling a generator function only creates an iterator,
+ * and the body isn't evaluated until the iterator is advanced. Async functions that can
+ * suspend are excluded as well, because everything that follows the first `await` is
+ * evaluated in a later job.
+ * @param {Scope} scope A scope to check.
+ * @param {Object} visitorKeys The visitor keys to traverse child nodes with.
+ * @returns {boolean} `true` if the scope is the scope of an immediately invoked function.
+ */
+function isImmediatelyInvokedFunctionScope(scope, visitorKeys) {
+	if (scope.type !== "function") {
+		return false;
+	}
+
+	// `scope.block` is a function node
+	const node = scope.block;
+
+	if (node.parent.type !== "CallExpression" || node.parent.callee !== node) {
+		return false;
+	}
+
+	if (node.generator) {
+		return false;
+	}
+
+	return !node.async || !canSuspend(node, visitorKeys);
+}
+
+/**
  * Checks whether a given reference is evaluated in an execution context
  * that isn't the one where the variable it refers to is defined.
  * Execution contexts are:
@@ -103,12 +191,17 @@ function isClassStaticInitializerScope(scope) {
  * - class static blocks (implicit functions)
  * Static class field initializers and class static blocks are automatically run during the class definition evaluation,
  * and therefore we'll consider them as a part of the parent execution context.
+ * The same applies to immediately invoked functions, whose bodies are evaluated where the function appears.
  * Example:
  *
  *   const x = 1;
  *
  *   x; // returns `false`
  *   () => x; // returns `true`
+ *   (() => x)(); // returns `false`
+ *   (() => () => x)(); // returns `true`, the inner function is deferred
+ *   (function* () { x; })(); // returns `true`, the body is not evaluated on call
+ *   (async () => { await 0; x; })(); // returns `true`, evaluated in a later job
  *
  *   class C {
  *       field = x; // returns `true`
@@ -127,15 +220,19 @@ function isClassStaticInitializerScope(scope) {
  *       }
  *   }
  * @param {Reference} reference A reference to check.
+ * @param {Object} visitorKeys The visitor keys to traverse child nodes with.
  * @returns {boolean} `true` if the reference is from a separate execution context.
  */
-function isFromSeparateExecutionContext(reference) {
+function isFromSeparateExecutionContext(reference, visitorKeys) {
 	const variable = reference.resolved;
 	let scope = reference.from;
 
 	// Scope#variableScope represents execution context
 	while (variable.scope.variableScope !== scope.variableScope) {
-		if (isClassStaticInitializerScope(scope.variableScope)) {
+		if (
+			isClassStaticInitializerScope(scope.variableScope) ||
+			isImmediatelyInvokedFunctionScope(scope.variableScope, visitorKeys)
+		) {
 			scope = scope.variableScope.upper;
 		} else {
 			return true;
@@ -162,10 +259,11 @@ function isFromSeparateExecutionContext(reference) {
  *     class C extends (class { static foo = C; }) {}
  *     class C { [C]; }
  * @param {Reference} reference A reference to check.
+ * @param {Object} visitorKeys The visitor keys to traverse child nodes with.
  * @returns {boolean} `true` if the reference is evaluated during the initialization.
  */
-function isEvaluatedDuringInitialization(reference) {
-	if (isFromSeparateExecutionContext(reference)) {
+function isEvaluatedDuringInitialization(reference, visitorKeys) {
+	if (isFromSeparateExecutionContext(reference, visitorKeys)) {
 		/*
 		 * Even if the reference appears in the initializer, it isn't evaluated during the initialization.
 		 * For example, `const x = () => x;` is valid.
@@ -373,7 +471,10 @@ module.exports = {
 				((!options.variables && definitionType === "Variable") ||
 					(!options.classes && definitionType === "ClassName")) &&
 				// don't skip checking the reference if it's in the same execution context, because of TDZ
-				isFromSeparateExecutionContext(reference)
+				isFromSeparateExecutionContext(
+					reference,
+					sourceCode.visitorKeys,
+				)
 			) {
 				return false;
 			}
@@ -429,7 +530,10 @@ module.exports = {
 				if (
 					reference.identifier.range[1] <
 						definitionIdentifier.range[1] ||
-					(isEvaluatedDuringInitialization(reference) &&
+					(isEvaluatedDuringInitialization(
+						reference,
+						sourceCode.visitorKeys,
+					) &&
 						reference.identifier.parent.type !== "TSTypeReference")
 				) {
 					context.report({

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -6,12 +6,6 @@
 "use strict";
 
 //------------------------------------------------------------------------------
-// Requirements
-//------------------------------------------------------------------------------
-
-const Traverser = require("../shared/traverser");
-
-//------------------------------------------------------------------------------
 // Types
 //------------------------------------------------------------------------------
 
@@ -25,8 +19,6 @@ const Traverser = require("../shared/traverser");
 const SENTINEL_TYPE =
 	/^(?:(?:Function|Class)(?:Declaration|Expression)|ArrowFunctionExpression|CatchClause|ImportDeclaration|ExportNamedDeclaration)$/u;
 const FOR_IN_OF_TYPE = /^For(?:In|Of)Statement$/u;
-const FUNCTION_TYPE =
-	/^(?:FunctionDeclaration|FunctionExpression|ArrowFunctionExpression)$/u;
 
 /**
  * Parses a given value as options.
@@ -102,67 +94,17 @@ function isClassStaticInitializerScope(scope) {
 }
 
 /**
- * Cache for `canSuspend()`. The result depends only on the function node,
- * so it's safe to reuse it for every reference in that function.
- * @type {WeakMap<ASTNode, boolean>}
- */
-const suspensionCache = new WeakMap();
-
-/**
- * Checks whether a given async function can suspend its own execution,
- * i.e. whether it contains an `await` that belongs to it.
- * `await` in a nested function belongs to that function, so it's ignored.
- * @param {ASTNode} node An async function node to check.
- * @param {Object} visitorKeys The visitor keys to traverse child nodes with.
- * @returns {boolean} `true` if the function can suspend its own execution.
- */
-function canSuspend(node, visitorKeys) {
-	if (suspensionCache.has(node)) {
-		return suspensionCache.get(node);
-	}
-
-	let found = false;
-
-	Traverser.traverse(node.body, {
-		visitorKeys,
-		enter(child) {
-			if (
-				child.type === "AwaitExpression" ||
-				(child.type === "ForOfStatement" && child.await) ||
-				/*
-				 * `await using` declarations await the disposal of the resource
-				 * when the enclosing scope is exited.
-				 */
-				(child.type === "VariableDeclaration" &&
-					child.kind === "await using")
-			) {
-				found = true;
-				this.break();
-			} else if (FUNCTION_TYPE.test(child.type)) {
-				this.skip();
-			}
-		},
-	});
-
-	suspensionCache.set(node, found);
-
-	return found;
-}
-
-/**
  * Checks whether a given scope is the scope of an immediately invoked function.
  * The body of an immediately invoked function is evaluated where the function appears,
  * so it belongs to the execution context that contains it.
  *
  * Generators are excluded because calling a generator function only creates an iterator,
- * and the body isn't evaluated until the iterator is advanced. Async functions that can
- * suspend are excluded as well, because everything that follows the first `await` is
- * evaluated in a later job.
+ * and the body isn't evaluated until the iterator is advanced. Async functions are excluded
+ * as well, because everything that follows the first `await` is evaluated in a later job.
  * @param {Scope} scope A scope to check.
- * @param {Object} visitorKeys The visitor keys to traverse child nodes with.
  * @returns {boolean} `true` if the scope is the scope of an immediately invoked function.
  */
-function isImmediatelyInvokedFunctionScope(scope, visitorKeys) {
+function isImmediatelyInvokedFunctionScope(scope) {
 	if (scope.type !== "function") {
 		return false;
 	}
@@ -174,11 +116,7 @@ function isImmediatelyInvokedFunctionScope(scope, visitorKeys) {
 		return false;
 	}
 
-	if (node.generator) {
-		return false;
-	}
-
-	return !node.async || !canSuspend(node, visitorKeys);
+	return !node.generator && !node.async;
 }
 
 /**
@@ -201,7 +139,7 @@ function isImmediatelyInvokedFunctionScope(scope, visitorKeys) {
  *   (() => x)(); // returns `false`
  *   (() => () => x)(); // returns `true`, the inner function is deferred
  *   (function* () { x; })(); // returns `true`, the body is not evaluated on call
- *   (async () => { await 0; x; })(); // returns `true`, evaluated in a later job
+ *   (async () => { x; })(); // returns `true`, the body may be evaluated in a later job
  *
  *   class C {
  *       field = x; // returns `true`
@@ -220,10 +158,9 @@ function isImmediatelyInvokedFunctionScope(scope, visitorKeys) {
  *       }
  *   }
  * @param {Reference} reference A reference to check.
- * @param {Object} visitorKeys The visitor keys to traverse child nodes with.
  * @returns {boolean} `true` if the reference is from a separate execution context.
  */
-function isFromSeparateExecutionContext(reference, visitorKeys) {
+function isFromSeparateExecutionContext(reference) {
 	const variable = reference.resolved;
 	let scope = reference.from;
 
@@ -231,7 +168,7 @@ function isFromSeparateExecutionContext(reference, visitorKeys) {
 	while (variable.scope.variableScope !== scope.variableScope) {
 		if (
 			isClassStaticInitializerScope(scope.variableScope) ||
-			isImmediatelyInvokedFunctionScope(scope.variableScope, visitorKeys)
+			isImmediatelyInvokedFunctionScope(scope.variableScope)
 		) {
 			scope = scope.variableScope.upper;
 		} else {
@@ -259,11 +196,10 @@ function isFromSeparateExecutionContext(reference, visitorKeys) {
  *     class C extends (class { static foo = C; }) {}
  *     class C { [C]; }
  * @param {Reference} reference A reference to check.
- * @param {Object} visitorKeys The visitor keys to traverse child nodes with.
  * @returns {boolean} `true` if the reference is evaluated during the initialization.
  */
-function isEvaluatedDuringInitialization(reference, visitorKeys) {
-	if (isFromSeparateExecutionContext(reference, visitorKeys)) {
+function isEvaluatedDuringInitialization(reference) {
+	if (isFromSeparateExecutionContext(reference)) {
 		/*
 		 * Even if the reference appears in the initializer, it isn't evaluated during the initialization.
 		 * For example, `const x = () => x;` is valid.
@@ -471,10 +407,7 @@ module.exports = {
 				((!options.variables && definitionType === "Variable") ||
 					(!options.classes && definitionType === "ClassName")) &&
 				// don't skip checking the reference if it's in the same execution context, because of TDZ
-				isFromSeparateExecutionContext(
-					reference,
-					sourceCode.visitorKeys,
-				)
+				isFromSeparateExecutionContext(reference)
 			) {
 				return false;
 			}
@@ -530,10 +463,7 @@ module.exports = {
 				if (
 					reference.identifier.range[1] <
 						definitionIdentifier.range[1] ||
-					(isEvaluatedDuringInitialization(
-						reference,
-						sourceCode.visitorKeys,
-					) &&
+					(isEvaluatedDuringInitialization(reference) &&
 						reference.identifier.parent.type !== "TSTypeReference")
 				) {
 					context.report({

--- a/tests/lib/rules/no-use-before-define.js
+++ b/tests/lib/rules/no-use-before-define.js
@@ -495,22 +495,24 @@ ruleTester.run("no-use-before-define", rule, {
 			languageOptions: { ecmaVersion: 2022 },
 		},
 
-		// async functions that suspend: the reference is evaluated after the module finished
+		/*
+		 * async functions are not immediately invoked: the body can suspend at any
+		 * `await`, and everything that follows it is evaluated in a later job.
+		 */
+		{
+			code: "(async () => { a; })(); let a;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 2022 },
+		},
 		{
 			code: "(async () => { await 0; a; })(); let a;",
 			options: [{ variables: false }],
 			languageOptions: { ecmaVersion: 2022 },
 		},
 		{
-			code: "(async () => { for await (const x of []) {} a; })(); let a;",
+			code: "await (async () => { a; })(); let a;",
 			options: [{ variables: false }],
-			languageOptions: { ecmaVersion: 2022 },
-		},
-		{
-			// `await using` suspends when the resource is disposed at scope exit
-			code: "(async () => { { await using x = f(); } a; })(); let a;",
-			options: [{ variables: false }],
-			languageOptions: { ecmaVersion: "latest" },
+			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
 		},
 
 		// `.call()`/`.apply()` are not syntactically IIFEs
@@ -527,8 +529,8 @@ ruleTester.run("no-use-before-define", rule, {
 			languageOptions: { ecmaVersion: 2022 },
 		},
 		{
-			// `a` is read in a later job, when it's already initialized
-			code: "const a = (async () => { await 0; a; })();",
+			// the async body is not evaluated during the initialization
+			code: "const a = (async () => { a; })();",
 			languageOptions: { ecmaVersion: 2022 },
 		},
 	],
@@ -1861,56 +1863,9 @@ ruleTester.run("no-use-before-define", rule, {
 			],
 		},
 
-		// an async IIFE that never suspends runs entirely in the enclosing context
-		{
-			code: "(async () => { a; })(); let a;",
-			options: [{ variables: false }],
-			languageOptions: { ecmaVersion: 2022 },
-			errors: [
-				{
-					messageId: "usedBeforeDefined",
-					data: { name: "a" },
-				},
-			],
-		},
-		{
-			code: "await (async () => { a; })(); let a;",
-			options: [{ variables: false }],
-			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
-			errors: [
-				{
-					messageId: "usedBeforeDefined",
-					data: { name: "a" },
-				},
-			],
-		},
-
-		// an `await` inside a nested function does not suspend the IIFE itself
-		{
-			code: "(async () => { const f = async () => { await 0; }; a; })(); let a;",
-			options: [{ variables: false }],
-			languageOptions: { ecmaVersion: 2022 },
-			errors: [
-				{
-					messageId: "usedBeforeDefined",
-					data: { name: "a" },
-				},
-			],
-		},
-
 		// IIFEs in an initializer are evaluated during the initialization
 		{
 			code: "const a = (() => a)();",
-			languageOptions: { ecmaVersion: 2022 },
-			errors: [
-				{
-					messageId: "usedBeforeDefined",
-					data: { name: "a" },
-				},
-			],
-		},
-		{
-			code: "const a = (async () => { a; })();",
 			languageOptions: { ecmaVersion: 2022 },
 			errors: [
 				{

--- a/tests/lib/rules/no-use-before-define.js
+++ b/tests/lib/rules/no-use-before-define.js
@@ -453,6 +453,84 @@ ruleTester.run("no-use-before-define", rule, {
 				parserOptions: { ecmaFeatures: { jsx: true } },
 			},
 		},
+
+		// IIFEs: deferred code inside an IIFE is still a separate execution context
+		{
+			code: "(() => () => a)(); let a;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 2022 },
+		},
+		{
+			code: "(() => { function f() { a; } })(); let a;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 2022 },
+		},
+		{
+			code: "(() => { class C { m() { a; } } })(); let a;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 2022 },
+		},
+
+		// not immediately invoked: the function expression is not the callee
+		{
+			code: "const f = () => { a; }; let a;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 2022 },
+		},
+		{
+			code: "foo(() => { a; }); let a;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 2022 },
+		},
+
+		// generators are not immediately invoked: the body is suspended before the first statement
+		{
+			code: "(function* () { a; })(); let a;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 2022 },
+		},
+		{
+			code: "(async function* () { a; })(); let a;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 2022 },
+		},
+
+		// async functions that suspend: the reference is evaluated after the module finished
+		{
+			code: "(async () => { await 0; a; })(); let a;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 2022 },
+		},
+		{
+			code: "(async () => { for await (const x of []) {} a; })(); let a;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 2022 },
+		},
+		{
+			// `await using` suspends when the resource is disposed at scope exit
+			code: "(async () => { { await using x = f(); } a; })(); let a;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: "latest" },
+		},
+
+		// `.call()`/`.apply()` are not syntactically IIFEs
+		{
+			code: "(function () { a; }).call(null); let a;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 2022 },
+		},
+
+		// IIFEs in an initializer, with the default options
+		{
+			// the generator body isn't evaluated, so `a` is already initialized
+			code: "const a = (function* () { a; })();",
+			languageOptions: { ecmaVersion: 2022 },
+		},
+		{
+			// `a` is read in a later job, when it's already initialized
+			code: "const a = (async () => { await 0; a; })();",
+			languageOptions: { ecmaVersion: 2022 },
+		},
 	],
 	invalid: [
 		{
@@ -1711,6 +1789,133 @@ ruleTester.run("no-use-before-define", rule, {
 					column: 2,
 					endLine: 1,
 					endColumn: 5,
+				},
+			],
+		},
+
+		// IIFE bodies run in the enclosing execution context
+		{
+			code: "(() => { a; })(); let a;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 2022 },
+			errors: [
+				{
+					messageId: "usedBeforeDefined",
+					data: { name: "a" },
+				},
+			],
+		},
+		{
+			code: "(function () { a; })(); let a;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 2022 },
+			errors: [
+				{
+					messageId: "usedBeforeDefined",
+					data: { name: "a" },
+				},
+			],
+		},
+		{
+			code: "(function f() { a; })(); let a;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 2022 },
+			errors: [
+				{
+					messageId: "usedBeforeDefined",
+					data: { name: "a" },
+				},
+			],
+		},
+		{
+			code: "(() => { (() => { a; })(); })(); let a;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 2022 },
+			errors: [
+				{
+					messageId: "usedBeforeDefined",
+					data: { name: "a" },
+				},
+			],
+		},
+		{
+			code: "(() => { new C(); })(); class C {}",
+			options: [{ classes: false }],
+			languageOptions: { ecmaVersion: 2022 },
+			errors: [
+				{
+					messageId: "usedBeforeDefined",
+					data: { name: "C" },
+				},
+			],
+		},
+		{
+			code: "(() => { a; })?.(); let a;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 2022 },
+			errors: [
+				{
+					messageId: "usedBeforeDefined",
+					data: { name: "a" },
+				},
+			],
+		},
+
+		// an async IIFE that never suspends runs entirely in the enclosing context
+		{
+			code: "(async () => { a; })(); let a;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 2022 },
+			errors: [
+				{
+					messageId: "usedBeforeDefined",
+					data: { name: "a" },
+				},
+			],
+		},
+		{
+			code: "await (async () => { a; })(); let a;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+			errors: [
+				{
+					messageId: "usedBeforeDefined",
+					data: { name: "a" },
+				},
+			],
+		},
+
+		// an `await` inside a nested function does not suspend the IIFE itself
+		{
+			code: "(async () => { const f = async () => { await 0; }; a; })(); let a;",
+			options: [{ variables: false }],
+			languageOptions: { ecmaVersion: 2022 },
+			errors: [
+				{
+					messageId: "usedBeforeDefined",
+					data: { name: "a" },
+				},
+			],
+		},
+
+		// IIFEs in an initializer are evaluated during the initialization
+		{
+			code: "const a = (() => a)();",
+			languageOptions: { ecmaVersion: 2022 },
+			errors: [
+				{
+					messageId: "usedBeforeDefined",
+					data: { name: "a" },
+				},
+			],
+		},
+		{
+			code: "const a = (async () => { a; })();",
+			languageOptions: { ecmaVersion: 2022 },
+			errors: [
+				{
+					messageId: "usedBeforeDefined",
+					data: { name: "a" },
 				},
 			],
 		},


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**

`no-use-before-define`

**What change do you want to make?**

Generate more warnings.

**How will the change be implemented?**

A new default behavior.

**Please provide some example code that this change will affect:**

```js
/*eslint no-use-before-define: ["error", { "variables": false }]*/

(() => {
    console.log(a);
})();

const a = 5;
```

**What does the rule currently do for this code?**

Nothing is reported, even though the IIFE body runs before `a` is initialized, so this throws `ReferenceError: Cannot access 'a' before initialization` at runtime.

**What will the rule do after it's changed?**

The reference to `a` is reported, consistent with how the rule already treats class static initializers, which are also evaluated immediately.

---

Fixes #21224.

#### What changes did you make?

`isFromSeparateExecutionContext()` decides whether a reference may be exempt under `variables: false` / `classes: false`. It already walks out of class static initializer scopes, because those are evaluated during the class definition evaluation and therefore belong to the parent execution context. An immediately invoked function is evaluated where it appears for the same reason, but wasn't handled.

**Not every immediately invoked function actually runs on call**, so two kinds are excluded:

* **Generators** — calling a generator function only creates an iterator; the body isn't evaluated until the iterator is advanced.
* **Async functions that can suspend** — everything after the first `await` is evaluated in a later job. A function counts as able to suspend if it contains an `await` **of its own** (`await`, `for await`, or an `await using` declaration, whose disposal is awaited at scope exit). An `await` inside a nested function belongs to that function and is ignored.

This matters, and not only for the opt-out options — see the measurements below.

Modified files:

* `lib/rules/no-use-before-define.js` — added `isImmediatelyInvokedFunctionScope()` and `canSuspend()`, and extended the scope walk in `isFromSeparateExecutionContext()`.
* `tests/lib/rules/no-use-before-define.js` — 11 invalid and 13 valid cases.
* `docs/src/rules/no-use-before-define.md` — examples in the `classes` and `variables` sections.

Because the walk stops at the first scope that isn't immediately invoked, deferred functions are unaffected and nested cases fall out of the existing loop:

```js
/*eslint no-use-before-define: ["error", { "variables": false }]*/

const f = () => { console.log(a); };  // still not reported
const a = 5;
f();
```

```js
/*eslint no-use-before-define: ["error", { "variables": false }]*/

(() => () => b)();                    // still not reported, the inner function is deferred
const b = 5;
```

```js
/*eslint no-use-before-define: ["error", { "variables": false }]*/

(() => { (() => { console.log(c); })(); })();  // reported, walks out twice
const c = 5;
```

#### Why generators and async functions are excluded

This addresses the point @fasttime raised in the issue about execution that can be delayed. I verified each shape against the runtime rather than reasoning about it only from the AST (Node v22.22.3, capturing rejected promises as well as sync throws, and distinguishing a TDZ `ReferenceError` from an unrelated `TypeError`):

| Code | Runtime | Reported |
| :--- | :--- | :--- |
| `(() => { a; })(); let a;` | TDZ `ReferenceError` | yes |
| `(() => { a; })?.(); let a;` | TDZ `ReferenceError` | yes |
| `(async () => { a; })(); let a;` | TDZ `ReferenceError` | yes |
| `(async () => { const f = async () => { await 0; }; a; })(); let a;` | TDZ `ReferenceError` | yes |
| `(function* () { a; })(); let a;` | no error | no |
| `(async function* () { a; })(); let a;` | no error | no |
| `(async () => { await 0; a; })(); let a;` | no error | no |
| `(async () => { for await (const x of []) {} a; })(); let a;` | no error | no |
| `(() => () => a)(); let a;` | no error | no |

Worth noting for the async case: the body of an async function runs synchronously up to its first `await`, so `(async () => { console.log(a); })()` really is a TDZ error — it just surfaces as a rejected promise rather than a synchronous throw.

Cases where immediacy can't be established from the call site alone are deliberately left unreported, so the approximations only ever produce false negatives:

```js
(function* () { console.log(a); })().next();   // throws, not reported
(function () { console.log(a); }).call(null);  // throws, not reported
new (function () { console.log(a); })();       // throws, not reported
const a = 5;
```

#### This also changes behavior under the default options

An IIFE in a variable's own initializer reaches `isFromSeparateExecutionContext()` through `isEvaluatedDuringInitialization()` rather than through the options gate, so it changes regardless of the options. Measured before and after, with the default options:

| Code | Runtime | Before | After |
| :--- | :--- | :--- | :--- |
| `const a = (() => a)();` | TDZ `ReferenceError` | not reported | **reported** |
| `const a = (async () => { a; })();` | TDZ `ReferenceError` | not reported | **reported** |
| `const a = (function* () { a; })();` | no error | not reported | not reported |
| `const a = (async () => { await 0; a; })();` | no error | not reported | not reported |
| `const a = foo(() => a);` | no error | not reported | not reported |
| `const a = () => a;` | no error | not reported | not reported |
| `const a = { get self() { return a; } };` | no error | not reported | not reported |

This is the provably-immediate subset of #20014; the rest of that issue (callbacks whose immediacy can't be proven) and the circular-getter pattern are unaffected.

**This is also where excluding generators and async functions stops being optional.** Without those exclusions, the last two "no error" rows above are reported — two false positives under the *default* options, affecting every user of the rule rather than only those who opt out via `variables: false`. Tests pin all of these.

#### Performance

`canSuspend()` only runs for async, non-generator IIFEs and stops at the first `await` it finds, but the result is memoized per function node — a reference-heavy module wrapped in an `await`-less async IIFE (3,000 references) went from 1.25s to 0.20s with the cache.

#### Verification

| Check | Result |
| :--- | :--- |
| `npx mocha tests/lib/rules/no-use-before-define.js` | 378 passing (was 354) |
| the same, with the rule change reverted | 11 failing — the 11 new invalid cases |
| the same, with the generator/async exclusions removed | 7 failing — the cases pinning those exclusions |
| `npx mocha "tests/lib/rules/**/*.js"` | 34,780 passing |
| `node bin/eslint.js lib/rules/no-use-before-define.js tests/lib/rules/no-use-before-define.js` | clean |
| `node Makefile.js checkRuleExamples` | passes |

#### Is there anything you'd like reviewers to focus on?

1. **`.call()` / `.apply()` are not included**, since they aren't syntactically IIFEs. They're pinned as valid tests to make the current scope explicit; happy to extend `isImmediatelyInvokedFunctionScope()` if the team wants them covered.
2. **`NewExpression`** (`new (function () { ... })()`) is immediate too, but is likewise out of scope here. Easy to add if wanted.
3. **The async refinement.** Treating an async IIFE as immediate only when it has no `await` of its own is the narrowest sound reading I found. Excluding async functions entirely would be simpler, but would miss `await (async () => { ... })()` from the issue; including them unconditionally introduces the false positives shown above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the `no-use-before-define` rule to correctly handle references inside immediately invoked synchronous functions.
  - Preserved distinct behavior for deferred, asynchronous, generator, optional, and indirect function calls.
  - Maintained existing handling for class static initializers.

- **Documentation**
  - Expanded rule examples to clarify use-before-definition behavior across function scopes.

- **Tests**
  - Added comprehensive coverage for immediate, deferred, asynchronous, generator, and indirect invocation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->