### PR TITLE
feat: no-extra-bind false negatives with class fields and static blocks

### DIFF
--- a/lib/rules/no-extra-bind.js
+++ b/lib/rules/no-extra-bind.js
@@ -47,7 +47,6 @@ module.exports = {
 	create(context) {
 		const sourceCode = context.sourceCode;
 		let scopeInfo = null;
-		let classFieldLevel = 0;
 
 		/**
 		 * Checks if a node is free of side effects.
@@ -208,7 +207,7 @@ module.exports = {
 		 * @returns {void}
 		 */
 		function markAsThisFound() {
-			if (scopeInfo && classFieldLevel === 0) {
+			if (scopeInfo) {
 				scopeInfo.thisFound = true;
 			}
 		}
@@ -219,18 +218,16 @@ module.exports = {
 			"FunctionDeclaration:exit": exitFunction,
 			FunctionExpression: enterFunction,
 			"FunctionExpression:exit": exitFunction,
-			PropertyDefinition() {
-				classFieldLevel++;
-			},
-			"PropertyDefinition:exit"() {
-				classFieldLevel--;
-			},
-			StaticBlock() {
-				classFieldLevel++;
-			},
-			"StaticBlock:exit"() {
-				classFieldLevel--;
-			},
+
+			/*
+			 * Class field initializers and static blocks have their own `this` binding.
+			 * Enter the scope after the key, which is evaluated in the enclosing scope.
+			 */
+			"PropertyDefinition > *.key:exit": enterFunction,
+			"PropertyDefinition:exit": exitFunction,
+			StaticBlock: enterFunction,
+			"StaticBlock:exit": exitFunction,
+
 			ThisExpression: markAsThisFound,
 		};
 	},

--- a/lib/rules/no-extra-bind.js
+++ b/lib/rules/no-extra-bind.js
@@ -47,6 +47,7 @@ module.exports = {
 	create(context) {
 		const sourceCode = context.sourceCode;
 		let scopeInfo = null;
+		let classFieldLevel = 0;
 
 		/**
 		 * Checks if a node is free of side effects.
@@ -207,7 +208,7 @@ module.exports = {
 		 * @returns {void}
 		 */
 		function markAsThisFound() {
-			if (scopeInfo) {
+			if (scopeInfo && classFieldLevel === 0) {
 				scopeInfo.thisFound = true;
 			}
 		}
@@ -218,6 +219,18 @@ module.exports = {
 			"FunctionDeclaration:exit": exitFunction,
 			FunctionExpression: enterFunction,
 			"FunctionExpression:exit": exitFunction,
+			PropertyDefinition() {
+				classFieldLevel++;
+			},
+			"PropertyDefinition:exit"() {
+				classFieldLevel--;
+			},
+			StaticBlock() {
+				classFieldLevel++;
+			},
+			"StaticBlock:exit"() {
+				classFieldLevel--;
+			},
 			ThisExpression: markAsThisFound,
 		};
 	},

--- a/tests/lib/rules/no-extra-bind.js
+++ b/tests/lib/rules/no-extra-bind.js
@@ -47,6 +47,20 @@ ruleTester.run("no-extra-bind", rule, {
 			code: "var a = function() { return () => this; }.bind(b)",
 			languageOptions: { ecmaVersion: 6 },
 		},
+
+		// Class fields and static blocks
+		{
+			code: "var a = function() { return class { [this.foo] = 5; }; }.bind(b);",
+			languageOptions: { ecmaVersion: 2022 },
+		},
+		{
+			code: "class C { field = function() { this; }.bind(b); }",
+			languageOptions: { ecmaVersion: 2022 },
+		},
+		{
+			code: "class C { static { var a = function() { this; }.bind(b); } }",
+			languageOptions: { ecmaVersion: 2022 },
+		},
 	],
 	invalid: [
 		{
@@ -256,26 +270,20 @@ ruleTester.run("no-extra-bind", rule, {
 
 		// Class fields and static blocks
 		{
-			code: "const f = (function() { class C { field = this.x; } }).bind(this);",
-			output: "const f = (function() { class C { field = this.x; } });",
+			code: "var a = function() { class C { field = this.x; } }.bind(b)",
+			output: "var a = function() { class C { field = this.x; } }",
 			languageOptions: { ecmaVersion: 2022 },
 			errors,
 		},
 		{
-			code: "const f = (function() { class C { static field = this.x; } }).bind(this);",
-			output: "const f = (function() { class C { static field = this.x; } });",
+			code: "var a = function() { class C { static field = this.x; } }.bind(b)",
+			output: "var a = function() { class C { static field = this.x; } }",
 			languageOptions: { ecmaVersion: 2022 },
 			errors,
 		},
 		{
-			code: "const f = (function() { class C { static { this.x = 1; } } }).bind(this);",
-			output: "const f = (function() { class C { static { this.x = 1; } } });",
-			languageOptions: { ecmaVersion: 2022 },
-			errors,
-		},
-		{
-			code: "const f = (function() { class C { a = this.x; b = this.y; } }).bind(this);",
-			output: "const f = (function() { class C { a = this.x; b = this.y; } });",
+			code: "var a = function() { class C { static { this.x = 1; } } }.bind(b)",
+			output: "var a = function() { class C { static { this.x = 1; } } }",
 			languageOptions: { ecmaVersion: 2022 },
 			errors,
 		},

--- a/tests/lib/rules/no-extra-bind.js
+++ b/tests/lib/rules/no-extra-bind.js
@@ -253,5 +253,31 @@ ruleTester.run("no-extra-bind", rule, {
 			languageOptions: { ecmaVersion: 2020 },
 			errors: [{ messageId: "unexpected" }],
 		},
+
+		// Class fields and static blocks
+		{
+			code: "const f = (function() { class C { field = this.x; } }).bind(this);",
+			output: "const f = (function() { class C { field = this.x; } });",
+			languageOptions: { ecmaVersion: 2022 },
+			errors,
+		},
+		{
+			code: "const f = (function() { class C { static field = this.x; } }).bind(this);",
+			output: "const f = (function() { class C { static field = this.x; } });",
+			languageOptions: { ecmaVersion: 2022 },
+			errors,
+		},
+		{
+			code: "const f = (function() { class C { static { this.x = 1; } } }).bind(this);",
+			output: "const f = (function() { class C { static { this.x = 1; } } });",
+			languageOptions: { ecmaVersion: 2022 },
+			errors,
+		},
+		{
+			code: "const f = (function() { class C { a = this.x; b = this.y; } }).bind(this);",
+			output: "const f = (function() { class C { a = this.x; b = this.y; } });",
+			languageOptions: { ecmaVersion: 2022 },
+			errors,
+		},
 	],
 });


### PR DESCRIPTION

<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

fixes: #21258 

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
 Fixed `no-extra-bind` to correctly flag unnecessary `.bind()` calls when `this` is used only inside class field initializers or static blocks.
 In these contexts, `this` refers to the class instance (for fields) or constructor (for static blocks), not the enclosing function, so `.bind(this)` on the outer function is redundant.
#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
