### PR TITLE
chore: update dependency file-entry-cache to v11 [17733]

### DIFF
--- a/lib/cli-engine/lint-result-cache.js
+++ b/lib/cli-engine/lint-result-cache.js
@@ -89,11 +89,16 @@ class LintResultCache {
 
 		debug(`Using "${cacheStrategy}" strategy to detect changes`);
 
-		this.fileEntryCache = fileEntryCache.create(
-			cacheFileLocation,
-			void 0,
-			useChecksum,
-		);
+		/*
+		 * `file-entry-cache` checks modification time and checksum independently,
+		 * so modification time checking must be turned off for the "content"
+		 * strategy to avoid invalidating entries for files that were touched
+		 * but whose contents didn't change.
+		 */
+		this.fileEntryCache = fileEntryCache.createFromFile(cacheFileLocation, {
+			useCheckSum: useChecksum,
+			useModifiedTime: !useChecksum,
+		});
 		this.cacheFileLocation = cacheFileLocation;
 	}
 

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "esquery": "^1.7.0",
     "esutils": "^2.0.2",
     "fast-deep-equal": "^3.1.3",
-    "file-entry-cache": "^11.1.5",
+    "file-entry-cache": "11.1.5",
     "find-up": "^5.0.0",
     "glob-parent": "^6.0.2",
     "ignore": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "esquery": "^1.7.0",
     "esutils": "^2.0.2",
     "fast-deep-equal": "^3.1.3",
-    "file-entry-cache": "^8.0.0",
+    "file-entry-cache": "^11.1.5",
     "find-up": "^5.0.0",
     "glob-parent": "^6.0.2",
     "ignore": "^5.2.0",

--- a/tests/lib/cli-engine/lint-result-cache.js
+++ b/tests/lib/cli-engine/lint-result-cache.js
@@ -125,13 +125,13 @@ describe("LintResultCache", () => {
 		before(() => {
 			getFileDescriptorStub = sandbox.stub();
 
-			fileEntryCacheStubs.create = () => ({
+			fileEntryCacheStubs.createFromFile = () => ({
 				getFileDescriptor: getFileDescriptorStub,
 			});
 		});
 
 		after(() => {
-			delete fileEntryCacheStubs.create;
+			delete fileEntryCacheStubs.createFromFile;
 		});
 
 		beforeEach(() => {
@@ -287,13 +287,13 @@ describe("LintResultCache", () => {
 		before(() => {
 			getFileDescriptorStub = sandbox.stub();
 
-			fileEntryCacheStubs.create = () => ({
+			fileEntryCacheStubs.createFromFile = () => ({
 				getFileDescriptor: getFileDescriptorStub,
 			});
 		});
 
 		after(() => {
-			delete fileEntryCacheStubs.create;
+			delete fileEntryCacheStubs.createFromFile;
 		});
 
 		beforeEach(() => {
@@ -408,13 +408,13 @@ describe("LintResultCache", () => {
 		before(() => {
 			reconcileStub = sandbox.stub();
 
-			fileEntryCacheStubs.create = () => ({
+			fileEntryCacheStubs.createFromFile = () => ({
 				reconcile: reconcileStub,
 			});
 		});
 
 		after(() => {
-			delete fileEntryCacheStubs.create;
+			delete fileEntryCacheStubs.createFromFile;
 		});
 
 		beforeEach(() => {

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -13992,22 +13992,22 @@ describe("ESLint", () => {
 			 */
 			await eslint.lintFiles([badFile, goodFile]);
 
-			cache = JSON.parse(fs.readFileSync(cacheFilePath));
+			cache = fCache.createFromFile(cacheFilePath).cache;
 
 			assert.strictEqual(
-				typeof cache[0][toBeDeletedFile],
+				typeof cache.getKey(toBeDeletedFile),
 				"undefined",
 				"the entry for the file to be deleted should not have been in the cache",
 			);
 
 			// make sure that the previous assertion checks the right place
 			assert.notStrictEqual(
-				typeof cache[0][badFile],
+				typeof cache.getKey(badFile),
 				"undefined",
 				"the entry for the bad file should have been in the cache",
 			);
 			assert.notStrictEqual(
-				typeof cache[0][goodFile],
+				typeof cache.getKey(goodFile),
 				"undefined",
 				"the entry for the good file should have been in the cache",
 			);
@@ -14336,7 +14336,7 @@ describe("ESLint", () => {
 					"the cache for eslint should have been created",
 				);
 
-				const fileCache = fCache.create(cacheFilePath);
+				const fileCache = fCache.createFromFile(cacheFilePath);
 				const descriptor = fileCache.getFileDescriptor(filePath);
 
 				assert(
@@ -14403,7 +14403,7 @@ describe("ESLint", () => {
 					"the cache for eslint should have been created",
 				);
 
-				const fileCache = fCache.create(cacheFilePath);
+				const fileCache = fCache.createFromFile(cacheFilePath);
 				const descriptor = fileCache.getFileDescriptor(filePath);
 
 				assert(
@@ -14512,7 +14512,10 @@ describe("ESLint", () => {
 				);
 
 				await eslint.lintFiles([badFile, goodFile]);
-				let fileCache = fCache.createFromFile(cacheFilePath, true);
+				let fileCache = fCache.createFromFile(cacheFilePath, {
+					useCheckSum: true,
+					useModifiedTime: false,
+				});
 				let entries = fileCache.normalizeEntries([badFile, goodFile]);
 
 				entries.forEach(entry => {
@@ -14524,7 +14527,10 @@ describe("ESLint", () => {
 
 				// this should NOT result in a changed entry
 				shell.touch(goodFile);
-				fileCache = fCache.createFromFile(cacheFilePath, true);
+				fileCache = fCache.createFromFile(cacheFilePath, {
+					useCheckSum: true,
+					useModifiedTime: false,
+				});
 				entries = fileCache.normalizeEntries([badFile, goodFile]);
 				entries.forEach(entry => {
 					assert(
@@ -14572,7 +14578,10 @@ describe("ESLint", () => {
 				shell.cp(goodFile, goodFileCopy);
 
 				await eslint.lintFiles([badFile, goodFileCopy]);
-				let fileCache = fCache.createFromFile(cacheFilePath, true);
+				let fileCache = fCache.createFromFile(cacheFilePath, {
+					useCheckSum: true,
+					useModifiedTime: false,
+				});
 				const entries = fileCache.normalizeEntries([
 					badFile,
 					goodFileCopy,
@@ -14587,7 +14596,10 @@ describe("ESLint", () => {
 
 				// this should result in a changed entry
 				shell.sed("-i", "abc", "xzy", goodFileCopy);
-				fileCache = fCache.createFromFile(cacheFilePath, true);
+				fileCache = fCache.createFromFile(cacheFilePath, {
+					useCheckSum: true,
+					useModifiedTime: false,
+				});
 				assert(
 					fileCache.getFileDescriptor(badFile).changed === false,
 					`the entry for ${badFile} should have been unchanged`,


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
(Claude helped)

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] *Other, please explain: *
I noticed that `json-buffer` which is now orphaned was in my dependency chain, which triggered some of my security tooling. Tracing it back, found that `eslint` has a hard dependency on file-entry-cache v8, and by would then drop orphaned project.  I saw https://github.com/eslint/eslint/issues/17733 highlighted (`file-entry-cache` v8 → v11) so hoping this might be accepted so my OCD is cleared 😸 

#### What changes did you make? (Give an overview)

Upgrades `file-entry-cache` from `^8.0.0` to `^11.1.5`. Three breaking changes in the major bump affected `LintResultCache`:

**1. `create()` → `createFromFile()`**

In v8, `create(cacheId, cacheDirectory)` accepted an absolute path as `cacheId` with an undefined directory, and flat-cache resolved it. In v11, `create()` **skips loading entirely when `cacheDirectory` is undefined** — the cache would have silently stopped persisting. `createFromFile()` splits the path into basename/dirname and is the correct call for a full cache-file path.

**2. The third argument is now an options object**, not a `useChecksum` boolean.

**3. `cacheStrategy: "content"` now needs `useModifiedTime: false`**

This is the subtle one. v8 treated a checksum as a *replacement* for the mtime check. v11 checks mtime and checksum **independently, both on by default**. Left alone, `--cache-strategy content` would have started invalidating entries for merely-touched files — precisely the behavior that option exists to avoid. A comment in the constructor documents this.

**Test updates**

- `tests/lib/cli-engine/lint-result-cache.js`: proxyquire stubs retargeted from `create` to `createFromFile`.
- `tests/lib/eslint/eslint.js`: `fCache.create(path)` → `createFromFile(path)`, and `createFromFile(path, true)` → the options object.
- One assertion read the cache file as raw JSON (`cache[0][filePath]`). The flat-cache v6 on-disk format changed from a flatted key/value object to a flatted array of `{key, value}` entries, so that assertion now goes through `cache.getKey()`, matching the idiom already used by the sibling test directly above it.

#### Verification

Full `npm test` passes (exit 0):

Additionally verified by hand:

- **Upgrade path:** an `.eslintcache` written by v8 is read correctly by v11 (`changed: false`, cached results intact) and rewritten in the new format on reconcile. **Existing cache files are not invalidated by this upgrade.**

#### Is there anything you'd like reviewers to focus on?

1. **The `useModifiedTime: !useChecksum` line** is the behavioral crux. Without it, `--cache-strategy content` silently regresses to mtime-sensitive invalidation — which still passes most tests, but defeats the point of the option. Worth confirming this reading of the v11 semantics.

2. **Cache file format change.** Reads are backward compatible (verified above), but anything downstream parsing `.eslintcache` directly rather than through the library will break. The test that did exactly this is the one changed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lint-result caching reliability by validating files with content checksums or modification times according to the selected cache strategy.
  * Ensured cached results remain accurate when files are changed or reconciled.
  * Improved cache initialization and inspection for more consistent behavior.

* **Tests**
  * Expanded coverage for storing, retrieving, reconciling, and inspecting cached lint results across supported caching strategies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->