### PR TITLE
fix: `new-cap` false positive for `UTC` calls with `properties: false`

### DIFF
--- a/lib/rules/new-cap.js
+++ b/lib/rules/new-cap.js
@@ -197,15 +197,21 @@ module.exports = {
 
 			const callee = astUtils.skipChainExpression(node.callee);
 
-			if (calleeName === "UTC" && callee.type === "MemberExpression") {
-				// allow if callee is Date.UTC
-				return (
-					callee.object.type === "Identifier" &&
-					callee.object.name === "Date"
-				);
+			if (callee.type === "MemberExpression") {
+				if (skipProperties) {
+					return true;
+				}
+
+				if (calleeName === "UTC") {
+					// allow if callee is Date.UTC
+					return (
+						callee.object.type === "Identifier" &&
+						callee.object.name === "Date"
+					);
+				}
 			}
 
-			return skipProperties && callee.type === "MemberExpression";
+			return false;
 		}
 
 		/**

--- a/tests/lib/rules/new-cap.js
+++ b/tests/lib/rules/new-cap.js
@@ -108,6 +108,9 @@ ruleTester.run("new-cap", rule, {
 			code: "var x = foo.Bar(42);",
 			options: [{ capIsNew: false, properties: false }],
 		},
+		{ code: "foo.UTC();", options: [{ properties: false }] },
+		{ code: "foo?.UTC();", options: [{ properties: false }] },
+		{ code: "const b = a.Date.UTC();", options: [{ properties: false }] },
 
 		// Optional chaining
 		{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment (`npx eslint --env-info`):**

- **Node version:** v24.16.0
- **npm version:** v11.13.0
- **Local ESLint version:** v10.9.1
- **Global ESLint version:** no
- **Operating System:** windows

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->

```js
export default [{}];
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/*eslint new-cap: ["error", { properties: false }]*/
foo.Bar();
foo.UTC();
```

[Playground](https://eslint.org/play/#eyJ0ZXh0IjoiLyplc2xpbnQgbmV3LWNhcDogW1wiZXJyb3JcIiwgeyBwcm9wZXJ0aWVzOiBmYWxzZSB9XSovXG5mb28uQmFyKCk7XG5mb28uVVRDKCk7Iiwib3B0aW9ucyI6eyJydWxlcyI6e30sImxhbmd1YWdlT3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFGZWF0dXJlcyI6e319fX19)

**What did you expect to happen?**

No errors. `properties: false` disables checks on object properties, so every capitalized property call should be skipped regardless of its name.

**What actually happened? Please include the actual, raw output from ESLint.**

`foo.Bar()` is skipped, but `foo.UTC()` is still reported:
```
A function with a name starting with an uppercase letter should only be used as a constructor.
```

#### What changes did you make? (Give an overview)

Reordered the checks in `isCapAllowed()` so the `properties: false` check runs before the `Date.UTC` special case.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected `new-cap` rule handling for property calls when property checks are disabled.
  * Preserved valid usage of `Date.UTC()`, including optional chaining and nested access patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->