### PR TITLE
fix: detect control character escapes in no-control-regex

### DIFF
--- a/docs/src/rules/no-control-regex.md
+++ b/docs/src/rules/no-control-regex.md
@@ -19,9 +19,10 @@ The following elements of regular expression patterns are considered possible er
 * Hexadecimal character escapes from `\x00` to `\x1F`.
 * Unicode character escapes from `\u0000` to `\u001F`.
 * Unicode code point escapes from `\u{0}` to `\u{1F}`.
+* Control character escapes from `\cA` to `\cZ` (and `\ca` to `\cz`).
 * Unescaped raw characters from U+0000 to U+001F.
 
-Control escapes such as `\t` and `\n` are allowed by this rule.
+Other control escapes such as `\t` and `\n` are allowed by this rule.
 
 Examples of **incorrect** code for this rule:
 
@@ -35,8 +36,9 @@ const pattern2 = /\x0C/;
 const pattern3 = /\x1F/;
 const pattern4 = /\u000C/;
 const pattern5 = /\u{C}/u;
-const pattern6 = new RegExp("\x0C"); // raw U+000C character in the pattern
-const pattern7 = new RegExp("\\x0C"); // \x0C pattern
+const pattern6 = /\cL/;
+const pattern7 = new RegExp("\x0C"); // raw U+000C character in the pattern
+const pattern8 = new RegExp("\\x0C"); // \x0C pattern
 ```
 
 :::

--- a/lib/rules/no-control-regex.js
+++ b/lib/rules/no-control-regex.js
@@ -32,7 +32,8 @@ const collector = new (class {
 			cp <= 0x1f &&
 			(this._source.codePointAt(start) === cp ||
 				this._source.slice(start, end).startsWith("\\x") ||
-				this._source.slice(start, end).startsWith("\\u"))
+				this._source.slice(start, end).startsWith("\\u") ||
+				this._source.slice(start, end).startsWith("\\c"))
 		) {
 			this._controlChars.push(`\\x${`0${cp.toString(16)}`.slice(-2)}`);
 		}

--- a/tests/lib/rules/no-control-regex.js
+++ b/tests/lib/rules/no-control-regex.js
@@ -22,6 +22,7 @@ ruleTester.run("no-control-regex", rule, {
 	valid: [
 		"var regex = /x1f/",
 		String.raw`var regex = /\\x1f/`,
+		String.raw`var regex = /\\cA/`,
 		"var regex = new RegExp('x1f')",
 		"var regex = RegExp('x1f')",
 		"new RegExp('[')",
@@ -48,6 +49,24 @@ ruleTester.run("no-control-regex", rule, {
 		},
 	],
 	invalid: [
+		{
+			code: String.raw`var regex = /\cA\cz/`,
+			errors: [
+				{
+					messageId: "unexpected",
+					data: { controlChars: "\\x01, \\x1a" },
+				},
+			],
+		},
+		{
+			code: String.raw`new RegExp("\\cZ")`,
+			errors: [
+				{
+					messageId: "unexpected",
+					data: { controlChars: "\\x1a" },
+				},
+			],
+		},
 		{
 			code: String.raw`var regex = /\x1f/`,
 			errors: [


### PR DESCRIPTION
Fixes #21281

## Summary
- report \c control-letter escapes that match ASCII control characters
- cover regex literals and RegExp constructor patterns with regression tests
- document the supported escape forms

## Validation
- npx mocha tests/lib/rules/no-control-regex.js
- npx prettier --check lib/rules/no-control-regex.js tests/lib/rules/no-control-regex.js docs/src/rules/no-control-regex.md
- npx eslint lib/rules/no-control-regex.js tests/lib/rules/no-control-regex.js
- npx markdownlint-cli2 docs/src/rules/no-control-regex.md

This contribution was prepared with AI assistance and reviewed against the repository\'s AI contribution policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of control-character escapes in regular expressions, including `\cA`–`\cZ` and lowercase variants.
  * Added coverage for regex literals and `RegExp` constructor patterns.

* **Documentation**
  * Clarified which control escapes are disallowed and confirmed that escapes such as `\t` and `\n` remain valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->