### PR TITLE
feat: only exempt `new-cap` built-ins that reference the global

### DIFF
--- a/docs/src/rules/new-cap.md
+++ b/docs/src/rules/new-cap.md
@@ -26,6 +26,8 @@ This rule requires constructor names to begin with a capital letter. Certain bui
 * `Symbol`
 * `BigInt`
 
+These identifiers are exempt only when they reference the global built-in, either directly or as a property of the global object (`global`, `globalThis`, `self`, or `window`). `Date.UTC()` is exempt under the same condition.
+
 Examples of **correct** code for this rule:
 
 ::: correct
@@ -36,6 +38,34 @@ Examples of **correct** code for this rule:
 function foo(arg) {
     return Boolean(arg);
 }
+
+function bar(arg) {
+    return globalThis.Boolean(arg);
+}
+
+const time = Date.UTC(2000, 0);
+
+const otherTime = globalThis.Date.UTC(2000, 0);
+```
+
+:::
+
+Examples of **incorrect** code for this rule:
+
+::: incorrect
+
+```js
+/*eslint new-cap: "error"*/
+
+function String(value) {
+    return value + "";
+}
+
+const foo = String(42);
+
+const Date = { UTC() { return 0; } };
+
+const time = Date.UTC(2000, 0);
 ```
 
 :::

--- a/lib/rules/new-cap.js
+++ b/lib/rules/new-cap.js
@@ -15,7 +15,7 @@ const astUtils = require("./utils/ast-utils");
 // Helpers
 //------------------------------------------------------------------------------
 
-const CAPS_ALLOWED = [
+const CAPS_ALLOWED = new Set([
 	"Array",
 	"Boolean",
 	"Date",
@@ -27,7 +27,9 @@ const CAPS_ALLOWED = [
 	"String",
 	"Symbol",
 	"BigInt",
-];
+]);
+
+const GLOBAL_OBJECT_NAMES = new Set(["global", "globalThis", "self", "window"]);
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -84,7 +86,7 @@ module.exports = {
 		defaultOptions: [
 			{
 				capIsNew: true,
-				capIsNewExceptions: CAPS_ALLOWED,
+				capIsNewExceptions: [],
 				newIsCap: true,
 				newIsCapExceptions: [],
 				properties: true,
@@ -106,10 +108,7 @@ module.exports = {
 			? new RegExp(config.newIsCapExceptionPattern, "u")
 			: null;
 
-		const capIsNewExceptions = new Set([
-			...config.capIsNewExceptions,
-			...CAPS_ALLOWED,
-		]);
+		const capIsNewExceptions = new Set(config.capIsNewExceptions);
 		const capIsNewExceptionPattern = config.capIsNewExceptionPattern
 			? new RegExp(config.capIsNewExceptionPattern, "u")
 			: null;
@@ -156,6 +155,43 @@ module.exports = {
 		}
 
 		/**
+		 * Checks if the given node is a reference to the global object
+		 * @param {ASTNode} node Node to check
+		 * @returns {boolean} Returns true if the node references the global object
+		 */
+		function isGlobalObject(node) {
+			return (
+				node.type === "Identifier" &&
+				GLOBAL_OBJECT_NAMES.has(node.name) &&
+				sourceCode.isGlobalReference(node)
+			);
+		}
+
+		/**
+		 * Checks if the given node references a built-in of the global object,
+		 * such as `Date` or `globalThis.Date`
+		 * @param {ASTNode} node Node to check
+		 * @param {string} name Name of the built-in
+		 * @returns {boolean} Returns true if the node references the built-in of the global object
+		 */
+		function isGlobalBuiltIn(node, name) {
+			const expression = astUtils.skipChainExpression(node);
+
+			if (expression.type === "MemberExpression") {
+				return (
+					astUtils.getStaticPropertyName(expression) === name &&
+					isGlobalObject(expression.object)
+				);
+			}
+
+			return (
+				expression.type === "Identifier" &&
+				expression.name === name &&
+				sourceCode.isGlobalReference(expression)
+			);
+		}
+
+		/**
 		 * Check if capitalization is allowed for a CallExpression
 		 * @param {Set<string>} allowedNames Set of allowed callee names
 		 * @param {ASTNode} node CallExpression node
@@ -182,11 +218,8 @@ module.exports = {
 				}
 
 				if (calleeName === "UTC") {
-					// allow if callee is Date.UTC
-					return (
-						callee.object.type === "Identifier" &&
-						callee.object.name === "Date"
-					);
+					// allow if callee is the global `Date.UTC`
+					return isGlobalBuiltIn(callee.object, "Date");
 				}
 			}
 
@@ -248,7 +281,9 @@ module.exports = {
 							node,
 							calleeName,
 							capIsNewExceptionPattern,
-						);
+						) ||
+						(CAPS_ALLOWED.has(calleeName) &&
+							isGlobalBuiltIn(node.callee, calleeName));
 
 					if (!isAllowed) {
 						report(node, "upper");

--- a/tests/lib/rules/new-cap.js
+++ b/tests/lib/rules/new-cap.js
@@ -171,6 +171,72 @@ ruleTester.run("new-cap", rule, {
 			code: "const x = new toLocaleString();",
 			options: [{ newIsCapExceptions: ["toLocaleString"] }],
 		},
+		"globalThis.Array(42);",
+		"globalThis.String(42);",
+		"globalThis['String'](42);",
+		"globalThis?.String(42);",
+		"(globalThis?.String)(42);",
+		{
+			code: "window.String(42);",
+			languageOptions: { globals: { window: "readonly" } },
+		},
+		{
+			code: "self.String(42);",
+			languageOptions: { globals: { self: "readonly" } },
+		},
+		{
+			code: "global.String(42);",
+			languageOptions: { globals: { global: "readonly" } },
+		},
+		{
+			code: "function String(x) { return x; } String(42);",
+			options: [{ capIsNew: false }],
+		},
+		{
+			code: "function String(x) { return x; } String(42);",
+			options: [{ capIsNewExceptions: ["String"] }],
+		},
+		{
+			code: "function String(x) { return x; } String(42);",
+			options: [{ capIsNewExceptionPattern: "^String$" }],
+		},
+		{ code: "obj.String(42);", options: [{ properties: false }] },
+		{
+			code: "obj.String(42);",
+			options: [{ capIsNewExceptions: ["String"] }],
+		},
+		{
+			code: "obj.String(42);",
+			options: [{ capIsNewExceptions: ["obj.String"] }],
+		},
+		{
+			code: "obj.String(42);",
+			options: [{ capIsNewExceptionPattern: "^obj\\." }],
+		},
+		"globalThis.Date.UTC(2000, 0);",
+		"globalThis['Date'].UTC(2000, 0);",
+		"globalThis?.Date.UTC(2000, 0);",
+		"globalThis.Date?.UTC(2000, 0);",
+		{
+			code: "window.Date.UTC(2000, 0);",
+			languageOptions: { globals: { window: "readonly" } },
+		},
+		{
+			code: "self.Date.UTC(2000, 0);",
+			languageOptions: { globals: { self: "readonly" } },
+		},
+		{
+			code: "global.Date.UTC(2000, 0);",
+			languageOptions: { globals: { global: "readonly" } },
+		},
+		{
+			code: "const Date = { UTC() {} }; Date.UTC(2000, 0);",
+			options: [{ properties: false }],
+		},
+		{
+			code: "const Date = { UTC() {} }; Date.UTC(2000, 0);",
+			options: [{ capIsNewExceptions: ["UTC"] }],
+		},
 	],
 	invalid: [
 		{
@@ -517,6 +583,215 @@ ruleTester.run("new-cap", rule, {
 					column: 15,
 					endLine: 1,
 					endColumn: 29,
+				},
+			],
+		},
+		{
+			code: "function String(x) { return x; } String(42);",
+			errors: [
+				{
+					messageId: "upper",
+					line: 1,
+					column: 34,
+					endLine: 1,
+					endColumn: 40,
+				},
+			],
+		},
+		{
+			code: "let Array = () => {}; Array(42);",
+			errors: [
+				{
+					messageId: "upper",
+					line: 1,
+					column: 23,
+					endLine: 1,
+					endColumn: 28,
+				},
+			],
+		},
+		{
+			code: "function foo(Number) { return Number(42); }",
+			errors: [
+				{
+					messageId: "upper",
+					line: 1,
+					column: 31,
+					endLine: 1,
+					endColumn: 37,
+				},
+			],
+		},
+		{
+			code: "import { String } from 'foo'; String(42);",
+			languageOptions: { sourceType: "module" },
+			errors: [
+				{
+					messageId: "upper",
+					line: 1,
+					column: 31,
+					endLine: 1,
+					endColumn: 37,
+				},
+			],
+		},
+		{
+			code: "String(42);",
+			languageOptions: { globals: { String: "off" } },
+			errors: [
+				{
+					messageId: "upper",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 7,
+				},
+			],
+		},
+		{
+			code: "function String(x) { return x; } String(42);",
+			options: [{ properties: false }],
+			errors: [
+				{
+					messageId: "upper",
+					line: 1,
+					column: 34,
+					endLine: 1,
+					endColumn: 40,
+				},
+			],
+		},
+		{
+			code: "const obj = {}; obj.String(42);",
+			errors: [
+				{
+					messageId: "upper",
+					line: 1,
+					column: 21,
+					endLine: 1,
+					endColumn: 27,
+				},
+			],
+		},
+		{
+			code: "obj['Number'](42);",
+			errors: [
+				{
+					messageId: "upper",
+					line: 1,
+					column: 5,
+					endLine: 1,
+					endColumn: 13,
+				},
+			],
+		},
+		{
+			code: "obj?.String(42);",
+			errors: [
+				{
+					messageId: "upper",
+					line: 1,
+					column: 6,
+					endLine: 1,
+					endColumn: 12,
+				},
+			],
+		},
+		{
+			code: "globalThis.foo.String(42);",
+			errors: [
+				{
+					messageId: "upper",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 22,
+				},
+			],
+		},
+		{
+			code: "const window = {}; window.String(42);",
+			languageOptions: { globals: { window: "readonly" } },
+			errors: [
+				{
+					messageId: "upper",
+					line: 1,
+					column: 27,
+					endLine: 1,
+					endColumn: 33,
+				},
+			],
+		},
+		{
+			code: "obj.String(42);",
+			options: [{ capIsNewExceptions: ["Foo"] }],
+			errors: [
+				{
+					messageId: "upper",
+					line: 1,
+					column: 5,
+					endLine: 1,
+					endColumn: 11,
+				},
+			],
+		},
+		{
+			code: "const Date = { UTC() {} }; Date.UTC(2000, 0);",
+			errors: [
+				{
+					messageId: "upper",
+					line: 1,
+					column: 33,
+					endLine: 1,
+					endColumn: 36,
+				},
+			],
+		},
+		{
+			code: "function foo(Date) { return Date.UTC(2000, 0); }",
+			errors: [
+				{
+					messageId: "upper",
+					line: 1,
+					column: 34,
+					endLine: 1,
+					endColumn: 37,
+				},
+			],
+		},
+		{
+			code: "import { Date } from 'foo'; Date?.UTC(2000, 0);",
+			errors: [
+				{
+					messageId: "upper",
+					line: 1,
+					column: 35,
+					endLine: 1,
+					endColumn: 38,
+				},
+			],
+		},
+		{
+			code: "function foo(globalThis) { return globalThis.Date.UTC(2000, 0); }",
+			errors: [
+				{
+					messageId: "upper",
+					line: 1,
+					column: 51,
+					endLine: 1,
+					endColumn: 54,
+				},
+			],
+		},
+		{
+			code: "globalThis.foo.UTC(2000, 0);",
+			errors: [
+				{
+					messageId: "upper",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 19,
 				},
 			],
 		},

--- a/tests/lib/rules/new-cap.js
+++ b/tests/lib/rules/new-cap.js
@@ -723,6 +723,18 @@ ruleTester.run("new-cap", rule, {
 			],
 		},
 		{
+			code: "const globalThis = {}; globalThis.String(42);",
+			errors: [
+				{
+					messageId: "upper",
+					line: 1,
+					column: 35,
+					endLine: 1,
+					endColumn: 41,
+				},
+			],
+		},
+		{
 			code: "obj.String(42);",
 			options: [{ capIsNewExceptions: ["Foo"] }],
 			errors: [

--- a/tests/lib/rules/new-cap.js
+++ b/tests/lib/rules/new-cap.js
@@ -710,6 +710,18 @@ ruleTester.run("new-cap", rule, {
 			],
 		},
 		{
+			code: "globalThis.Foo();",
+			errors: [
+				{
+					messageId: "upper",
+					line: 1,
+					column: 12,
+					endLine: 1,
+					endColumn: 15,
+				},
+			],
+		},
+		{
 			code: "const window = {}; window.String(42);",
 			languageOptions: { globals: { window: "readonly" } },
 			errors: [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

`capIsNew` no longer automatically exempts the built-in constructor names (`Array`, `Boolean`, `Date`, `Error`, `Function`, `Number`, `Object`, `RegExp`, `String`, `Symbol`, `BigInt`). They are now exempt only when they reference the global, either directly, or as a property of the global object (`globalThis`, `window`, `self`, `global`).

Fixes #21268

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of uppercase function calls and built-in exceptions.
  - Correctly handles locally defined, imported, shadowed, and disabled global names.
  - Improved support for property calls, optional chaining, and global-object-qualified built-ins.
  - Recognizes `Date.UTC` only when accessed through a global `Date` object.

- **Documentation**
  - Clarified when built-in constructor exceptions apply, with examples for global and shadowed identifiers.

- **Tests**
  - Expanded coverage for valid and invalid uppercase-call scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->