### PR TITLE
docs: note that --cache can serve stale results for cross-file rules

### DIFF
--- a/docs/src/use/command-line-interface.md
+++ b/docs/src/use/command-line-interface.md
@@ -712,6 +712,14 @@ If you run ESLint with `--cache` and then run ESLint without `--cache`, the `.es
 
 Autofixed files are not placed in the cache. Subsequent linting that does not trigger an autofix will place it in the cache.
 
+::: warning
+
+ESLint determines whether a cached result is still valid from the file itself (its contents or metadata, depending on `--cache-strategy`) and the configuration. It does not track dependencies between files, so a file's cached results are reused even when another file it depends on has changed. Rules whose results depend on other files, such as type-aware rules and rules that resolve imports across modules, can therefore report stale results.
+
+For example, if a module is changed in a way that introduces a problem in an unchanged file that imports it, `--cache` does not report that problem until the importing file or the configuration changes. The opposite can also happen: a problem that has already been fixed in another file continues to be reported. Run ESLint without `--cache` when you need accurate results from such rules. See [Can I use ESLint's `--cache` with typescript-eslint?](https://typescript-eslint.io/troubleshooting/faqs/eslint/#can-i-use-eslints---cache-with-typescript-eslint) for more details.
+
+:::
+
 ##### `--cache` example
 
 {{ npx_tabs ({


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

Fixes #21219

#### What changes did you make? (Give an overview)

Added a warning callout to the `--cache` subsection of the Caching section. It explains that cache validity is based on the linted file and the configuration, with no tracking of dependencies between files, so rules that depend on other files, such as type-aware rules and rules that resolve imports across modules, can report stale results in either direction. Links to typescript-eslint's FAQ entry, as suggested in the issue.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that `--cache` validates results against the individual file and configuration, but does not track cross-file dependencies.
  * Added examples of type-aware and import-resolving rules that may produce stale cached results after dependency changes.
  * Added links to relevant rule documentation.
  * Recommended running ESLint without caching when dependency-sensitive accuracy is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->