### PR TITLE
fix: prefer-object-has-own autofix breaks when Object is shadowed

### DIFF
--- a/lib/rules/prefer-object-has-own.js
+++ b/lib/rules/prefer-object-has-own.js
@@ -99,7 +99,7 @@ module.exports = {
 					objectPropertyName === "hasOwnProperty" &&
 					isObject &&
 					variable &&
-					variable.scope.type === "global"
+					variable.defs.length === 0
 				) {
 					context.report({
 						node,

--- a/lib/rules/prefer-object-has-own.js
+++ b/lib/rules/prefer-object-has-own.js
@@ -99,6 +99,7 @@ module.exports = {
 					objectPropertyName === "hasOwnProperty" &&
 					isObject &&
 					variable &&
+					variable.scope.type === "global" &&
 					variable.defs.length === 0
 				) {
 					context.report({

--- a/tests/lib/rules/prefer-object-has-own.js
+++ b/tests/lib/rules/prefer-object-has-own.js
@@ -88,6 +88,16 @@ ruleTester.run("prefer-object-has-own", rule, {
 		"const hasProperty = Object.hasOwn(object, property);",
 		`/* global Object: off */
         ({}).hasOwnProperty.call(a, b);`,
+		{
+			// Object is shadowed
+			code: "var Object = foo;\nObject.prototype.hasOwnProperty.call(obj, prop);",
+			languageOptions: { sourceType: "script" },
+		},
+		{
+			// Object is shadowed
+			code: "var Object = foo;\n({}).hasOwnProperty.call(obj, prop);",
+			languageOptions: { sourceType: "script" },
+		},
 	],
 	invalid: [
 		{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixes #21279

prefer-object-has-own only checked that Object refers to a variable in the global scope, not whether that variable was actually declared by the user. 
In a script file, a top-level var also lives in the global scope, so the rule treated it the same as the real built-in Object.

```js
var Object = foo;
Object.prototype.hasOwnProperty.call(obj, prop);
```
was autofixed to
```js
var Object = foo;
Object.hasOwn(obj, prop);
```
which calls a method that doesn't exist on the user-defined Object.

Updated prefer-object-has-own to only report when Object hasn't been declared by the user.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->

Disclosure: I'm a participant of [open source contribution program OSSCA](https://github.com/eslint-ossca)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of `Object` references when checking `hasOwnProperty` usage.
  * Prevented automatic transformations when `Object` is shadowed in script scope.
  * Preserved existing reporting and autofix behavior for valid built-in references.
  * Added coverage for shadowed `Object` references in multiple supported usage patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->