### PR TITLE
docs: Clarify eqeqeq suggestion behavior

### DIFF
--- a/docs/src/_data/further_reading_links.json
+++ b/docs/src/_data/further_reading_links.json
@@ -852,5 +852,12 @@
     "logo": "https://github.com/fluidicon.png",
     "title": "bluebird/docs/docs/warning-explanations.md at master · petkaantonov/bluebird",
     "description": ":bird: :zap: Bluebird is a full featured promise library with unmatched performance. - petkaantonov/bluebird"
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Equality_comparisons_and_sameness": {
+    "domain": "developer.mozilla.org",
+    "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Equality_comparisons_and_sameness",
+    "logo": "https://developer.mozilla.org/favicon.ico",
+    "title": "Equality comparisons and sameness - JavaScript | MDN",
+    "description": "JavaScript provides three different value-comparison operations:"
   }
 }

--- a/docs/src/rules/eqeqeq.md
+++ b/docs/src/rules/eqeqeq.md
@@ -38,6 +38,8 @@ if (obj.getStuff() != undefined) { }
 
 The `--fix` option on the command line automatically fixes some problems reported by this rule. A problem is only fixed if one of the operands is a `typeof` expression, or if both operands are literals with the same type.
 
+In other cases a suggestion is offered which can change runtime behavior if the operands have [different types](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Equality_comparisons_and_sameness).
+
 ## Options
 
 ### always

--- a/docs/src/rules/eqeqeq.md
+++ b/docs/src/rules/eqeqeq.md
@@ -1,6 +1,8 @@
 ---
 title: eqeqeq
 rule_type: suggestion
+further_reading:
+- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Equality_comparisons_and_sameness
 ---
 
 
@@ -38,7 +40,7 @@ if (obj.getStuff() != undefined) { }
 
 The `--fix` option on the command line automatically fixes some problems reported by this rule. A problem is only fixed if one of the operands is a `typeof` expression, or if both operands are literals with the same type.
 
-In other cases a suggestion is offered which can change runtime behavior if the operands have [different types](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Equality_comparisons_and_sameness).
+In other cases a suggestion is offered which can change runtime behavior if the operands have different types.
 
 ## Options
 


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

https://github.com/eslint/eslint/issues/21254

#### What changes did you make? (Give an overview)

Clarifies that eqeqeq suggestions can change runtime behavior when operands have different types, and links to MDN's equality comparison guide for context.

Fixes #21254

AI assistance was used to draft this documentation change; I reviewed the final wording and validation results before submitting.

#### Is there anything you'd like reviewers to focus on?

Please verify that the wording clearly distinguishes suggestions from automatic fixes.

<!-- markdownlint-disable-file MD004 -->