### PR TITLE
feat: warn when the fix loop reaches the maximum number of fix passes

### DIFF
--- a/docs/src/use/troubleshooting/fix-pass-limit.md
+++ b/docs/src/use/troubleshooting/fix-pass-limit.md
@@ -1,0 +1,33 @@
+---
+title: The fix loop reached the maximum number of fix passes …
+eleventyNavigation:
+    key: fix pass limit
+    parent: troubleshooting
+    title: The fix loop reached the maximum number of fix passes …
+---
+
+## Symptoms
+
+When running ESLint with the `--fix` option, you may see the following warning:
+
+```plaintext
+ESLintMaxAutoFixWarning: The fix loop reached the maximum number of fix passes (10) while fixing path/to/file. Some fixable problems might not have been fixed.
+```
+
+## Cause
+
+ESLint autofixes code in multiple passes, up to a maximum of 10 passes per file. If the fix loop reaches that limit while still applying fixes, ESLint stops to avoid running indefinitely. This warning indicates that not all fixable problems were resolved before the loop stopped.
+
+## Resolution
+
+Common resolutions for this issue include:
+
+- Review the fixable rules enabled for the file and check whether any of them apply fixes that do not converge.
+- If a single rule or a combination of rules keeps producing new fixes in every pass, consider reconfiguring or disabling the most likely offending rule.
+- If the file is generated or third-party code, consider disabling `--fix` for it so that partial fixes are not applied to code that you do not own.
+
+## Resources
+
+For more information, see:
+
+- [Configure Rules](../configure/rules) for documentation on how to configure rules

--- a/docs/src/use/troubleshooting/index.md
+++ b/docs/src/use/troubleshooting/index.md
@@ -12,6 +12,7 @@ This page serves as a reference for common issues working with ESLint.
 ## Configuration
 
 - [`Circular fixes detected …`](./circular-fixes)
+- [`The fix loop reached the maximum number of fix passes …`](./fix-pass-limit)
 - [`TypeError: context.getScope is not a function`](./v9-rule-api-changes)
 
 Issues oftentimes can be resolved by updating to the latest versions of the `eslint` package and any related packages, such as for ESLint shareable configs and plugins.

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -1492,7 +1492,8 @@ class Linter {
 			passNumber = 0,
 			currentText = text,
 			secondPreviousText,
-			previousText;
+			previousText,
+			circularFix = false;
 		const options =
 			typeof filenameOrOptions === "string"
 				? { filename: filenameOrOptions }
@@ -1591,12 +1592,32 @@ class Linter {
 				debug(
 					`Circular fixes detected after pass ${passNumber}. Exiting fix loop.`,
 				);
+				circularFix = true;
 				slots.warningService.emitCircularFixesWarning(
 					options.filename ?? "text",
 				);
 				break;
 			}
 		} while (fixedResult.fixed && passNumber < MAX_AUTOFIX_PASSES);
+
+		/*
+		 * If the fix loop stopped because it reached the maximum number of fix
+		 * passes (`MAX_AUTOFIX_PASSES`) while still applying fixes, then not all
+		 * fixable problems could be resolved within the fix budget. Emit a warning
+		 * so the caller can distinguish this from a fully-fixed result. This does
+		 * not apply to the circular-fix or syntax-error exits, which are handled
+		 * separately above.
+		 */
+		if (
+			passNumber === MAX_AUTOFIX_PASSES &&
+			fixedResult.fixed &&
+			!circularFix
+		) {
+			slots.warningService.emitMaxAutoFixWarning(
+				options.filename ?? "text",
+				MAX_AUTOFIX_PASSES,
+			);
+		}
 
 		/*
 		 * If the last result had fixes, we need to lint again to be sure we have

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -1601,25 +1601,6 @@ class Linter {
 		} while (fixedResult.fixed && passNumber < MAX_AUTOFIX_PASSES);
 
 		/*
-		 * If the fix loop stopped because it reached the maximum number of fix
-		 * passes (`MAX_AUTOFIX_PASSES`) while still applying fixes, then not all
-		 * fixable problems could be resolved within the fix budget. Emit a warning
-		 * so the caller can distinguish this from a fully-fixed result. This does
-		 * not apply to the circular-fix or syntax-error exits, which are handled
-		 * separately above.
-		 */
-		if (
-			passNumber === MAX_AUTOFIX_PASSES &&
-			fixedResult.fixed &&
-			!circularFix
-		) {
-			slots.warningService.emitMaxAutoFixWarning(
-				options.filename ?? "text",
-				MAX_AUTOFIX_PASSES,
-			);
-		}
-
-		/*
 		 * If the last result had fixes, we need to lint again to be sure we have
 		 * the most up-to-date information.
 		 */
@@ -1636,6 +1617,25 @@ class Linter {
 				storeTime(0, { type: "fix" }, slots);
 				slots.times.passes.at(-1).total = endTime(tTotal);
 			}
+		}
+
+		/*
+		 * If the fix loop stopped because it reached the maximum number of fix
+		 * passes (`MAX_AUTOFIX_PASSES`) while still applying fixes, and there are
+		 * still fixable problems left, then not all fixable problems could be
+		 * resolved within the fix budget. Emit a warning so the caller can
+		 * distinguish this from a fully-fixed result. This does not apply to the
+		 * circular-fix or syntax-error exits, which are handled separately above.
+		 */
+		if (
+			passNumber === MAX_AUTOFIX_PASSES &&
+			!circularFix &&
+			fixedResult.messages.some(message => message.fix)
+		) {
+			slots.warningService.emitMaxAutoFixWarning(
+				options.filename ?? "text",
+				MAX_AUTOFIX_PASSES,
+			);
 		}
 
 		// ensure the last result properly reflects if fixes were done

--- a/lib/services/warning-service.js
+++ b/lib/services/warning-service.js
@@ -37,6 +37,20 @@ class WarningService {
 	}
 
 	/**
+	 * Emits a warning when the maximum number of fix passes is reached while fixing a file.
+	 * This method is used by the Linter and is safe to call outside Node.js.
+	 * @param {string} filename The name of the file being fixed.
+	 * @param {number} maxPasses The maximum number of fix passes that were allowed.
+	 * @returns {void}
+	 */
+	emitMaxAutoFixWarning(filename, maxPasses) {
+		this.emitWarning(
+			`The fix loop reached the maximum number of fix passes (${maxPasses}) while fixing ${filename}. Some fixable problems might not have been fixed.`,
+			"ESLintMaxAutoFixWarning",
+		);
+	}
+
+	/**
 	 * Emits a warning when an empty config file has been loaded.
 	 * @param {string} configFilePath The path to the config file.
 	 * @returns {void}

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -9806,6 +9806,15 @@ let c; // var a = "test2";
 			assert.strictEqual(fixResult.output, `${" ".repeat(10)}a`);
 			assert.strictEqual(fixResult.messages.length, 1);
 
+			// Verify the warning was emitted
+			assert(
+				warningService.emitMaxAutoFixWarning.calledOnceWithExactly(
+					"text",
+					10,
+				),
+				"calls `warningService.emitMaxAutoFixWarning()` once with the correct arguments",
+			);
+
 			assert.strictEqual(suppressedMessages.length, 0);
 		});
 

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -9818,6 +9818,65 @@ let c; // var a = "test2";
 			assert.strictEqual(suppressedMessages.length, 0);
 		});
 
+		it("does not emit a max-fix-pass warning when the last fix is applied on the 10th pass", () => {
+			const config = {
+				plugins: {
+					test: {
+						rules: {
+							"add-spaces-until-ten": {
+								meta: {
+									fixable: "whitespace",
+								},
+								create(context) {
+									return {
+										Program(node) {
+											const sourceCode =
+												context.sourceCode;
+											const text =
+												sourceCode.getText(node);
+
+											if (
+												!text.startsWith(" ".repeat(10))
+											) {
+												context.report({
+													node,
+													message:
+														"Add a space before this node.",
+													fix: fixer =>
+														fixer.insertTextBefore(
+															node,
+															" ",
+														),
+												});
+											}
+										},
+									};
+								},
+							},
+						},
+					},
+				},
+				rules: {
+					"test/add-spaces-until-ten": "error",
+				},
+			};
+
+			const fixResult = linter.verifyAndFix("a", config);
+
+			assert.strictEqual(fixResult.fixed, true);
+			assert.strictEqual(fixResult.output, `${" ".repeat(10)}a`);
+			assert.strictEqual(fixResult.messages.length, 0);
+
+			/*
+			 * The fix loop reached the pass limit, but no fixable problems
+			 * remain, so the warning should not be emitted.
+			 */
+			assert.strictEqual(
+				warningService.emitMaxAutoFixWarning.called,
+				false,
+			);
+		});
+
 		it("should throw an error if fix is passed but meta has no `fixable` property", () => {
 			const config = {
 				plugins: {

--- a/tests/lib/services/warning-service.js
+++ b/tests/lib/services/warning-service.js
@@ -48,6 +48,20 @@ describe("WarningService", () => {
 			);
 		});
 
+		it("emitMaxAutoFixWarning", () => {
+			const filename = "/project/file.js";
+			const maxPasses = 10;
+			warningService.emitMaxAutoFixWarning(filename, maxPasses);
+
+			assert(
+				process.emitWarning.calledOnceWithExactly(
+					`The fix loop reached the maximum number of fix passes (${maxPasses}) while fixing ${filename}. Some fixable problems might not have been fixed.`,
+					"ESLintMaxAutoFixWarning",
+				),
+				"Expected process.emitWarning to be called with the correct arguments",
+			);
+		});
+
 		it("emitEmptyConfigWarning", () => {
 			const configFilePath = "/project/eslint.config.js";
 			warningService.emitEmptyConfigWarning(configFilePath);
@@ -120,6 +134,12 @@ describe("WarningService", () => {
 		it("emitCircularFixesWarning", () => {
 			const filename = "/project/file.js";
 			warningService.emitCircularFixesWarning(filename);
+		});
+
+		it("emitMaxAutoFixWarning", () => {
+			const filename = "/project/file.js";
+			const maxPasses = 10;
+			warningService.emitMaxAutoFixWarning(filename, maxPasses);
 		});
 
 		it("emitInactiveFlagWarning", () => {


### PR DESCRIPTION
## Summary

When ESLint runs `--fix`, the fix loop applies fixes across up to 10 passes. If the loop reaches that limit while still applying fixes, it currently stops silently and returns the same result as a fully-fixed run. As a result, callers such as CI cannot distinguish "all fixable problems were fixed" from "the fix budget ran out before all fixes could be applied."

This PR emits a `process.emitWarning()` (type `ESLintMaxAutoFixWarning`) when the fix loop exits at `MAX_AUTOFIX_PASSES` while fixable problems still remain, mirroring the existing `ESLintCircularFixesWarning` warning for circular fixes.

Fixes #21223

## Changes

- `lib/linter/linter.js`: track the circular-fix exit and emit `emitMaxAutoFixWarning()` when the loop stops at `MAX_AUTOFIX_PASSES` while still applying fixes.
- `lib/services/warning-service.js`: add `emitMaxAutoFixWarning(filename, maxPasses)`.
- `tests/lib/linter/linter.js`: assert the new warning is emitted for the "stops fixing after 10 passes" case.
- `tests/lib/services/warning-service.js`: add `emitMaxAutoFixWarning` unit tests.
- `docs/src/use/troubleshooting/fix-pass-limit.md`: add a troubleshooting page for the new warning and link it from the troubleshooting index.

## Testing

Ran the linter and warning-service test suites: 770 tests passing. Verified with `node bin/eslint.js` and Prettier/Markdownlint on the changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a warning when automatic fixes remain applicable after the maximum number of fix passes.
  * Warnings are suppressed when fixes stop because of a circular fix or the final pass resolves all remaining issues.

* **Documentation**
  * Added troubleshooting guidance for maximum autofix-pass warnings, including causes and resolutions.
  * Added the new guidance to the troubleshooting index.

* **Tests**
  * Added coverage for maximum-pass warnings and warning behavior across supported environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->