### PR TITLE
fix: no-loss-of-precision false positive with trailing decimal point

### DIFF
--- a/lib/rules/no-loss-of-precision.js
+++ b/lib/rules/no-loss-of-precision.js
@@ -178,7 +178,7 @@ function convertNumberToScientificNotation(stringNumber, parseAsFloat) {
  * @returns {boolean} true if they do not match
  */
 function baseTenLosesPrecision(node) {
-	const rawNumber = getRaw(node).toLowerCase();
+	const rawNumber = getRaw(node).toLowerCase().replace(/\.$/u, "");
 	const normalizedRawNumber = convertNumberToScientificNotation(
 		rawNumber,
 		false,

--- a/tests/lib/rules/no-loss-of-precision.js
+++ b/tests/lib/rules/no-loss-of-precision.js
@@ -45,6 +45,7 @@ ruleTester.run("no-loss-of-precision", rule, {
 		"var x = 9007199254740991",
 		"var x = 0",
 		"var x = 0.0",
+		"var x = 0.",
 		"var x = 0.000000000000000000000000000000000000000000000000000000000000000000000000000000",
 		"var x = -0",
 		"var x = 123.0000000000000000000000",
@@ -152,6 +153,10 @@ ruleTester.run("no-loss-of-precision", rule, {
 	invalid: [
 		{
 			code: "var x = 9007199254740993",
+			errors: [{ messageId: "noLossOfPrecision" }],
+		},
+		{
+			code: "var x = 9007199254740993.",
 			errors: [{ messageId: "noLossOfPrecision" }],
 		},
 		{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

- [ ] Documentation update
- [x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
- [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
- [ ] Add autofix to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

After #21218 we started to validate zero values as well, but for the case of trailing decimal point notation, we treated the value as a float and incorrectly converted it to scientific notation, which caused false-positive triggering of the rule.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
