### PR TITLE
fix: no-unreachable reports false positives on module export declarations

### DIFF
--- a/lib/rules/no-unreachable.js
+++ b/lib/rules/no-unreachable.js
@@ -239,9 +239,6 @@ module.exports = {
 
 			WhileStatement: reportIfUnreachable,
 			WithStatement: reportIfUnreachable,
-			ExportNamedDeclaration: reportIfUnreachable,
-			ExportDefaultDeclaration: reportIfUnreachable,
-			ExportAllDeclaration: reportIfUnreachable,
 
 			"Program:exit"() {
 				reportIfUnreachable();

--- a/tests/lib/rules/no-unreachable.js
+++ b/tests/lib/rules/no-unreachable.js
@@ -95,6 +95,20 @@ ruleTester.run("no-unreachable", rule, {
 			code: "class C extends B { static foo = reachable; constructor() {} }",
 			languageOptions: { ecmaVersion: 2022 },
 		},
+
+		// https://github.com/eslint/eslint/issues/21295
+		{
+			code: "throw new Error();\nexport function foo() {}\nexport { foo as bar };\nexport * from './other.js';\nexport var x;",
+			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+		},
+		{
+			code: "throw new Error(); export default 1;",
+			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+		},
+		{
+			code: "export default function foo() {} throw new Error(); export { foo };",
+			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+		},
 	],
 	invalid: [
 		{
@@ -703,6 +717,21 @@ ruleTester.run("no-unreachable", rule, {
 					column: 34,
 					endLine: 1,
 					endColumn: 36,
+				},
+			],
+		},
+
+		{
+			// regression: regular statements after throw still flagged (https://github.com/eslint/eslint/issues/21295)
+			code: "throw new Error();\nfoo();",
+			languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+			errors: [
+				{
+					messageId: "unreachableCode",
+					line: 2,
+					column: 1,
+					endLine: 2,
+					endColumn: 7,
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What changes did you make? (Give an overview)

Export declarations in ECMAScript modules are not evaluated at their source location. They are hoisted and resolved during module instantiation, before the module body runs. The `no-unreachable` rule was previously treating them as ordinary statements and reporting false positives when they appeared after `throw`, `return`, `break`, or `continue`.

For example, this now reports no errors:

```js
throw new Error();
export function foo() {}
export { foo as bar };
export * from './other.js';
export var x;
```

`export var x` is still flagged because `var` declarations *are* hoisted bindings and the declaration occurs at that source position for the purposes of variable hoisting. The fix only removes the explicit `Export*` handlers; `VariableDeclaration` continues to be reported through its existing path.

The fix is one line: remove the three `Export*` selector registrations from `lib/rules/no-unreachable.js`. New regression tests cover both the issue example and the continued reporting of regular statements (e.g. `throw new Error(); foo();`).

#### Is there anything you'd like reviewers to focus on?

Whether the `export var` case should also be left alone — see the comment in the test file. My read of the spec is that the *binding* `x` is reachable (it's hoisted) so the existing `VariableDeclaration` behavior is correct, but happy to revisit if maintainers prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed incorrect unreachable-code warnings for named, default, and namespace export declarations that follow a `throw` statement.
  - Continued reporting unreachable ordinary statements after a `throw`, preserving expected validation behavior.
- **Tests**
  - Added coverage for export declarations and regular statements following `throw` statements in module code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->