### PR TITLE
fix: Ignore static imports in no-unreachable

### DIFF
--- a/lib/rules/no-unreachable.js
+++ b/lib/rules/no-unreachable.js
@@ -210,7 +210,7 @@ module.exports = {
 				currentCodePathSegments.add(segment);
 			},
 
-			// Registers for all statement nodes (excludes FunctionDeclaration).
+			// Registers for all statement nodes (excludes FunctionDeclaration and ImportDeclaration).
 			BlockStatement: reportIfUnreachable,
 			BreakStatement: reportIfUnreachable,
 			ClassDeclaration: reportIfUnreachable,

--- a/lib/rules/no-unreachable.js
+++ b/lib/rules/no-unreachable.js
@@ -222,7 +222,6 @@ module.exports = {
 			ForOfStatement: reportIfUnreachable,
 			ForStatement: reportIfUnreachable,
 			IfStatement: reportIfUnreachable,
-			ImportDeclaration: reportIfUnreachable,
 			LabeledStatement: reportIfUnreachable,
 			ReturnStatement: reportIfUnreachable,
 			SwitchStatement: reportIfUnreachable,

--- a/tests/lib/rules/no-unreachable.js
+++ b/tests/lib/rules/no-unreachable.js
@@ -28,6 +28,10 @@ ruleTester.run("no-unreachable", rule, {
 		"function foo() { function bar() { return 1; } return bar(); }",
 		"function foo() { return bar(); function bar() { return 1; } }",
 		"function foo() { return x; var x; }",
+		{
+			code: "throw new Error(); import foo from 'foo';",
+			languageOptions: { ecmaVersion: 6, sourceType: "module" },
+		},
 		"function foo() { var x = 1; var y = 2; }",
 		"function foo() { var x = 1; var y = 2; return; }",
 		"while (true) { switch (foo) { case 1: x = 1; x = 2;} }",
@@ -93,6 +97,19 @@ ruleTester.run("no-unreachable", rule, {
 		},
 	],
 	invalid: [
+		{
+			code: "throw new Error(); import foo from 'foo'; foo();",
+			languageOptions: { ecmaVersion: 6, sourceType: "module" },
+			errors: [
+				{
+					messageId: "unreachableCode",
+					line: 1,
+					column: 43,
+					endLine: 1,
+					endColumn: 49,
+				},
+			],
+		},
 		{
 			code: "function foo() { return x; var x = 1; }",
 			errors: [

--- a/tests/lib/rules/no-unreachable.js
+++ b/tests/lib/rules/no-unreachable.js
@@ -111,6 +111,26 @@ ruleTester.run("no-unreachable", rule, {
 			],
 		},
 		{
+			code: "throw new Error(); foo(); import foo from 'foo'; foo();",
+			languageOptions: { ecmaVersion: 6, sourceType: "module" },
+			errors: [
+				{
+					messageId: "unreachableCode",
+					line: 1,
+					column: 20,
+					endLine: 1,
+					endColumn: 26,
+				},
+				{
+					messageId: "unreachableCode",
+					line: 1,
+					column: 50,
+					endLine: 1,
+					endColumn: 56,
+				},
+			],
+		},
+		{
 			code: "function foo() { return x; var x = 1; }",
 			errors: [
 				{


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #21273

#### What changes did you make? (Give an overview)

Static import declarations are instantiated before module evaluation. This removes `ImportDeclaration` from `no-unreachable`'s runtime-statement listeners and adds regression coverage ensuring imports after abrupt completion are ignored while later executable statements are still reported.

#### Is there anything you'd like reviewers to focus on?

Whether ignoring static imports at the listener boundary matches the intended rule semantics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved unreachable-code detection in ECMAScript modules.
  - Import statements following a top-level error are now correctly accepted.
  - Calls before and after such imports are correctly identified as unreachable where applicable.
  - Valid standalone imports no longer trigger unreachable-code warnings.

- **Tests**
  - Added coverage for module-mode scenarios, including imports and unreachable calls surrounding a top-level `throw`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->