### PR TITLE
fix: ignore `__proto__` properties in `prefer-object-spread`

### DIFF
--- a/lib/rules/prefer-object-spread.js
+++ b/lib/rules/prefer-object-spread.js
@@ -7,6 +7,7 @@
 
 const { CALL, ReferenceTracker } = require("@eslint-community/eslint-utils");
 const {
+	getStaticPropertyName,
 	isCommaToken,
 	isOpeningParenToken,
 	isClosingParenToken,
@@ -55,6 +56,39 @@ function hasArgumentsWithAccessors(node) {
 	return node.arguments
 		.filter(arg => arg.type === "ObjectExpression")
 		.some(hasAccessors);
+}
+
+/**
+ * Determines whether the given node is a property with a `__proto__` key.
+ * `Object.assign` copies properties with `[[Set]]`, so an own `__proto__` property on a
+ * source sets the target's prototype, while object spread defines an own property.
+ * @param {ASTNode} node Node to check.
+ * @returns {boolean} `true` if the node is a property named `__proto__`.
+ */
+function isProtoProperty(node) {
+	return (
+		node.type === "Property" && getStaticPropertyName(node) === "__proto__"
+	);
+}
+
+/**
+ * Determines whether the given object expression node has a `__proto__` property.
+ * @param {ASTNode} node `ObjectExpression` node to check.
+ * @returns {boolean} `true` if the node has at least one `__proto__` property.
+ */
+function hasProtoProperty(node) {
+	return node.properties.some(isProtoProperty);
+}
+
+/**
+ * Determines whether the given call expression node has object expression arguments with `__proto__` properties.
+ * @param {ASTNode} node `CallExpression` node to check.
+ * @returns {boolean} `true` if the node has at least one argument that is an object expression with a `__proto__` property.
+ */
+function hasArgumentsWithProtoProperty(node) {
+	return node.arguments
+		.filter(arg => arg.type === "ObjectExpression")
+		.some(hasProtoProperty);
 }
 
 /**
@@ -309,7 +343,8 @@ module.exports = {
 						!hasArraySpread(refNode) &&
 						!(
 							refNode.arguments.length > 1 &&
-							hasArgumentsWithAccessors(refNode)
+							(hasArgumentsWithAccessors(refNode) ||
+								hasArgumentsWithProtoProperty(refNode))
 						)
 					) {
 						const messageId =

--- a/lib/rules/prefer-object-spread.js
+++ b/lib/rules/prefer-object-spread.js
@@ -60,8 +60,13 @@ function hasArgumentsWithAccessors(node) {
 
 /**
  * Determines whether the given node is a property with a `__proto__` key.
- * `Object.assign` copies properties with `[[Set]]`, so an own `__proto__` property on a
- * source sets the target's prototype, while object spread defines an own property.
+ * Such a property can't be inlined into an object literal, because `__proto__` behaves
+ * differently in the two positions, and in opposite directions:
+ * - A `__proto__:` initializer creates no own property, so `Object.assign` doesn't copy it
+ *   and the prototype is unaffected. Inlined into an object literal, it sets the prototype.
+ * - Any other form (computed, shorthand, or method) creates an own property, which
+ *   `Object.assign` copies with `[[Set]]`, triggering the `__proto__` setter and changing
+ *   the target's prototype. Inlined into an object literal, it is an ordinary own property.
  * @param {ASTNode} node Node to check.
  * @returns {boolean} `true` if the node is a property named `__proto__`.
  */

--- a/lib/rules/prefer-object-spread.js
+++ b/lib/rules/prefer-object-spread.js
@@ -60,8 +60,8 @@ function hasArgumentsWithAccessors(node) {
 
 /**
  * Determines whether the given node is a property with a `__proto__` key.
- * Such a property can't be inlined into an object literal, because `__proto__` behaves
- * differently in the two positions, and in opposite directions:
+ * Such a property in a source object can't be inlined into the target literal, because
+ * `__proto__` behaves differently in the two positions, and in opposite directions:
  * - A `__proto__:` initializer creates no own property, so `Object.assign` doesn't copy it
  *   and the prototype is unaffected. Inlined into an object literal, it sets the prototype.
  * - Any other form (computed, shorthand, or method) creates an own property, which
@@ -86,12 +86,16 @@ function hasProtoProperty(node) {
 }
 
 /**
- * Determines whether the given call expression node has object expression arguments with `__proto__` properties.
+ * Determines whether the given call expression node has object expression source arguments (all but the first) with `__proto__` properties.
+ * The first argument is not checked. It is the target of the assignment, and its properties are
+ * inlined into the resulting object literal with the same meaning they already had. Properties of
+ * the other arguments are copied by `Object.assign` with `[[Set]]`, and that is the step the autofix removes.
  * @param {ASTNode} node `CallExpression` node to check.
- * @returns {boolean} `true` if the node has at least one argument that is an object expression with a `__proto__` property.
+ * @returns {boolean} `true` if the node has at least one source argument that is an object expression with a `__proto__` property.
  */
 function hasArgumentsWithProtoProperty(node) {
 	return node.arguments
+		.slice(1)
 		.filter(arg => arg.type === "ObjectExpression")
 		.some(hasProtoProperty);
 }

--- a/tests/lib/rules/prefer-object-spread.js
+++ b/tests/lib/rules/prefer-object-spread.js
@@ -98,6 +98,14 @@ ruleTester.run("prefer-object-spread", rule, {
 		"Object.assign({}, { set a(val) {} })",
 		"Object.assign({}, { foo: 'bar', get a() {} }, {})",
 		"Object.assign({ foo }, bar, {}, { baz: 'quux', set a(val) {}, quuux }, {})",
+
+		// ignore Object.assign() with > 1 arguments if any of the arguments is an object expression with a `__proto__` property
+		"Object.assign({}, { __proto__: proto })",
+		'Object.assign({}, { "__proto__": proto })',
+		'Object.assign({}, { ["__proto__"]: proto })',
+		"Object.assign({}, { __proto__() {} })",
+		"Object.assign({ __proto__: proto }, foo)",
+		'Object.assign({}, foo, { ["__proto__"]: proto })',
 	],
 
 	invalid: [
@@ -978,6 +986,30 @@ ruleTester.run("prefer-object-spread", rule, {
 		{
 			code: "Object.assign({ get a() {}, set b(val) {} })",
 			output: "({get a() {}, set b(val) {}})",
+			errors: [
+				{
+					messageId: "useLiteralMessage",
+					line: 1,
+					column: 1,
+				},
+			],
+		},
+
+		// report Object.assign() with a `__proto__` property if the function call has only 1 argument
+		{
+			code: "Object.assign({ __proto__: proto })",
+			output: "({__proto__: proto})",
+			errors: [
+				{
+					messageId: "useLiteralMessage",
+					line: 1,
+					column: 1,
+				},
+			],
+		},
+		{
+			code: 'Object.assign({ ["__proto__"]: proto })',
+			output: '({["__proto__"]: proto})',
 			errors: [
 				{
 					messageId: "useLiteralMessage",

--- a/tests/lib/rules/prefer-object-spread.js
+++ b/tests/lib/rules/prefer-object-spread.js
@@ -104,6 +104,7 @@ ruleTester.run("prefer-object-spread", rule, {
 		'Object.assign({}, { "__proto__": proto })',
 		'Object.assign({}, { ["__proto__"]: proto })',
 		"Object.assign({}, { __proto__() {} })",
+		"Object.assign({}, { __proto__ })",
 		"Object.assign({ __proto__: proto }, foo)",
 		'Object.assign({}, foo, { ["__proto__"]: proto })',
 	],

--- a/tests/lib/rules/prefer-object-spread.js
+++ b/tests/lib/rules/prefer-object-spread.js
@@ -99,14 +99,14 @@ ruleTester.run("prefer-object-spread", rule, {
 		"Object.assign({}, { foo: 'bar', get a() {} }, {})",
 		"Object.assign({ foo }, bar, {}, { baz: 'quux', set a(val) {}, quuux }, {})",
 
-		// ignore Object.assign() with > 1 arguments if any of the arguments is an object expression with a `__proto__` property
+		// ignore Object.assign() with > 1 arguments if any of the source arguments is an object expression with a `__proto__` property
 		"Object.assign({}, { __proto__: proto })",
 		'Object.assign({}, { "__proto__": proto })',
 		'Object.assign({}, { ["__proto__"]: proto })',
 		"Object.assign({}, { __proto__() {} })",
 		"Object.assign({}, { __proto__ })",
-		"Object.assign({ __proto__: proto }, foo)",
 		'Object.assign({}, foo, { ["__proto__"]: proto })',
+		"Object.assign({ __proto__: proto }, { __proto__: other })",
 	],
 
 	invalid: [
@@ -1014,6 +1014,63 @@ ruleTester.run("prefer-object-spread", rule, {
 			errors: [
 				{
 					messageId: "useLiteralMessage",
+					line: 1,
+					column: 1,
+				},
+			],
+		},
+
+		// report Object.assign() with a `__proto__` property in the first argument (the target), as its meaning doesn't change
+		{
+			code: "Object.assign({ __proto__: proto }, foo)",
+			output: "({__proto__: proto, ...foo})",
+			errors: [
+				{
+					messageId: "useSpreadMessage",
+					line: 1,
+					column: 1,
+				},
+			],
+		},
+		{
+			code: 'Object.assign({ "__proto__": proto }, foo)',
+			output: '({"__proto__": proto, ...foo})',
+			errors: [
+				{
+					messageId: "useSpreadMessage",
+					line: 1,
+					column: 1,
+				},
+			],
+		},
+		{
+			code: 'Object.assign({ ["__proto__"]: proto }, { a: 1 })',
+			output: '({["__proto__"]: proto, a: 1})',
+			errors: [
+				{
+					messageId: "useSpreadMessage",
+					line: 1,
+					column: 1,
+				},
+			],
+		},
+		{
+			code: "Object.assign({ __proto__ }, foo)",
+			output: "({__proto__, ...foo})",
+			errors: [
+				{
+					messageId: "useSpreadMessage",
+					line: 1,
+					column: 1,
+				},
+			],
+		},
+		{
+			code: "Object.assign({ __proto__() {} }, { a: 1 })",
+			output: "({__proto__() {}, a: 1})",
+			errors: [
+				{
+					messageId: "useSpreadMessage",
 					line: 1,
 					column: 1,
 				},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What parser are you using (place an "X" next to just one item)?**

[x] `Default (Espree)`
[ ] `@typescript-eslint/parser`
[ ] `@babel/eslint-parser`
[ ] `vue-eslint-parser`
[ ] `@angular-eslint/template-parser`
[ ] `Other`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->

```js
export default [{
  rules: {
    "prefer-object-spread": "error"
  }
}];
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
const proto = { tag: "proto" };

const a = Object.assign({}, { ["__proto__"]: proto });
const b = Object.assign({}, { __proto__: proto });
```

**What did you expect to happen?**

No errors. `Object.assign()` and object spread are not interchangeable when a `__proto__` property is involved.

**What actually happened? Please include the actual, raw output from ESLint.**

Both are reported and autofixed into code that behaves differently.

#### What changes did you make? (Give an overview)

Extended the existing accessor bail-out so a call with more than one argument is also not reported when one of its object literal arguments has a `__proto__` property.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of `Object.assign` transformations involving `__proto__` properties.
  - Prevents unsafe autofixes when source objects contain accessors or `__proto__` properties.
  - Correctly preserves target-object properties while converting eligible calls to object spread syntax.
  - Improved detection of static, quoted, computed, shorthand, and method-style `__proto__` properties.
  - Ensures eligible calls continue to be reported and converted without altering the target object’s properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->