### PR TITLE
ci: restore EMFILE test on Node.js 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,10 +91,6 @@ jobs:
             - name: Fuzz Test
               run: node Makefile fuzz
             - name: Test EMFILE Handling
-              # Node.js 26.8+ no longer reliably triggers `EMFILE` for small-file reads.
-              # See: https://github.com/nodejs/node/pull/65327
-              # TODO: Re-enable after replacing this with deterministic error injection.
-              if: matrix.node != '26.x'
               run: npm run test:emfile
 
     test_on_browser:

--- a/tools/check-emfile-handling.js
+++ b/tools/check-emfile-handling.js
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 const fs = require("node:fs");
-const { readFile } = require("node:fs/promises");
+const { writeFile } = require("node:fs/promises");
 const { execSync } = require("node:child_process");
 const os = require("node:os");
 
@@ -76,7 +76,11 @@ function generateFiles() {
 }
 
 /**
- * Generates an EMFILE error by reading all files in the output directory.
+ * Generates an EMFILE error by writing to all files in the output directory.
+ * Since Node.js 26.8.0, `readFile()` runs open, fstat, read, and close in a
+ * single thread pool task, so concurrent reads no longer accumulate file
+ * descriptors and cannot trigger EMFILE (https://github.com/nodejs/node/pull/65327).
+ * Concurrent writes still can, and writing is also what `--fix` does above.
  * @returns {undefined}
  */
 async function generateEmFileError() {
@@ -84,7 +88,10 @@ async function generateEmFileError() {
 		Array.from({ length: FILE_COUNT }, (_, i) => {
 			const fileName = `file_${i}.js`;
 
-			return readFile(`${OUTPUT_DIRECTORY}/${fileName}`);
+			return writeFile(
+				`${OUTPUT_DIRECTORY}/${fileName}`,
+				"// Overwritten",
+			);
 		}),
 	);
 	const failedResult = results.find(({ status }) => status === "rejected");


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain: Restore the EMFILE check on Node.js 26 by switching `generateEmFileError()` from `readFile()` to `writeFile()`.

Fixes #21274.

#### What changes did you make? (Give an overview)

This PR restores the EMFILE check on Node.js 26 by changing its probe from `readFile()` to `writeFile()`.

Since Node.js 26.8.0, small path-based `readFile()` calls perform open, fstat, read, and close in a single thread pool task (nodejs/node#65327). Concurrent reads therefore no longer accumulate file descriptors. As a result, `generateEmFileError()` stopped raising EMFILE and failed with the error `EMFILE error not encountered.` #21265 temporarily skipped the check on Node.js 26.

Specifically, this PR:

* Replaces the `readFile()` probe with `writeFile()`. Path-based writes still open and close files in separate thread pool tasks in current Node.js releases, allowing concurrent writes to exhaust file descriptors. This also reflects the `--fix` workload exercised earlier in the script.
* Removes the Node.js 26 skip and its TODO from the `Test EMFILE Handling` step in `.github/workflows/ci.yml`.

I ran `node tools/check-emfile-handling.js`, the command behind `npm run test:emfile`, on macOS with both soft and hard `RLIMIT_NOFILE` set to 512. I tested Node.js 24.18.0, 26.7.0, and 26.8.1. In all three cases, the ESLint run passed and the probe raised EMFILE.

#### Is there anything you'd like reviewers to focus on?

##### Windows behavior

Does `writeFile()` reliably raise EMFILE on `windows-latest`, where this CI step also runs? The script notes that Windows has no hard file-descriptor limit, and I could not test it locally.

##### Probe contents

The probe overwrites each generated file with `// Overwritten`. The content is arbitrary because the probe runs after ESLint and the directory is removed on exit. I kept it as a valid line comment in case the files are inspected.

##### Future Node.js behavior

As [noted on the issue](https://github.com/eslint/eslint/issues/21274#issuecomment-5512115984), nodejs/node#65489 would batch small path-based `writeFile()` calls into a single thread pool task. If that change ships in a Node.js version covered by ESLint CI, this probe will stop raising EMFILE. The check will then fail with the error `EMFILE error not encountered.` This PR restores the check for current Node.js releases, but it is not a permanent way to trigger EMFILE.

A raw `open()` probe would keep triggering EMFILE, but it would no longer demonstrate that ESLint's actual read or write workload can exhaust file descriptors. If maintainers prefer a durable check now, deterministic EMFILE/ENFILE injection is the better direction.

The optimization proposed in nodejs/node#65489 does not cover every promise-based write. Data larger than 512 KiB stays on the existing `FileHandle` path. Other activity in the process can also exhaust file descriptors. The optimization alone therefore would not establish that the retry handling in `ESLint.outputFixes()` can be removed.

Disclosure: I'm a participant of [open source contribution program OSSCA](https://github.com/eslint-ossca).

<!-- markdownlint-disable-file MD004 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved reliability of file-descriptor limit testing by validating concurrent file writes.
  - Expanded EMFILE handling checks to run across all supported Node.js versions, including Node.js 26.x.
  - Increased confidence that file-system resource exhaustion is handled consistently across runtime versions.
  - Updated test coverage to better reflect current Node.js behavior when many files are accessed concurrently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->