### PR TITLE
fix: avoid false positives in consistent-return for shadowed undefined

### DIFF
--- a/lib/rules/consistent-return.js
+++ b/lib/rules/consistent-return.js
@@ -30,6 +30,19 @@ function isClassConstructor(node) {
 	);
 }
 
+/**
+ * Checks whether a given node is a reference to the global `undefined` identifier.
+ * @param {ASTNode} node A node to check.
+ * @param {SourceCode} sourceCode The source code object.
+ * @returns {boolean} `true` if the node is a global `undefined` identifier.
+ */
+function isUndefinedIdentifier(node, sourceCode) {
+	return (
+		astUtils.isSpecificId(node, "undefined") &&
+		sourceCode.isGlobalReference(node)
+	);
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -168,7 +181,7 @@ module.exports = {
 
 				if (treatUndefinedAsUnspecified && hasReturnValue) {
 					hasReturnValue =
-						!astUtils.isSpecificId(argument, "undefined") &&
+						!isUndefinedIdentifier(argument, context.sourceCode) &&
 						argument.operator !== "void";
 				}
 

--- a/tests/lib/rules/consistent-return.js
+++ b/tests/lib/rules/consistent-return.js
@@ -61,6 +61,12 @@ ruleTester.run("consistent-return", rule, {
 			code: "function foo() { if (true) return void 0; else return undefined; }",
 			options: [{ treatUndefinedAsUnspecified: true }],
 		},
+
+		// Shadowed `undefined` should not be treated as unspecified.
+		{
+			code: "function foo(undefined) { if (true) return 1; else return undefined; }",
+			options: [{ treatUndefinedAsUnspecified: true }],
+		},
 		{
 			code: "var x = () => {  return {}; };",
 			languageOptions: { ecmaVersion: 6 },
@@ -218,6 +224,20 @@ ruleTester.run("consistent-return", rule, {
 					column: 43,
 					endLine: 1,
 					endColumn: 55,
+				},
+			],
+		},
+		{
+			code: "function foo(undefined) { if (true) return; else return undefined; }",
+			options: [{ treatUndefinedAsUnspecified: true }],
+			errors: [
+				{
+					messageId: "unexpectedReturnValue",
+					data: { name: "Function 'foo'" },
+					line: 1,
+					column: 50,
+					endLine: 1,
+					endColumn: 67,
 				},
 			],
 		},


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix
[ ] New rule
[ ] Changes an existing rule
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What did you do? Please include the actual source code causing the issue.**

```js
/*eslint consistent-return: ["error", { treatUndefinedAsUnspecified: true }]*/

function foo(undefined) {
    if (true) {
        return 1;
    }
    return undefined; // `undefined` here is the shadowed parameter, not the global.
}
```

**What did you expect to happen?**

No error, since both branches return a value (the second branch returns whatever was passed as the `undefined` parameter, which is not necessarily `undefined`).

**What actually happened? Please include the actual, raw output from ESLint.**

```
1:1  error  Function 'foo' expected a return value  consistent-return
```

The `treatUndefinedAsUnspecified` option treats `return undefined;` the same as a bare `return;`, but the rule checked for an identifier named `undefined` by name only, without verifying it's actually a reference to the global `undefined` rather than a shadowed local binding (e.g. a function parameter named `undefined`, a pattern sometimes used before `let`/`const` existed to guarantee `undefined` couldn't be reassigned).

#### What changes did you make? (Give an overview)

Added an `isUndefinedIdentifier()` helper that uses `sourceCode.isGlobalReference()` to confirm the `undefined` identifier is actually a reference to the global before treating it as an unspecified return value. This follows the same fix pattern already applied to other rules for shadowed globals (e.g. `use-isnan`, `radix`, `prefer-numeric-literals`, `no-implied-eval`), which all use `sourceCode.isGlobalReference()` for this exact purpose.

Also added two test cases: one confirming the false positive is gone, and one confirming a real inconsistency (mixing a bare `return;` with a shadowed `return undefined;`) is still correctly reported, so shadowing doesn't introduce a false negative either.

#### Is there anything you'd like reviewers to focus on?

The fix mirrors the exact approach used in the already-merged fixes for `use-isnan` (#20958) and `prefer-numeric-literals`, so the pattern should be familiar. No issue was filed beforehand since this is a small, self-contained bug fix per the contributing guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistent-return checks so locally defined or shadowed `undefined` values are correctly treated as explicit return values.
  - Prevented false warnings when functions use a parameter or local variable named `undefined`.

- **Tests**
  - Added coverage for shadowed `undefined` scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->