### PR TITLE
chore: Upgrade Stylelint to the latest version in docs

### DIFF
--- a/docs/.stylelintrc.json
+++ b/docs/.stylelintrc.json
@@ -3,6 +3,7 @@
   "rules": {
     "alpha-value-notation": "number",
     "at-rule-empty-line-before": null,
+    "color-function-alias-notation": "with-alpha",
     "color-function-notation": "legacy",
     "custom-property-empty-line-before": null,
     "custom-property-pattern": null,
@@ -13,9 +14,11 @@
       }
     ],
     "declaration-block-no-redundant-longhand-properties": null,
+    "declaration-property-value-keyword-no-deprecated": null,
     "hue-degree-notation": "number",
     "no-descending-specificity": null,
     "media-feature-range-notation": "prefix",
+    "property-no-deprecated": null,
     "selector-class-pattern": null,
     "value-keyword-case": null
   },

--- a/docs/.stylelintrc.json
+++ b/docs/.stylelintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["stylelint-config-standard-scss", "stylelint-config-prettier"],
+  "extends": ["stylelint-config-standard-scss"],
   "rules": {
     "alpha-value-notation": "number",
     "at-rule-empty-line-before": null,
@@ -15,8 +15,7 @@
     "declaration-block-no-redundant-longhand-properties": null,
     "hue-degree-notation": "number",
     "no-descending-specificity": null,
-    "number-leading-zero": null,
-    "number-no-trailing-zeros": null,
+    "media-feature-range-notation": "prefix",
     "selector-class-pattern": null,
     "value-keyword-case": null
   },
@@ -25,8 +24,7 @@
       "files": ["**/*.html"],
       "extends": [
         "stylelint-config-html/html",
-        "stylelint-config-standard",
-        "stylelint-config-prettier"
+        "stylelint-config-standard"
       ]
     },
     {

--- a/docs/.stylelintrc.json
+++ b/docs/.stylelintrc.json
@@ -25,10 +25,7 @@
   "overrides": [
     {
       "files": ["**/*.html"],
-      "extends": [
-        "stylelint-config-html/html",
-        "stylelint-config-standard"
-      ]
+      "extends": ["stylelint-config-html/html", "stylelint-config-standard"]
     },
     {
       "files": ["**/*.scss"],

--- a/docs/package.json
+++ b/docs/package.json
@@ -46,13 +46,13 @@
         "markdown-it-container": "^4.0.0",
         "npm-run-all2": "^8.0.0",
         "postcss-cli": "^10.0.0",
-        "postcss-html": "^1.5.0",
+        "postcss-html": "^2.0.0",
         "prismjs": "^1.29.0",
         "sass": "^1.85.1",
-        "stylelint": "^15.11.0",
-        "stylelint-config-html": "^1.1.0",
-        "stylelint-config-standard": "^34.0.0",
-        "stylelint-config-standard-scss": "^11.0.0",
+        "stylelint": "^16.26.1",
+        "stylelint-config-html": "^2.0.0",
+        "stylelint-config-standard": "^39.0.0",
+        "stylelint-config-standard-scss": "^16.0.0",
         "tap-spot": "^1.1.2"
     },
     "engines": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -49,10 +49,10 @@
         "postcss-html": "^2.0.0",
         "prismjs": "^1.29.0",
         "sass": "^1.85.1",
-        "stylelint": "^16.26.1",
+        "stylelint": "^17.14.1",
         "stylelint-config-html": "^2.0.0",
-        "stylelint-config-standard": "^39.0.0",
-        "stylelint-config-standard-scss": "^16.0.0",
+        "stylelint-config-standard": "^40.0.0",
+        "stylelint-config-standard-scss": "^17.0.0",
         "tap-spot": "^1.1.2"
     },
     "engines": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -49,11 +49,10 @@
         "postcss-html": "^1.5.0",
         "prismjs": "^1.29.0",
         "sass": "^1.85.1",
-        "stylelint": "^14.13.0",
+        "stylelint": "^15.11.0",
         "stylelint-config-html": "^1.1.0",
-        "stylelint-config-prettier": "^9.0.5",
-        "stylelint-config-standard": "^29.0.0",
-        "stylelint-config-standard-scss": "^5.0.0",
+        "stylelint-config-standard": "^34.0.0",
+        "stylelint-config-standard-scss": "^11.0.0",
         "tap-spot": "^1.1.2"
     },
     "engines": {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Upgraded Stylelint used by `docs` from `14.13.0` to `17.14.1`, along with the related configuration packages required for compatibility.

This work addresses [#21230](https://github.com/eslint/eslint/issues/21230) and also follows the existing Stylelint upgrade discussion in [#17733](https://github.com/eslint/eslint/issues/17733).

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Updated the Stylelint configuration to be compatible with Stylelint 17 while preserving the existing styling conventions used by the ESLint documentation.

- Removed `stylelint-config-prettier`, which is no longer needed with Stylelint 15+.
- Removed rules deprecated/removed in Stylelint 15:
  - `number-leading-zero`
  - `number-no-trailing-zeros`
- Added `media-feature-range-notation: "prefix"` to preserve the existing media feature range notation used in the documentation.
- Added `color-function-alias-notation: "with-alpha"` to match the color function notation used in the documentation.
- Disabled `property-no-deprecated` and `declaration-property-value-keyword-no-deprecated` because fixing the existing occurrences would require changing multiple existing style properties and values, which is outside the scope of this dependency upgrade.

The migration was performed incrementally through Stylelint 15 and 16 before upgrading to 17.14.1, addressing configuration and rule changes introduced by each major version.

The existing documentation linting and build commands were run to verify that the migration does not require changes to ESLint source code or ESLint rule behavior.

#### Is there anything you'd like reviewers to focus on?

Please focus on whether the updated Stylelint configuration preserves the existing styling conventions used by the ESLint documentation.

In particular:

- Whether `media-feature-range-notation: "prefix"` correctly preserves the existing media feature range notation.
- Whether `color-function-alias-notation: "with-alpha"` matches the existing color function usage.
- Whether disabling `property-no-deprecated` and `declaration-property-value-keyword-no-deprecated` is appropriate for this dependency upgrade instead of making unrelated changes to existing documentation styles.
- Whether the selected versions of the Stylelint configuration packages are appropriate for Stylelint 17.14.1.

The migration was verified with:

```sh
npm run lint:scss
npm run build:postcss
```


Disclosure: I'm a participant of [open source contribution program OSSCA](https://github.com/eslint-ossca)
<!-- markdownlint-disable-file MD004 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated documentation linting and build tooling dependencies.
  * Improved stylesheet validation for modern color syntax, media query range notation, and deprecated declarations.
  * Removed obsolete formatting overrides and refreshed related configuration for more consistent documentation builds.
  * Updated validation rules to align with current styling standards and improve compatibility with modern CSS practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->