### PR TITLE
feat: report unsafe labeled `continue` in `no-unsafe-finally` rule

### DIFF
--- a/lib/rules/no-unsafe-finally.js
+++ b/lib/rules/no-unsafe-finally.js
@@ -62,7 +62,7 @@ module.exports = {
 
 			if (node.type === "BreakStatement" && !node.label) {
 				sentinelNodeType = SENTINEL_NODE_TYPE_BREAK;
-			} else if (node.type === "ContinueStatement") {
+			} else if (node.type === "ContinueStatement" && !node.label) {
 				sentinelNodeType = SENTINEL_NODE_TYPE_CONTINUE;
 			} else {
 				sentinelNodeType = SENTINEL_NODE_TYPE_RETURN_THROW;

--- a/tests/lib/rules/no-unsafe-finally.js
+++ b/tests/lib/rules/no-unsafe-finally.js
@@ -28,6 +28,7 @@ ruleTester.run("no-unsafe-finally", rule, {
 		"var foo = function() { try { return 1 } catch(err) { return 2 } finally { var a = function(x) { label: while(true) { if(x) { break label; } else { continue } } } } }",
 		"var foo = function() { try {} finally { while (true) break; } }",
 		"var foo = function() { try {} finally { while (true) continue; } }",
+		"var foo = function() { try { return 1; } finally { a: while (true) { while (true) continue a; } } }",
 		"var foo = function() { try {} finally { switch (true) { case true: break; } } }",
 		"var foo = function() { try {} finally { do { break; } while (true) } }",
 		{
@@ -168,6 +169,19 @@ ruleTester.run("no-unsafe-finally", rule, {
 					data: { nodeType: "ContinueStatement" },
 					line: 1,
 					column: 54,
+				},
+			],
+		},
+		{
+			code: "var foo = function() { a: while (true) try {} finally { while (true) continue a; } }",
+			errors: [
+				{
+					messageId: "unsafeUsage",
+					data: { nodeType: "ContinueStatement" },
+					line: 1,
+					column: 70,
+					endLine: 1,
+					endColumn: 81,
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

<!--
    The following template is intentionally not a markdown checkbox list for the reasons
    explained in https://github.com/eslint/eslint/pull/12848#issuecomment-580302888
-->

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/HEAD/templates/rule-change-proposal.md))
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Fixed the `no-unsafe-finally` rule to report labeled `continue` statements that exit a `finally` block, and added tests.

Fixes #21314 

#### Is there anything you'd like reviewers to focus on?

The invalid test uses the example from the comment on the earlier PR referenced in the issue #21314.

<!-- markdownlint-disable-file MD004 -->

<hr />

Disclosure: I'm a participant of [open source contribution program OSSCA](https://github.com/eslint-ossca)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of labeled `continue` statements within `finally` blocks.
  - The `no-unsafe-finally` rule now correctly distinguishes safe labeled continues from continues that exit an outer loop, providing more accurate warnings.

- **Tests**
  - Added coverage for valid nested-loop usage and invalid labeled continues that leave the enclosing loop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->