### PR TITLE
docs: standardize no-iterator rule documentation

### DIFF
--- a/docs/src/rules/no-iterator.md
+++ b/docs/src/rules/no-iterator.md
@@ -1,26 +1,19 @@
 ---
 title: no-iterator
 rule_type: suggestion
+related_rules:
+- no-proto
 further_reading:
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators
 - https://compat-table.github.io/compat-table/non-standard/#test-__iterator__
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#Object_methods
 ---
 
-
-The `__iterator__` property was a SpiderMonkey extension to JavaScript that could be used to create custom iterators that are compatible with JavaScript's `for in` and `for each` constructs. However, this property is now obsolete, so it should not be used. Here's an example of how this used to work:
-
-```js
-Foo.prototype.__iterator__ = function() {
-    return new FooIterator(this);
-}
-```
-
-You should use ECMAScript 6 iterators and generators instead.
+The `__iterator__` property was a SpiderMonkey extension to JavaScript that could be used to create custom iterators compatible with JavaScript's `for in` and `for each` constructs. This property is now obsolete and not supported across all environments. Use ECMAScript 6 iterators and generators instead.
 
 ## Rule Details
 
-This rule is aimed at preventing errors that may arise from using the `__iterator__` property, which is not implemented in several browsers. As such, it will warn whenever it encounters the `__iterator__` property.
+This rule disallows the use of the `__iterator__` property. It will warn whenever it encounters a `__iterator__` property access or assignment.
 
 Examples of **incorrect** code for this rule:
 
@@ -36,7 +29,6 @@ Foo.prototype.__iterator__ = function() {
 foo.__iterator__ = function () {};
 
 foo["__iterator__"] = function () {};
-
 ```
 
 :::
@@ -48,7 +40,27 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-iterator: "error"*/
 
-const __iterator__ = foo; // Not using the `__iterator__` property.
+// Use the standard Symbol.iterator protocol instead
+Foo.prototype[Symbol.iterator] = function() {
+    let index = 0;
+    const items = this.items;
+    return {
+        next() {
+            return index < items.length
+                ? { value: items[index++], done: false }
+                : { done: true };
+        }
+    };
+};
+
+// Use a generator function
+function* generateItems(arr) {
+    for (const item of arr) {
+        yield item;
+    }
+}
+
+const __iterator__ = foo; // Assigning to a variable named __iterator__ is fine.
 ```
 
 :::
@@ -56,3 +68,7 @@ const __iterator__ = foo; // Not using the `__iterator__` property.
 ## Options
 
 This rule has no options.
+
+## When Not To Use It
+
+This rule should not be disabled in modern codebases. If you need to support very old environments where `Symbol.iterator` is unavailable and `__iterator__` was already in use, you may disable this rule, though migrating to the standard iteration protocol is strongly recommended.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- Please fill out the following to help us review this PR -->

## Summary

Improves the \
o-iterator\ rule documentation to align with the standardized rule documentation format proposed in issue #16474.

**Changes made:**

1. **Frontmatter**: Added \elated_rules\ linking to \
o-proto\ (both rules target obsolete property access patterns)
2. **Intro paragraph**: Tightened the opening description — removed redundant example code block from the intro (which was just noise before \## Rule Details\)
3. **Rule Details**: Rewrote to be more direct and concise per template guidance
4. **Correct examples**: Expanded to show the *actual modern alternatives* — \Symbol.iterator\ protocol and generator functions — so readers understand what to use instead, not just what to avoid
5. **Options**: Kept as-is (no options)
6. **When Not To Use It**: Added this missing section, which is part of the standardized template

## Related Issues

Closes #16474

## Checklist

- [x] Documentation only change (no source code changes)
- [x] Follows the page-level outline defined in the discussion: https://github.com/eslint/eslint/discussions/16643
- [x] \## Rule Details\ section present
- [x] \## Options\ section present
- [x] \## When Not To Use It\ section added
- [x] \elated_rules\ frontmatter added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `no-iterator` rule documentation with clearer, more concise guidance.
  * Added a link to the related `no-proto` rule.
  * Revised examples to demonstrate `Symbol.iterator`, generator functions, and valid variable naming.
  * Clarified warning behavior and documented the legacy-environment exception, including migration guidance.
  * Removed the outdated `__iterator__` example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->