### PR TITLE
feat: avoid prototype lookups in new-cap exception maps

### DIFF
--- a/lib/rules/new-cap.js
+++ b/lib/rules/new-cap.js
@@ -50,7 +50,7 @@ function calculateCapIsNewExceptions(config) {
 		new Set([...config.capIsNewExceptions, ...CAPS_ALLOWED]),
 	);
 
-	return capIsNewExceptions.reduce(invert, {});
+	return capIsNewExceptions.reduce(invert, Object.create(null));
 }
 
 //------------------------------------------------------------------------------
@@ -125,7 +125,10 @@ module.exports = {
 		const [config] = context.options;
 		const skipProperties = !config.properties;
 
-		const newIsCapExceptions = config.newIsCapExceptions.reduce(invert, {});
+		const newIsCapExceptions = config.newIsCapExceptions.reduce(
+			invert,
+			Object.create(null),
+		);
 		const newIsCapExceptionPattern = config.newIsCapExceptionPattern
 			? new RegExp(config.newIsCapExceptionPattern, "u")
 			: null;

--- a/tests/lib/rules/new-cap.js
+++ b/tests/lib/rules/new-cap.js
@@ -389,6 +389,43 @@ ruleTester.run("new-cap", rule, {
 			],
 		},
 
+		// Object.prototype method names should be flagged under new-cap, not silently allowed (https://github.com/eslint/eslint/issues/21255)
+		{
+			code: "var x = new toString();",
+			errors: [
+				{
+					messageId: "lower",
+					line: 1,
+					column: 13,
+					endLine: 1,
+					endColumn: 21,
+				},
+			],
+		},
+		{
+			code: "var x = new constructor();",
+			errors: [
+				{
+					messageId: "lower",
+					line: 1,
+					column: 13,
+					endLine: 1,
+					endColumn: 24,
+				},
+			],
+		},
+		{
+			code: "var x = new hasOwnProperty();",
+			errors: [
+				{
+					messageId: "lower",
+					line: 1,
+					column: 13,
+					endLine: 1,
+					endColumn: 27,
+				},
+			],
+		},
 		// Optional chaining
 		{
 			code: "new (foo?.bar)();",


### PR DESCRIPTION
### What is the purpose of this pull request?

[X] Bug fix

### What changes did you make? (Give an overview)

The `new-cap` rule builds its exception maps with `Array.prototype.reduce(invert, {})`. The two resulting objects inherit from `Object.prototype`, so a membership check like `allowedMap[calleeName]` returns a function reference for any name that shadows a built-in prototype property (`toString`, `constructor`, `hasOwnProperty`, `isPrototypeOf`, `propertyIsEnumerable`, `valueOf`, `toLocaleString`). The rule then treated those names as configured exceptions and silently skipped them, so `new toString()`, `new constructor()`, etc. were never reported despite starting with a lowercase letter.

This change builds both maps with `Object.create(null)` instead of `{}`, so they have no prototype to look up, and adds regression tests for the affected names.

Fixes #21255.

### Is there anything you'd like reviewers to focus on?

The fix is a one-key change in two places; the regression tests are the only behavioural assertion worth a second look. I confirmed the existing `tests/lib/rules/new-cap.js` suite still passes (83 cases) and that a wider smoke run against neighbouring rule tests stays green.