### PR TITLE
fix: make TimePass.parse optional in types and docs

### DIFF
--- a/docs/src/extend/stats.md
+++ b/docs/src/extend/stats.md
@@ -30,10 +30,10 @@ The `Stats` value is the timing information of each lint run. The `stats` proper
   The number of times ESLint has applied at least one fix after linting.
 - `times` (`{ passes: TimePass[] }`)<br>
   The times spent on (parsing, fixing, linting) a file, where the linting refers to the timing information for each rule.
-    - `TimePass` (`{ parse: ParseTime, rules?: Record<string, RuleTime>, fix: FixTime, total: number }`)<br>
+    - `TimePass` (`{ parse?: ParseTime, rules?: Record<string, RuleTime>, fix: FixTime, total: number }`)<br>
       An object containing the times spent on (parsing, fixing, linting)
         - `ParseTime` (`{ total: number }`)<br>
-          The total time that is spent when parsing a file.
+          The total time that is spent when parsing a file. The `parse` property is omitted if no parsing was performed, for example, when a processor's `preprocess()` method returns an empty array.
         - `RuleTime` (`{ total: number }`)<br>
           The total time that is spent on a rule.
         - `FixTime` (`{ total: number }`)<br>

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -1125,8 +1125,9 @@ export namespace Linter {
 	interface TimePass {
 		/**
 		 * The parse object containing all parse time information.
+		 * If no parsing was performed, the property is omitted.
 		 */
-		parse: { total: number };
+		parse?: { total: number };
 
 		/**
 		 * The rules object containing all lint time information for each rule.

--- a/tests/lib/eslint/eslint.js
+++ b/tests/lib/eslint/eslint.js
@@ -10644,6 +10644,47 @@ describe("ESLint", () => {
 				true,
 			);
 		});
+
+		it("Should omit parse stats when a processor returns no code blocks", async () => {
+			const engine = new ESLint({
+				overrideConfigFile: true,
+				stats: true,
+				overrideConfig: {
+					files: ["**/*.txt"],
+					processor: {
+						preprocess() {
+							return [];
+						},
+						postprocess() {
+							return [];
+						},
+					},
+				},
+			});
+			const results = await engine.lintText("plain text", {
+				filePath: "empty.txt",
+			});
+
+			assert.deepStrictEqual(results[0].messages, []);
+			assert.strictEqual(results[0].stats.fixPasses, 0);
+			assert.strictEqual(results[0].stats.times.passes.length, 1);
+			assert.strictEqual(
+				Object.hasOwn(results[0].stats.times.passes[0], "parse"),
+				false,
+			);
+			assert.strictEqual(
+				Object.hasOwn(results[0].stats.times.passes[0], "rules"),
+				false,
+			);
+			assert.deepStrictEqual(results[0].stats.times.passes[0].fix, {
+				total: 0,
+			});
+			assert.strictEqual(
+				isNumber(results[0].stats.times.passes[0].total),
+				true,
+			);
+			assert.ok(results[0].stats.times.passes[0].total >= 0);
+		});
 	});
 
 	describe("getRulesMetaForResults()", () => {

--- a/tests/lib/types/types.test.mts
+++ b/tests/lib/types/types.test.mts
@@ -1294,7 +1294,13 @@ linter.getFixPassCount(); // $ExpectType number
 (index: number, ruleId: string) => {
 	const pass = linter.getTimes().passes[index];
 	pass.fix.total; // $ExpectType number
-	pass.parse.total; // $ExpectType number
+	pass.parse?.total; // $ExpectType number | undefined
+	// @ts-expect-error -- parse may be omitted
+	pass.parse.total;
+	if (pass.parse) {
+		pass.parse.total; // $ExpectType number
+	}
+	delete pass.parse;
 	pass.rules![ruleId].total; // $ExpectType number
 	delete pass.rules;
 	pass.total; // $ExpectType number
@@ -1799,7 +1805,7 @@ for (const result of results) {
 	result.output = "foo";
 
 	result.stats = {
-		fixPasses: 2,
+		fixPasses: 3,
 		times: {
 			passes: [
 				{
@@ -1812,6 +1818,10 @@ for (const result of results) {
 					rules: { foo: { total: 0.5 } },
 					fix: { total: 5 },
 					total: 9,
+				},
+				{
+					fix: { total: 0 },
+					total: 1,
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[x] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This PR fixes #21293 and adds test cases for it.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Linter statistics now accurately omit parsing and rule details when no code blocks are produced.
  - Statistics continue to report fix passes, fixes, and total duration correctly, including zero-fix passes.

- **Documentation**
  - Clarified when the parsing statistics are unavailable.

- **Type Definitions**
  - Updated linter statistics typings to indicate that parsing details may be omitted when no parsing occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->