### PR TITLE
fix: use format strings in debug calls

### DIFF
--- a/docs/src/use/configure/debug.md
+++ b/docs/src/use/configure/debug.md
@@ -25,7 +25,7 @@ ESLint creates a configuration for each file that is linted based on your config
 This outputs all of ESLint's debugging information onto the console. You should copy this output to a file and then search for `eslint.config.js` to see which file is loaded. Here's some example output:
 
 ```text
-eslint:eslint Using file patterns: bin/eslint.js +0ms
+eslint:eslint Using file patterns: [ 'bin/eslint.js' ] +0ms
 eslint:eslint Searching for eslint.config.js +0ms
 eslint:eslint Loading config from C:\Users\nzakas\projects\eslint\eslint\eslint.config.js +5ms
 eslint:eslint Config file URL is file:///C:/Users/nzakas/projects/eslint/eslint/eslint.config.js +0ms

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -111,6 +111,7 @@ module.exports = defineConfig([
 		},
 		rules: {
 			"internal-rules/multiline-comment-style": "error",
+			"internal-rules/no-debug-template-literals": "error",
 		},
 	},
 	{

--- a/lib/cli-engine/lint-result-cache.js
+++ b/lib/cli-engine/lint-result-cache.js
@@ -83,11 +83,11 @@ class LintResultCache {
 			invalidCacheStrategyErrorMessage,
 		);
 
-		debug(`Caching results to ${cacheFileLocation}`);
+		debug("Caching results to %s", cacheFileLocation);
 
 		const useChecksum = cacheStrategy === "content";
 
-		debug(`Using "${cacheStrategy}" strategy to detect changes`);
+		debug('Using "%s" strategy to detect changes', cacheStrategy);
 
 		this.fileEntryCache = fileEntryCache.create(
 			cacheFileLocation,
@@ -124,7 +124,8 @@ class LintResultCache {
 		// If source is present but null, need to reread the file from the filesystem.
 		if (results.source === null) {
 			debug(
-				`Rereading cached result source from filesystem: ${filePath}`,
+				"Rereading cached result source from filesystem: %s",
+				filePath,
 			);
 			results.source = fs.readFileSync(filePath, "utf-8");
 		}
@@ -152,7 +153,7 @@ class LintResultCache {
 		const fileDescriptor = this.fileEntryCache.getFileDescriptor(filePath);
 
 		if (fileDescriptor.notFound) {
-			debug(`File not found on the file system: ${filePath}`);
+			debug("File not found on the file system: %s", filePath);
 			return null;
 		}
 
@@ -162,7 +163,7 @@ class LintResultCache {
 			fileDescriptor.meta.hashOfConfig !== hashOfConfig;
 
 		if (changed) {
-			debug(`Cache entry not found or no longer valid: ${filePath}`);
+			debug("Cache entry not found or no longer valid: %s", filePath);
 			return null;
 		}
 
@@ -188,7 +189,7 @@ class LintResultCache {
 		const fileDescriptor = this.fileEntryCache.getFileDescriptor(filePath);
 
 		if (fileDescriptor && !fileDescriptor.notFound) {
-			debug(`Updating cached result: ${filePath}`);
+			debug("Updating cached result: %s", filePath);
 
 			// Serialize the result, except that we want to remove the file source if present.
 			const resultToSerialize = Object.assign({}, result);
@@ -212,7 +213,7 @@ class LintResultCache {
 	 * @returns {void}
 	 */
 	reconcile() {
-		debug(`Persisting cached results: ${this.cacheFileLocation}`);
+		debug("Persisting cached results: %s", this.cacheFileLocation);
 		this.fileEntryCache.reconcile();
 	}
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -284,7 +284,7 @@ const cli = {
 			return 0;
 		}
 
-		debug(`Running on ${useStdin ? "text" : "files"}`);
+		debug("Running on %s", useStdin ? "text" : "files");
 
 		if (options.fix && options.fixDryRun) {
 			log.error(
@@ -463,7 +463,7 @@ const cli = {
 		 * Neither option was provided, `options.color` is omitted, so `undefined`.
 		 */
 		if (options.color !== void 0) {
-			debug(`Color setting for output: ${options.color}`);
+			debug("Color setting for output: %s", options.color);
 			resultsMeta.color = options.color;
 		}
 
@@ -502,7 +502,16 @@ const cli = {
 					log.error(
 						"There are suppressions left that do not occur anymore. To resolve this, re-run the command with `--prune-suppressions` to remove unused suppressions. To ignore unused suppressions, use `--pass-on-unpruned-suppressions`.",
 					);
-					debug(JSON.stringify(unusedSuppressions, null, 2));
+
+					/* c8 ignore start */
+					if (debug.enabled) {
+						// Avoid interpreting the JSON output as a format string.
+						debug(
+							"%s",
+							JSON.stringify(unusedSuppressions, null, 2),
+						);
+					}
+					/* c8 ignore end */
 
 					return 2;
 				}

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -502,16 +502,7 @@ const cli = {
 					log.error(
 						"There are suppressions left that do not occur anymore. To resolve this, re-run the command with `--prune-suppressions` to remove unused suppressions. To ignore unused suppressions, use `--pass-on-unpruned-suppressions`.",
 					);
-
-					/* c8 ignore start */
-					if (debug.enabled) {
-						// Avoid interpreting the JSON output as a format string.
-						debug(
-							"%s",
-							JSON.stringify(unusedSuppressions, null, 2),
-						);
-					}
-					/* c8 ignore end */
+					debug("%O", unusedSuppressions);
 
 					return 2;
 				}

--- a/lib/config/config-loader.js
+++ b/lib/config/config-loader.js
@@ -196,11 +196,11 @@ async function dynamicImportConfig(filePath, fileURL, mtime) {
  * @returns {Promise<any>} The config loaded from the config file.
  */
 async function loadConfigFile(filePath, hasUnstableNativeNodeJsTSConfigFlag) {
-	debug(`Loading config from ${filePath}`);
+	debug("Loading config from %s", filePath);
 
 	const fileURL = pathToFileURL(filePath);
 
-	debug(`Config file URL is ${fileURL}`);
+	debug("Config file URL is %s", fileURL);
 
 	const mtime = (await fs.stat(filePath)).mtime.getTime();
 
@@ -406,7 +406,7 @@ class ConfigLoader {
 	async loadConfigArrayForFile(filePath) {
 		assertValidFilePath(filePath);
 
-		debug(`Calculating config for file ${filePath}`);
+		debug("Calculating config for file %s", filePath);
 
 		const configFilePath = await this.findConfigFileForPath(filePath);
 
@@ -425,7 +425,7 @@ class ConfigLoader {
 	async loadConfigArrayForDirectory(dirPath) {
 		assertValidFilePath(dirPath);
 
-		debug(`Calculating config for directory ${dirPath}`);
+		debug("Calculating config for directory %s", dirPath);
 
 		const absoluteDirPath = path.resolve(
 			this.#options.cwd,
@@ -434,7 +434,11 @@ class ConfigLoader {
 		const { configFilePath, basePath } =
 			await this.#locateConfigFileToUse(absoluteDirPath);
 
-		debug(`Using config file ${configFilePath} and base path ${basePath}`);
+		debug(
+			"Using config file %s and base path %s",
+			configFilePath,
+			basePath,
+		);
 		return this.#calculateConfigArray(configFilePath, basePath);
 	}
 
@@ -452,7 +456,7 @@ class ConfigLoader {
 	getCachedConfigArrayForFile(filePath) {
 		assertValidFilePath(filePath);
 
-		debug(`Looking up cached config for ${filePath}`);
+		debug("Looking up cached config for %s", filePath);
 
 		return this.getCachedConfigArrayForPath(path.dirname(filePath));
 	}
@@ -471,7 +475,7 @@ class ConfigLoader {
 	getCachedConfigArrayForPath(fileOrDirPath) {
 		assertValidFilePath(fileOrDirPath);
 
-		debug(`Looking up cached config for ${fileOrDirPath}`);
+		debug("Looking up cached config for %s", fileOrDirPath);
 
 		const absoluteDirPath = path.resolve(this.#options.cwd, fileOrDirPath);
 
@@ -533,7 +537,7 @@ class ConfigLoader {
 		let basePath = cwd;
 
 		if (typeof useConfigFile === "string") {
-			debug(`Override config file path is ${useConfigFile}`);
+			debug("Override config file path is %s", useConfigFile);
 			configFilePath = path.resolve(cwd, useConfigFile);
 			basePath = cwd;
 		} else if (useConfigFile !== false) {
@@ -574,7 +578,9 @@ class ConfigLoader {
 		} = options;
 
 		debug(
-			`Calculating config array from config file ${configFilePath} and base path ${basePath}`,
+			"Calculating config array from config file %s and base path %s",
+			configFilePath,
+			basePath,
 		);
 
 		const configs = new FlatConfigArray(baseConfig || [], {
@@ -584,7 +590,7 @@ class ConfigLoader {
 
 		// load config file
 		if (configFilePath) {
-			debug(`Loading config file ${configFilePath}`);
+			debug("Loading config file %s", configFilePath);
 			const fileConfig = await loadConfigFile(
 				configFilePath,
 				hasUnstableNativeNodeJsTSConfigFlag,
@@ -602,14 +608,17 @@ class ConfigLoader {
 			let emptyConfig = typeof fileConfig === "undefined";
 
 			debug(
-				`Config file ${configFilePath} is ${emptyConfig ? "empty" : "not empty"}`,
+				"Config file %s is %s",
+				configFilePath,
+				emptyConfig ? "empty" : "not empty",
 			);
 
 			if (!emptyConfig) {
 				if (Array.isArray(fileConfig)) {
 					if (fileConfig.length === 0) {
 						debug(
-							`Config file ${configFilePath} is an empty array`,
+							"Config file %s is an empty array",
+							configFilePath,
 						);
 						emptyConfig = true;
 					} else {
@@ -622,7 +631,8 @@ class ConfigLoader {
 						Object.keys(fileConfig).length === 0
 					) {
 						debug(
-							`Config file ${configFilePath} is an empty object`,
+							"Config file %s is an empty object",
+							configFilePath,
 						);
 						emptyConfig = true;
 					} else {

--- a/lib/eslint/eslint-helpers.js
+++ b/lib/eslint/eslint-helpers.js
@@ -1261,9 +1261,12 @@ async function lintFile(
 				cachedResult.messages && cachedResult.messages.length > 0;
 
 			if (hadMessages && fix) {
-				debug(`Reprocessing cached file to allow autofix: ${filePath}`);
+				debug(
+					"Reprocessing cached file to allow autofix: %s",
+					filePath,
+				);
 			} else {
-				debug(`Skipping file since it hasn't changed: ${filePath}`);
+				debug("Skipping file since it hasn't changed: %s", filePath);
 				return cachedResult;
 			}
 		}

--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -759,7 +759,7 @@ class ESLint {
 			warningService,
 		);
 
-		debug(`Using config loader ${this.#configLoader.constructor.name}`);
+		debug("Using config loader %s", this.#configLoader.constructor.name);
 
 		privateMembers.set(this, {
 			options: processedOptions,
@@ -1003,14 +1003,14 @@ class ESLint {
 			}
 		}
 
-		debug(`Using file patterns: ${normalizedPatterns}`);
+		debug("Using file patterns: %s", normalizedPatterns);
 
 		const { concurrency, cwd, globInputPaths, errorOnUnmatchedPattern } =
 			eslintOptions;
 
 		// Delete cache file; should this be done here?
 		if (!lintResultCache && cacheFilePath) {
-			debug(`Deleting cache file at ${cacheFilePath}`);
+			debug("Deleting cache file at %s", cacheFilePath);
 
 			try {
 				if (existsSync(cacheFilePath)) {
@@ -1046,7 +1046,7 @@ class ESLint {
 			filePaths,
 		);
 		if (workerCount) {
-			debug(`Linting using ${workerCount} worker thread(s).`);
+			debug("Linting using %d worker thread(s).", workerCount);
 			let poorConcurrencyNotice;
 			if (workerCount <= 2) {
 				poorConcurrencyNotice = "disable concurrency";
@@ -1069,7 +1069,7 @@ class ESLint {
 					),
 			);
 		} else {
-			debug(`Linting in single-thread mode.`);
+			debug("Linting in single-thread mode.");
 			results = await lintFilesWithoutMultithreading(this, filePaths);
 		}
 

--- a/lib/eslint/eslint.js
+++ b/lib/eslint/eslint.js
@@ -759,8 +759,6 @@ class ESLint {
 			warningService,
 		);
 
-		debug("Using config loader %s", this.#configLoader.constructor.name);
-
 		privateMembers.set(this, {
 			options: processedOptions,
 			linter,

--- a/lib/linter/code-path-analysis/code-path-analyzer.js
+++ b/lib/linter/code-path-analysis/code-path-analyzer.js
@@ -3,6 +3,8 @@
  * @author Toru Nagashima
  */
 
+/* eslint internal-rules/no-debug-template-literals: ["error", { methods: ["dump"] }] -- Check calls to `debug.dump`. */
+
 "use strict";
 
 //------------------------------------------------------------------------------
@@ -194,7 +196,7 @@ function forwardCurrentToHead(analyzer, node) {
 				? "onCodePathSegmentEnd"
 				: "onUnreachableCodePathSegmentEnd";
 
-			debug.dump(`${eventName} ${currentSegment.id}`);
+			debug.dump("%s %s", eventName, currentSegment.id);
 
 			analyzer.emit(eventName, [currentSegment, node]);
 		}
@@ -213,7 +215,7 @@ function forwardCurrentToHead(analyzer, node) {
 				? "onCodePathSegmentStart"
 				: "onUnreachableCodePathSegmentStart";
 
-			debug.dump(`${eventName} ${headSegment.id}`);
+			debug.dump("%s %s", eventName, headSegment.id);
 			CodePathSegment.markUsed(headSegment);
 			analyzer.emit(eventName, [headSegment, node]);
 		}
@@ -237,7 +239,7 @@ function leaveFromCurrentSegment(analyzer, node) {
 			? "onCodePathSegmentEnd"
 			: "onUnreachableCodePathSegmentEnd";
 
-		debug.dump(`${eventName} ${currentSegment.id}`);
+		debug.dump("%s %s", eventName, currentSegment.id);
 
 		analyzer.emit(eventName, [currentSegment, node]);
 	}
@@ -415,7 +417,7 @@ function processCodePathToEnter(analyzer, node) {
 		state = CodePath.getState(codePath);
 
 		// Emits onCodePathStart events.
-		debug.dump(`onCodePathStart ${codePath.id}`);
+		debug.dump("onCodePathStart %s", codePath.id);
 		analyzer.emit("onCodePathStart", [codePath, node]);
 	}
 
@@ -683,7 +685,7 @@ function postprocess(analyzer, node) {
 		leaveFromCurrentSegment(analyzer, node);
 
 		// Emits onCodePathEnd event of this code path.
-		debug.dump(`onCodePathEnd ${codePath.id}`);
+		debug.dump("onCodePathEnd %s", codePath.id);
 		analyzer.emit("onCodePathEnd", [codePath, node]);
 		debug.dumpDot(codePath);
 
@@ -817,7 +819,9 @@ class CodePathAnalyzer {
 	onLooped(fromSegment, toSegment) {
 		if (fromSegment.reachable && toSegment.reachable) {
 			debug.dump(
-				`onCodePathSegmentLoop ${fromSegment.id} -> ${toSegment.id}`,
+				"onCodePathSegmentLoop %s -> %s",
+				fromSegment.id,
+				toSegment.id,
 			);
 			this.emit("onCodePathSegmentLoop", [
 				fromSegment,

--- a/lib/linter/code-path-analysis/debug-helpers.js
+++ b/lib/linter/code-path-analysis/debug-helpers.js
@@ -106,10 +106,10 @@ module.exports = {
 				}
 
 				debug(
-					[
-						`${state.currentSegments.map(getId).join(",")})`,
-						`${node.type}${leaving ? ":exit" : ""}`,
-					].join(" "),
+					"%s) %s%s",
+					state.currentSegments.map(getId).join(","),
+					node.type,
+					leaving ? ":exit" : "",
 				);
 			},
 

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -1529,12 +1529,16 @@ class Linter {
 			}
 
 			debug(
-				`Linting code for ${debugTextDescription} (pass ${passNumber})`,
+				"Linting code for %s (pass %d)",
+				debugTextDescription,
+				passNumber,
 			);
 			messages = this.verify(currentText, config, options);
 
 			debug(
-				`Generating fixed text for ${debugTextDescription} (pass ${passNumber})`,
+				"Generating fixed text for %s (pass %d)",
+				debugTextDescription,
+				passNumber,
 			);
 			let t;
 
@@ -1589,7 +1593,8 @@ class Linter {
 				currentText === secondPreviousText
 			) {
 				debug(
-					`Circular fixes detected after pass ${passNumber}. Exiting fix loop.`,
+					"Circular fixes detected after pass %d. Exiting fix loop.",
+					passNumber,
 				);
 				slots.warningService.emitCircularFixesWarning(
 					options.filename ?? "text",

--- a/tests/tools/internal-rules/no-debug-template-literals.js
+++ b/tests/tools/internal-rules/no-debug-template-literals.js
@@ -161,11 +161,18 @@ ruleTester.run("internal-rules/no-debug-template-literals", rule, {
 			],
 		},
 
-		/*
-		 * No suggestion is provided when other arguments are present: `%` sequences in the
-		 * template text may be placeholders consuming them, so escaping those sequences and
-		 * inserting new arguments before the existing ones would change the output.
-		 */
+		// no suggestion is provided if the template literal contains a format specifier
+		{
+			code: "debug(`100%done`);",
+			errors: [
+				{
+					messageId: "unexpectedTemplateLiteral",
+					suggestions: [],
+				},
+			],
+		},
+
+		// no suggestion is provided if there are multiple arguments
 		{
 			code: "debug(`Hello ${name}`, extra);",
 			errors: [
@@ -176,7 +183,7 @@ ruleTester.run("internal-rules/no-debug-template-literals", rule, {
 			],
 		},
 		{
-			code: "debug(`%s items in ${dir}`, count);",
+			code: "debug(`No placeholders here`, extra);",
 			errors: [
 				{
 					messageId: "unexpectedTemplateLiteral",
@@ -185,7 +192,7 @@ ruleTester.run("internal-rules/no-debug-template-literals", rule, {
 			],
 		},
 		{
-			code: "debug(`No placeholders here`, extra);",
+			code: "debug(`%d items in ${dir}`, count);",
 			errors: [
 				{
 					messageId: "unexpectedTemplateLiteral",

--- a/tests/tools/internal-rules/no-debug-template-literals.js
+++ b/tests/tools/internal-rules/no-debug-template-literals.js
@@ -1,0 +1,289 @@
+/**
+ * @fileoverview Tests for internal no-debug-template-literals rule.
+ * @author Francesco Trotta
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../tools/internal-rules/no-debug-template-literals");
+const { RuleTester } = require("../../../lib/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("internal-rules/no-debug-template-literals", rule, {
+	valid: [
+		'debug("Hello");',
+		'debug("Hello %s", name);',
+		"debug();",
+		"debug(...args);",
+		"debug(format, `${value}`);",
+
+		// only calls to `debug` and the configured methods are checked
+		"createDebug(`eslint:worker:thread-${threadId}`);",
+		"log(`Hello ${name}`);",
+		"obj.debug(`Hello ${name}`);",
+		"debug.dump.call(null, `Hello ${name}`);",
+		{
+			code: "debug[method](`Hello ${name}`);",
+			options: [{ methods: ["dump"] }],
+		},
+
+		// no methods are checked by default
+		"debug.dump(`${eventName} ${segment.id}`);",
+
+		// methods that are not listed are not checked
+		{
+			code: "debug.extend(`worker:thread-${threadId}`);",
+			options: [{ methods: ["dump"] }],
+		},
+		{
+			code: "debug.log(`Hello ${name}`);",
+			options: [{ methods: ["dump"] }],
+		},
+
+		// a listed method that isn't called with a template literal
+		{
+			code: "debug.dumpState(node, state, false);",
+			options: [{ methods: ["dump", "dumpState"] }],
+		},
+	],
+	invalid: [
+		{
+			code: "debug(`Hello`);",
+			errors: [
+				{
+					messageId: "unexpectedTemplateLiteral",
+					column: 7,
+					endColumn: 14,
+					suggestions: [
+						{
+							messageId: "replaceWithFormatString",
+							output: 'debug("Hello");',
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "debug(`Hello ${name}`);",
+			errors: [
+				{
+					messageId: "unexpectedTemplateLiteral",
+					suggestions: [
+						{
+							messageId: "replaceWithFormatString",
+							output: 'debug("Hello %s", name);',
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "debug(`${a} and ${b}`);",
+			errors: [
+				{
+					messageId: "unexpectedTemplateLiteral",
+					suggestions: [
+						{
+							messageId: "replaceWithFormatString",
+							output: 'debug("%s and %s", a, b);',
+						},
+					],
+				},
+			],
+		},
+		{
+			code: 'debug(`Using "${strategy}" strategy`);',
+			errors: [
+				{
+					messageId: "unexpectedTemplateLiteral",
+					suggestions: [
+						{
+							messageId: "replaceWithFormatString",
+							output: 'debug("Using \\"%s\\" strategy", strategy);',
+						},
+					],
+				},
+			],
+		},
+
+		// `%` in the text is escaped
+		{
+			code: "debug(`100% of ${count} files`);",
+			errors: [
+				{
+					messageId: "unexpectedTemplateLiteral",
+					suggestions: [
+						{
+							messageId: "replaceWithFormatString",
+							output: 'debug("100%% of %s files", count);',
+						},
+					],
+				},
+			],
+		},
+
+		// escape sequences and newlines are preserved
+		{
+			code: "debug(`Line 1\\nLine 2 ${value}`);",
+			errors: [
+				{
+					messageId: "unexpectedTemplateLiteral",
+					suggestions: [
+						{
+							messageId: "replaceWithFormatString",
+							output: 'debug("Line 1\\nLine 2 %s", value);',
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "debug(`First\nSecond ${value}`);",
+			errors: [
+				{
+					messageId: "unexpectedTemplateLiteral",
+					suggestions: [
+						{
+							messageId: "replaceWithFormatString",
+							output: 'debug("First\\nSecond %s", value);',
+						},
+					],
+				},
+			],
+		},
+
+		/*
+		 * No suggestion is provided when other arguments are present: `%` sequences in the
+		 * template text may be placeholders consuming them, so escaping those sequences and
+		 * inserting new arguments before the existing ones would change the output.
+		 */
+		{
+			code: "debug(`Hello ${name}`, extra);",
+			errors: [
+				{
+					messageId: "unexpectedTemplateLiteral",
+					suggestions: [],
+				},
+			],
+		},
+		{
+			code: "debug(`%s items in ${dir}`, count);",
+			errors: [
+				{
+					messageId: "unexpectedTemplateLiteral",
+					suggestions: [],
+				},
+			],
+		},
+		{
+			code: "debug(`No placeholders here`, extra);",
+			errors: [
+				{
+					messageId: "unexpectedTemplateLiteral",
+					suggestions: [],
+				},
+			],
+		},
+
+		// a sequence expression must be parenthesized to remain a single argument
+		{
+			code: "debug(`Value: ${(a, b)}`);",
+			errors: [
+				{
+					messageId: "unexpectedTemplateLiteral",
+					suggestions: [
+						{
+							messageId: "replaceWithFormatString",
+							output: 'debug("Value: %s", (a, b));',
+						},
+					],
+				},
+			],
+		},
+
+		// nested template literals are not reported, but are kept as arguments
+		{
+			code: "debug(`Hello ${`dear ${name}`}`);",
+			errors: [
+				{
+					messageId: "unexpectedTemplateLiteral",
+					suggestions: [
+						{
+							messageId: "replaceWithFormatString",
+							output: 'debug("Hello %s", `dear ${name}`);',
+						},
+					],
+				},
+			],
+		},
+
+		// no suggestion is provided if a comment would be lost
+		{
+			code: "debug(`Hello ${/* comment */ name}`);",
+			errors: [
+				{
+					messageId: "unexpectedTemplateLiteral",
+					suggestions: [],
+				},
+			],
+		},
+
+		// methods listed in the `methods` option are checked as well
+		{
+			code: "debug.dump(`${eventName} ${segment.id}`);",
+			options: [{ methods: ["dump"] }],
+			errors: [
+				{
+					messageId: "unexpectedTemplateLiteral",
+					suggestions: [
+						{
+							messageId: "replaceWithFormatString",
+							output: 'debug.dump("%s %s", eventName, segment.id);',
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "debug.trace(`Hello ${name}`);",
+			options: [{ methods: ["dump", "trace"] }],
+			errors: [
+				{
+					messageId: "unexpectedTemplateLiteral",
+					suggestions: [
+						{
+							messageId: "replaceWithFormatString",
+							output: 'debug.trace("Hello %s", name);',
+						},
+					],
+				},
+			],
+		},
+
+		// `debug()` itself is checked regardless of the `methods` option
+		{
+			code: "debug(`Hello ${name}`);",
+			options: [{ methods: [] }],
+			errors: [
+				{
+					messageId: "unexpectedTemplateLiteral",
+					suggestions: [
+						{
+							messageId: "replaceWithFormatString",
+							output: 'debug("Hello %s", name);',
+						},
+					],
+				},
+			],
+		},
+	],
+});

--- a/tools/internal-rules/no-debug-template-literals.js
+++ b/tools/internal-rules/no-debug-template-literals.js
@@ -143,7 +143,7 @@ module.exports = {
 					suggest: [
 						{
 							messageId: "replaceWithFormatString",
-							fix: createFix(formatArgument, node),
+							fix: createFix(formatArgument),
 						},
 					],
 				});

--- a/tools/internal-rules/no-debug-template-literals.js
+++ b/tools/internal-rules/no-debug-template-literals.js
@@ -6,6 +6,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Types
+//------------------------------------------------------------------------------
+
+/** @import { Node as ASTNode, TemplateLiteral } from "estree"; */
+
+//------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
 
@@ -15,7 +21,7 @@
  * @returns {string} The escaped text.
  */
 function escapeFormatString(text) {
-	return text.replace(/%/gu, "%%");
+	return text.replaceAll("%", "%%");
 }
 
 /**
@@ -82,7 +88,7 @@ module.exports = {
 
 		/**
 		 * Creates a fix that replaces a template literal with a format string and arguments.
-		 * @param {ASTNode} templateLiteral The `TemplateLiteral` node to replace.
+		 * @param {TemplateLiteral} templateLiteral The `TemplateLiteral` node to replace.
 		 * @returns {Function} A fix function.
 		 */
 		function createFix(templateLiteral) {

--- a/tools/internal-rules/no-debug-template-literals.js
+++ b/tools/internal-rules/no-debug-template-literals.js
@@ -1,0 +1,154 @@
+/**
+ * @fileoverview Internal rule to disallow template literals in `debug` calls.
+ * @author Francesco Trotta
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Escapes the `%` characters in a text so that it can be safely used in a format string.
+ * @param {string} text The text to escape.
+ * @returns {string} The escaped text.
+ */
+function escapeFormatString(text) {
+	return text.replace(/%/gu, "%%");
+}
+
+/**
+ * Determines whether a callee refers to a `debug` logger that formats its first argument.
+ * `debug()` is always matched, while `debug.someMethod()` is only matched if the method
+ * name is listed in the `methods` option.
+ * @param {ASTNode} callee The callee of a `CallExpression` node.
+ * @param {Set<string>} methods The names of the `debug` methods to check.
+ * @returns {boolean} `true` if the callee is a `debug` logger.
+ */
+function isDebugCallee(callee, methods) {
+	if (callee.type === "Identifier") {
+		return callee.name === "debug";
+	}
+
+	return (
+		callee.type === "MemberExpression" &&
+		!callee.computed &&
+		callee.object.type === "Identifier" &&
+		callee.object.name === "debug" &&
+		methods.has(callee.property.name)
+	);
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+	meta: {
+		defaultOptions: [{ methods: [] }],
+		docs: {
+			description:
+				"Disallow template literals as the format argument of `debug` calls",
+			recommended: false,
+		},
+		type: "suggestion",
+		hasSuggestions: true,
+		schema: [
+			{
+				type: "object",
+				properties: {
+					methods: {
+						type: "array",
+						items: { type: "string" },
+						uniqueItems: true,
+					},
+				},
+				additionalProperties: false,
+			},
+		],
+		messages: {
+			unexpectedTemplateLiteral:
+				"Use a format string with placeholders instead of a template literal.",
+			replaceWithFormatString:
+				"Replace the template literal with a format string and arguments.",
+		},
+	},
+
+	create(context) {
+		const { sourceCode } = context;
+		const [{ methods }] = context.options;
+		const methodNames = new Set(methods);
+
+		/**
+		 * Creates a fix that replaces a template literal with a format string and arguments.
+		 * @param {ASTNode} templateLiteral The `TemplateLiteral` node to replace.
+		 * @returns {Function} A fix function.
+		 */
+		function createFix(templateLiteral) {
+			return fixer => {
+				// Comments inside the template literal would be lost or may break the code.
+				if (sourceCode.getCommentsInside(templateLiteral).length) {
+					return null;
+				}
+
+				const { expressions, quasis } = templateLiteral;
+				const formatString = quasis
+					.map(quasi => escapeFormatString(quasi.value.cooked))
+					.join("%s");
+				const newArguments = [
+					JSON.stringify(formatString),
+					...expressions.map(expression => {
+						const text = sourceCode.getText(expression);
+
+						// A sequence expression would be split into multiple arguments.
+						return expression.type === "SequenceExpression"
+							? `(${text})`
+							: text;
+					}),
+				];
+
+				return fixer.replaceText(
+					templateLiteral,
+					newArguments.join(", "),
+				);
+			};
+		}
+
+		return {
+			CallExpression(node) {
+				if (!isDebugCallee(node.callee, methodNames)) {
+					return;
+				}
+
+				const [formatArgument] = node.arguments;
+
+				if (formatArgument?.type !== "TemplateLiteral") {
+					return;
+				}
+
+				/*
+				 * A suggestion is only offered when the template literal is the sole argument.
+				 * Otherwise, `%` sequences in the template text are likely placeholders that
+				 * consume the other arguments, and rewriting the call would escape those
+				 * placeholders and shift the position of the arguments they consume.
+				 */
+				const suggest =
+					node.arguments.length === 1
+						? [
+								{
+									messageId: "replaceWithFormatString",
+									fix: createFix(formatArgument),
+								},
+							]
+						: [];
+
+				context.report({
+					node: formatArgument,
+					messageId: "unexpectedTemplateLiteral",
+					suggest,
+				});
+			},
+		};
+	},
+};

--- a/tools/internal-rules/no-debug-template-literals.js
+++ b/tools/internal-rules/no-debug-template-literals.js
@@ -85,6 +85,11 @@ module.exports = {
 		 */
 		function createFix(templateLiteral) {
 			return fixer => {
+				// No suggestion is provided when there are multiple arguments.
+				if (templateLiteral.parent.arguments.length > 1) {
+					return null;
+				}
+
 				// Comments inside the template literal would be lost or may break the code.
 				if (sourceCode.getCommentsInside(templateLiteral).length) {
 					return null;
@@ -132,21 +137,15 @@ module.exports = {
 					return;
 				}
 
-				// No suggestion is provided when there are multiple arguments.
-				const suggest =
-					node.arguments.length === 1
-						? [
-								{
-									messageId: "replaceWithFormatString",
-									fix: createFix(formatArgument),
-								},
-							]
-						: null;
-
 				context.report({
 					node: formatArgument,
 					messageId: "unexpectedTemplateLiteral",
-					suggest,
+					suggest: [
+						{
+							messageId: "replaceWithFormatString",
+							fix: createFix(formatArgument, node),
+						},
+					],
 				});
 			},
 		};

--- a/tools/internal-rules/no-debug-template-literals.js
+++ b/tools/internal-rules/no-debug-template-literals.js
@@ -9,20 +9,12 @@
 // Types
 //------------------------------------------------------------------------------
 
+/** @import { RuleFixer } from "@eslint/core"; */
 /** @import { Node as ASTNode, TemplateLiteral } from "estree"; */
 
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
-
-/**
- * Escapes the `%` characters in a text so that it can be safely used in a format string.
- * @param {string} text The text to escape.
- * @returns {string} The escaped text.
- */
-function escapeFormatString(text) {
-	return text.replaceAll("%", "%%");
-}
 
 /**
  * Determines whether a callee refers to a `debug` logger that formats its first argument.
@@ -89,7 +81,7 @@ module.exports = {
 		/**
 		 * Creates a fix that replaces a template literal with a format string and arguments.
 		 * @param {TemplateLiteral} templateLiteral The `TemplateLiteral` node to replace.
-		 * @returns {Function} A fix function.
+		 * @returns {RuleFixer} A fix function.
 		 */
 		function createFix(templateLiteral) {
 			return fixer => {
@@ -99,8 +91,15 @@ module.exports = {
 				}
 
 				const { expressions, quasis } = templateLiteral;
+
+				// No suggestion is provided if the template literal appears to contain placeholders.
+				if (quasis.some(quasi => /%[a-z]/iu.test(quasi.value.cooked))) {
+					return null;
+				}
+
+				// Escape `%` characters by replacing them with `%%`.
 				const formatString = quasis
-					.map(quasi => escapeFormatString(quasi.value.cooked))
+					.map(quasi => quasi.value.cooked.replaceAll("%", "%%"))
 					.join("%s");
 				const newArguments = [
 					JSON.stringify(formatString),
@@ -133,12 +132,7 @@ module.exports = {
 					return;
 				}
 
-				/*
-				 * A suggestion is only offered when the template literal is the sole argument.
-				 * Otherwise, `%` sequences in the template text are likely placeholders that
-				 * consume the other arguments, and rewriting the call would escape those
-				 * placeholders and shift the position of the arguments they consume.
-				 */
+				// No suggestion is provided when there are multiple arguments.
 				const suggest =
 					node.arguments.length === 1
 						? [
@@ -147,7 +141,7 @@ module.exports = {
 									fix: createFix(formatArgument),
 								},
 							]
-						: [];
+						: null;
 
 				context.report({
 					node: formatArgument,

--- a/tools/internal-rules/no-debug-template-literals.js
+++ b/tools/internal-rules/no-debug-template-literals.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Internal rule to disallow template literals in `debug` calls.
+ * @fileoverview Internal rule to disallow template literals as format strings in `debug` calls.
  * @author Francesco Trotta
  */
 
@@ -17,7 +17,7 @@
 //------------------------------------------------------------------------------
 
 /**
- * Determines whether a callee refers to a `debug` logger that formats its first argument.
+ * Determines whether a callee refers to a `debug` logger.
  * `debug()` is always matched, while `debug.someMethod()` is only matched if the method
  * name is listed in the `methods` option.
  * @param {ASTNode} callee The callee of a `CallExpression` node.


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What did you do? Please include the actual source code causing the issue.**

Linted files whose names contain a percent sign, with debug output enabled:

```shell
mkdir repro && cd repro
echo 'module.exports = [];' > eslint.config.js
echo 'var x = 1;' > 'a%%b.js'
echo 'var y = 2;' > 'c%sd.js'
DEBUG='eslint:*' npx eslint .
```

**What did you expect to happen?**

The debug output should show the file names as they are on disk.

**What actually happened? Please include the actual, raw output from ESLint.**

The percent sequences are consumed as format placeholders:

```text
eslint:config-loader Calculating config for file .../a%b.js +0ms
eslint:config-loader Calculating config for file .../c+2msd.js
```

`a%%b.js` is printed as `a%b.js`, and in `c%sd.js` the `%s` swallows the `+2ms` timestamp that `debug` appends when printing to a TTY terminal, splicing it into the middle of the path and dropping it from the end of the line.

This happens because these the message is built with a template literal:

```js
debug(`Calculating config for file ${filePath}`);
```

The interpolated string then becomes the format string, so any `%` sequence it happens to contain is interpreted by `debug` rather than printed literally. `debug` collapses `%%` to `%` itself ([`common.js`](https://github.com/debug-js/debug/blob/4.4.3/src/common.js#L91-L95)), and the remaining specifiers are resolved by Node.js' `util.format` against the appended arguments.

The same problem occurs for other debug messages produced from a template literal that interpolates variable strings (like filenames or URLs).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

##### Use format strings

Converted `debug()` calls that used template literals to format strings with placeholders, which is how other parts of the codebase already do it (e.g. `debug("%s\n%s", message, ex.stack)` in `lib/languages/js/index.js`):

```diff
-debug(`Calculating config for file ${filePath}`);
+debug("Calculating config for file %s", filePath);
```

Values passed as arguments (not in the format string) are substituted verbatim and are not scanned for placeholders, so the output remains correct regardless of the file name.

Using format strings has another less evident effect: the message is only assembled if debugging is enabled, whereas a template literal is interpolated unconditionally before `debug` is called. Deferring the message calculation avoids building a string that is possibly discarded, which seems desirable even if the benefit on memory usage or performance should be negligible.

##### Internal rule

Added an internal rule `internal-rules/no-debug-template-literals` that reports a template literal used as the format argument of a `debug` call.

This should prevent the issue from creeping back in, considering that debug messages aren't typically verified in unit tests.

The rule and tests are partly generated with Claude Opus 5 and GPT-5.6.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the debug output example to reflect the current quoted file-pattern format.

* **Developer Experience**
  * Standardized diagnostic output formatting for clearer, more consistent debug messages.
  * Added automated checks to prevent unsupported template-literal formatting in debug messages.
  * Added comprehensive validation for formatting conversions, escaping, newlines, nested templates, and other edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->