### PR TITLE
ci: skip EMFILE test on Node.js 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,16 +91,11 @@ jobs:
             - name: Fuzz Test
               run: node Makefile fuzz
             - name: Test EMFILE Handling
-              shell: bash
-              # Node.js 26.8+ no longer exhausts the runner's high file-descriptor limit.
-              # Lower the limit and increase concurrency to reliably trigger EMFILE.
-              # See https://github.com/nodejs/node/pull/65327
-              run: |
-                  if [ "$RUNNER_OS" != "Windows" ]; then
-                    ulimit -n 64
-                    export UV_THREADPOOL_SIZE=128
-                  fi
-                  npm run test:emfile
+              # Node.js 26.8+ no longer reliably triggers `EMFILE` for small-file reads.
+              # See: https://github.com/nodejs/node/pull/65327
+              # TODO: Re-enable after replacing this with deterministic error injection.
+              if: matrix.node != '26.x'
+              run: npm run test:emfile
 
     test_on_browser:
         name: Browser Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,16 @@ jobs:
             - name: Fuzz Test
               run: node Makefile fuzz
             - name: Test EMFILE Handling
-              run: npm run test:emfile
+              shell: bash
+              # Node.js 26.8+ no longer exhausts the runner's high file-descriptor limit.
+              # Lower the limit and increase concurrency to reliably trigger EMFILE.
+              # See https://github.com/nodejs/node/pull/65327
+              run: |
+                  if [ "$RUNNER_OS" != "Windows" ]; then
+                    ulimit -n 64
+                    export UV_THREADPOOL_SIZE=128
+                  fi
+                  npm run test:emfile
 
     test_on_browser:
         name: Browser Test


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Temporarily skipped the `EMFILE` test on Node.js 26 because Node.js 26.8+ no longer reliably triggers `EMFILE` for small-file reads.

The test continues to run on other Node.js versions.

#### Is there anything you'd like reviewers to focus on?

I think this issue was caused by https://github.com/nodejs/node/pull/65327 in Node.js, which is included in [Node.js 26.8.0](https://nodejs.org/en/blog/release/v26.8.0).

The PR is performance-related, so reading many files no longer seems to trigger an `EMFILE` error.

I’m not sure whether this is a regression in Node.js, but I think the issue is that we’ve been relying on the `EMFILE` error as a heuristic for throwing the error.

I haven’t been able to find a reliable solution yet, so I’m leaving this workaround in place for now to avoid blocking other PRs because of this issue.

<!-- markdownlint-disable-file MD004 -->
