### PR TITLE
docs: document `\c` control letter escapes in no-control-regex

### DIFF
--- a/docs/src/rules/no-control-regex.md
+++ b/docs/src/rules/no-control-regex.md
@@ -19,6 +19,7 @@ The following elements of regular expression patterns are considered possible er
 * Hexadecimal character escapes from `\x00` to `\x1F`.
 * Unicode character escapes from `\u0000` to `\u001F`.
 * Unicode code point escapes from `\u{0}` to `\u{1F}`.
+* Control letter escapes from `\cA` to `\cZ` (and `\ca` to `\cz`).
 * Unescaped raw characters from U+0000 to U+001F.
 
 Control escapes such as `\t` and `\n` are allowed by this rule.
@@ -37,6 +38,7 @@ const pattern4 = /\u000C/;
 const pattern5 = /\u{C}/u;
 const pattern6 = new RegExp("\x0C"); // raw U+000C character in the pattern
 const pattern7 = new RegExp("\\x0C"); // \x0C pattern
+const pattern8 = /\cJ/; // control letter escape for U+000A
 ```
 
 :::

--- a/docs/src/rules/no-control-regex.md
+++ b/docs/src/rules/no-control-regex.md
@@ -19,10 +19,9 @@ The following elements of regular expression patterns are considered possible er
 * Hexadecimal character escapes from `\x00` to `\x1F`.
 * Unicode character escapes from `\u0000` to `\u001F`.
 * Unicode code point escapes from `\u{0}` to `\u{1F}`.
-* Control letter escapes from `\cA` to `\cZ` (and `\ca` to `\cz`).
 * Unescaped raw characters from U+0000 to U+001F.
 
-Control escapes such as `\t` and `\n` are allowed by this rule.
+Control escapes such as `\t` and `\n` are allowed by this rule. Control letter escapes such as `\cA`-`\cZ` (and `\ca`-`\cz`) are also allowed, since writing a control character this way makes the intent to match a control character explicit, unlike the hexadecimal, Unicode, and raw forms above, which can obscure that intent.
 
 Examples of **incorrect** code for this rule:
 
@@ -38,7 +37,6 @@ const pattern4 = /\u000C/;
 const pattern5 = /\u{C}/u;
 const pattern6 = new RegExp("\x0C"); // raw U+000C character in the pattern
 const pattern7 = new RegExp("\\x0C"); // \x0C pattern
-const pattern8 = /\cJ/; // control letter escape for U+000A
 ```
 
 :::
@@ -58,6 +56,7 @@ const pattern5 = /\n/;
 const pattern6 = new RegExp("\x20");
 const pattern7 = new RegExp("\\t");
 const pattern8 = new RegExp("\\n");
+const pattern9 = /\cJ/; // control letter escape for U+000A
 ```
 
 :::

--- a/lib/rules/no-control-regex.js
+++ b/lib/rules/no-control-regex.js
@@ -32,8 +32,7 @@ const collector = new (class {
 			cp <= 0x1f &&
 			(this._source.codePointAt(start) === cp ||
 				this._source.slice(start, end).startsWith("\\x") ||
-				this._source.slice(start, end).startsWith("\\u") ||
-				this._source.slice(start, end).startsWith("\\c"))
+				this._source.slice(start, end).startsWith("\\u"))
 		) {
 			this._controlChars.push(`\\x${`0${cp.toString(16)}`.slice(-2)}`);
 		}

--- a/lib/rules/no-control-regex.js
+++ b/lib/rules/no-control-regex.js
@@ -32,7 +32,8 @@ const collector = new (class {
 			cp <= 0x1f &&
 			(this._source.codePointAt(start) === cp ||
 				this._source.slice(start, end).startsWith("\\x") ||
-				this._source.slice(start, end).startsWith("\\u"))
+				this._source.slice(start, end).startsWith("\\u") ||
+				this._source.slice(start, end).startsWith("\\c"))
 		) {
 			this._controlChars.push(`\\x${`0${cp.toString(16)}`.slice(-2)}`);
 		}

--- a/tests/lib/rules/no-control-regex.js
+++ b/tests/lib/rules/no-control-regex.js
@@ -49,6 +49,14 @@ ruleTester.run("no-control-regex", rule, {
 		String.raw`var regex = /\c1/`,
 		String.raw`var regex = /\c$/`,
 		String.raw`var regex = new RegExp('\\c1')`,
+		String.raw`var regex = /\cA/`,
+		String.raw`var regex = /\cz/`,
+		String.raw`var regex = new RegExp('\\cA')`,
+		{ code: String.raw`/\cA/u`, languageOptions: { ecmaVersion: 2015 } },
+		{
+			code: String.raw`/\cA/v`,
+			languageOptions: { ecmaVersion: 2024 },
+		},
 	],
 	invalid: [
 		{
@@ -241,58 +249,11 @@ ruleTester.run("no-control-regex", rule, {
 			],
 		},
 		{
-			code: String.raw`var regex = /\cA/`,
-			errors: [
-				{
-					messageId: "unexpected",
-					data: { controlChars: "\\x01" },
-				},
-			],
-		},
-		{
-			code: String.raw`var regex = /\cz/`,
-			errors: [
-				{
-					messageId: "unexpected",
-					data: { controlChars: "\\x1a" },
-				},
-			],
-		},
-		{
-			code: String.raw`var regex = new RegExp('\\cA')`,
-			errors: [
-				{
-					messageId: "unexpected",
-					data: { controlChars: "\\x01" },
-				},
-			],
-		},
-		{
 			code: String.raw`var regex = /\x1f\cA/`,
 			errors: [
 				{
 					messageId: "unexpected",
-					data: { controlChars: "\\x1f, \\x01" },
-				},
-			],
-		},
-		{
-			code: String.raw`/\cA/u`,
-			languageOptions: { ecmaVersion: 2015 },
-			errors: [
-				{
-					messageId: "unexpected",
-					data: { controlChars: "\\x01" },
-				},
-			],
-		},
-		{
-			code: String.raw`/\cA/v`,
-			languageOptions: { ecmaVersion: 2024 },
-			errors: [
-				{
-					messageId: "unexpected",
-					data: { controlChars: "\\x01" },
+					data: { controlChars: "\\x1f" },
 				},
 			],
 		},

--- a/tests/lib/rules/no-control-regex.js
+++ b/tests/lib/rules/no-control-regex.js
@@ -46,6 +46,9 @@ ruleTester.run("no-control-regex", rule, {
 			code: String.raw`/[\u{20}--B]/v`,
 			languageOptions: { ecmaVersion: 2024 },
 		},
+		String.raw`var regex = /\c1/`,
+		String.raw`var regex = /\c$/`,
+		String.raw`var regex = new RegExp('\\c1')`,
 	],
 	invalid: [
 		{
@@ -234,6 +237,62 @@ ruleTester.run("no-control-regex", rule, {
 					messageId: "unexpected",
 					data: { controlChars: "\\x11" },
 					column: 1,
+				},
+			],
+		},
+		{
+			code: String.raw`var regex = /\cA/`,
+			errors: [
+				{
+					messageId: "unexpected",
+					data: { controlChars: "\\x01" },
+				},
+			],
+		},
+		{
+			code: String.raw`var regex = /\cz/`,
+			errors: [
+				{
+					messageId: "unexpected",
+					data: { controlChars: "\\x1a" },
+				},
+			],
+		},
+		{
+			code: String.raw`var regex = new RegExp('\\cA')`,
+			errors: [
+				{
+					messageId: "unexpected",
+					data: { controlChars: "\\x01" },
+				},
+			],
+		},
+		{
+			code: String.raw`var regex = /\x1f\cA/`,
+			errors: [
+				{
+					messageId: "unexpected",
+					data: { controlChars: "\\x1f, \\x01" },
+				},
+			],
+		},
+		{
+			code: String.raw`/\cA/u`,
+			languageOptions: { ecmaVersion: 2015 },
+			errors: [
+				{
+					messageId: "unexpected",
+					data: { controlChars: "\\x01" },
+				},
+			],
+		},
+		{
+			code: String.raw`/\cA/v`,
+			languageOptions: { ecmaVersion: 2024 },
+			errors: [
+				{
+					messageId: "unexpected",
+					data: { controlChars: "\\x01" },
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #21281

#### What changes did you make? (Give an overview)

Per the discussion on #21281, `\cA`-`\cZ` (and `\ca`-`\cz`) control letter escapes are intentionally **not** flagged by `no-control-regex` — using this form makes the intent to match a control character explicit, unlike the `\x`/`\u`/raw forms the rule targets. No rule logic was changed.

This PR only:
- Documents that control letter escapes are allowed, alongside the existing note about `\t`/`\n`.
- Adds an example to the "correct" code block in the docs.
- Adds `RuleTester` cases (valid) covering `\cA`, `\cz`, invalid-letter forms (`\c1`, `\c$`), the `RegExp` constructor form, and the `u`/`v` flags, plus one case confirming a control letter escape next to a real offender (`\x1f`) doesn't suppress or get merged into that report.

#### Is there anything you'd like reviewers to focus on?

This PR was prepared with AI assistance (Claude Code). I reviewed the rule's actual runtime behavior (via `Linter.verify`) for each new test case before adding it, and ran the full `no-control-regex` test file plus this repo's own ESLint config and `checkRuleFiles` doc validation locally — all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that control-letter escapes are allowed in regular expressions.
  * Added a valid control-letter escape example.

* **Tests**
  * Added coverage for control-letter escapes in regex literals and constructors.
  * Added tests for Unicode-related contexts and invalid combinations involving hexadecimal control escapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->