### PR TITLE
fix: don't report `__proto__` properties in `object-shorthand`

### DIFF
--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -70,6 +70,19 @@ function isStringLiteral(node) {
 }
 
 /**
+ * Determines whether the key of a property in an object literal is a non-computed `__proto__`.
+ * @param {ASTNode} property Property AST node
+ * @returns {boolean} True if the key is a non-computed `__proto__`
+ * @private
+ */
+function isProtoKey(property) {
+	return (
+		!property.computed &&
+		astUtils.getStaticPropertyName(property) === "__proto__"
+	);
+}
+
+/**
  * Determines if the property is a shorthand or not.
  * @param {ASTNode} property Property AST node
  * @returns {boolean} True if the property is considered shorthand, false if not.
@@ -89,6 +102,9 @@ function isShorthand(property) {
 function isRedundant(property) {
 	const value = property.value;
 
+	if (isProtoKey(property)) {
+		return false;
+	}
 	if (value.type === "FunctionExpression") {
 		return !value.id; // Only anonymous should be shorthand method.
 	}
@@ -493,6 +509,10 @@ module.exports = {
 
 				// getters and setters are ignored
 				if (node.kind === "get" || node.kind === "set") {
+					return;
+				}
+
+				if (isProtoKey(node)) {
 					return;
 				}
 

--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -71,6 +71,11 @@ function isStringLiteral(node) {
 
 /**
  * Determines whether the key of a property in an object literal is a non-computed `__proto__`.
+ * `{ __proto__: foo }` and `{ "__proto__": foo }` set the object's prototype, while the concise
+ * forms `{ __proto__ }` and `{ __proto__() {} }` define an own property named `__proto__`, so
+ * converting between the two forms changes behavior in either direction.
+ * Computed keys are excluded because `{ ["__proto__"]: foo }` and `{ ["__proto__"]() {} }` both
+ * define an own property, which makes that conversion safe.
  * @param {ASTNode} property Property AST node
  * @returns {boolean} True if the key is a non-computed `__proto__`
  * @private

--- a/tests/lib/rules/object-shorthand.js
+++ b/tests/lib/rules/object-shorthand.js
@@ -483,6 +483,30 @@ ruleTester.run("object-shorthand", rule, {
 		"({ val: /**\n  *  @type   {Object} options\n  */ (val) })",
 		"({ val: /**\n\t *\t@type\t{Array}\n\t */ (val) })",
 		"({ val: /**\n   *\n   * @type {Function}\n   * @param {string} name\n   */ (val) })",
+		"const obj = { __proto__: function () {} };",
+		"const obj = { '__proto__': function () {} };",
+		"const obj = { __proto__: __proto__ };",
+		"const obj = { '__proto__': __proto__ };",
+		{
+			code: "const obj = { '__proto__'() {} };",
+			options: ["always", { avoidQuotes: true }],
+		},
+		{
+			code: "const obj = { __proto__() {} };",
+			options: ["never"],
+		},
+		{
+			code: "const obj = { __proto__ };",
+			options: ["never"],
+		},
+		{
+			code: "const obj = { __proto__: __proto__ };",
+			options: ["consistent-as-needed"],
+		},
+		{
+			code: "const obj = { __proto__: function () {} };",
+			options: ["consistent-as-needed"],
+		},
 	],
 	invalid: [
 		{
@@ -1406,6 +1430,22 @@ ruleTester.run("object-shorthand", rule, {
 		{
 			code: "({ val: /**\n   *\n   * @param {string} name\n   * @returns {number}\n   */ (val) })",
 			errors: [PROPERTY_ERROR],
+		},
+		{
+			code: "const obj = { ['__proto__']: function () {} };",
+			output: "const obj = { ['__proto__'] () {} };",
+			errors: [METHOD_ERROR],
+		},
+		{
+			code: "const obj = { ['__proto__']() {} };",
+			output: "const obj = { ['__proto__']: function() {} };",
+			options: ["never"],
+			errors: [LONGFORM_METHOD_ERROR],
+		},
+		{
+			code: "const obj = { __proto__: __proto__, a };",
+			options: ["consistent"],
+			errors: [MIXED_SHORTHAND_ERROR],
 		},
 	],
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->

```js
export default [{
  rules: {
    "object-shorthand": "error"
   }
}];
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
const a = { __proto__: function () {} };
const b = { __proto__: __proto__ };
```

**What did you expect to happen?**

No errors. A non-computed `__proto__` key in an object literal is a prototype setter, not an ordinary property, so there is no shorthand form that preserves its meaning.

**What actually happened? Please include the actual, raw output from ESLint.**

Both are reported and autofixed into code that behaves differently.

#### What changes did you make? (Give an overview)

- `Property:exit` returns early for such properties.
- `isRedundant()` returns false for them.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated object-shorthand validation to correctly handle non-computed `__proto__` properties.
  - These properties are no longer incorrectly reported as redundant or automatically converted to shorthand syntax.
  - Computed, quoted, shorthand, and method forms continue to be evaluated according to the configured rule options.

- **Tests**
  - Added coverage for `__proto__` properties and methods across supported configurations, including valid cases, reported errors, and autofixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->