### PR TITLE
perf: index previous tests in no-duplicate-case

### DIFF
--- a/lib/rules/no-duplicate-case.js
+++ b/lib/rules/no-duplicate-case.js
@@ -7,12 +7,6 @@
 "use strict";
 
 //------------------------------------------------------------------------------
-// Requirements
-//------------------------------------------------------------------------------
-
-const astUtils = require("./utils/ast-utils");
-
-//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -38,37 +32,36 @@ module.exports = {
 		const sourceCode = context.sourceCode;
 
 		/**
-		 * Determines whether the two given nodes are considered to be equal.
-		 * @param {ASTNode} a First node.
-		 * @param {ASTNode} b Second node.
-		 * @returns {boolean} `true` if the nodes are considered to be equal.
+		 * Builds the key that two nodes share exactly when the rule considers
+		 * them equal: the same node type and the same sequence of token types
+		 * and values.
+		 * @param {ASTNode} node The node to describe.
+		 * @returns {string} A key that is equal for equal nodes only.
 		 */
-		function equal(a, b) {
-			if (a.type !== b.type) {
-				return false;
+		function keyOf(node) {
+			let key = node.type;
+
+			for (const token of sourceCode.getTokens(node)) {
+				key += `\0${token.type}\0${token.value}`;
 			}
 
-			return astUtils.equalTokens(a, b, sourceCode);
+			return key;
 		}
 		return {
 			SwitchStatement(node) {
-				const previousTests = [];
+				const previousTests = new Set();
 
 				for (const switchCase of node.cases) {
 					if (switchCase.test) {
-						const test = switchCase.test;
+						const key = keyOf(switchCase.test);
 
-						if (
-							previousTests.some(previousTest =>
-								equal(previousTest, test),
-							)
-						) {
+						if (previousTests.has(key)) {
 							context.report({
 								node: switchCase,
 								messageId: "unexpected",
 							});
 						} else {
-							previousTests.push(test);
+							previousTests.add(key);
 						}
 					}
 				}


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix
[ ] New rule
[ ] Changes an existing rule
[ ] Add autofix to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain: performance of an existing rule, with no behavior change

#### What changes did you make? (Give an overview)

`no-duplicate-case` compares each `case` test against every earlier one with
`previousTests.some(previousTest => equal(previousTest, test))`, and `equal()`
walks both token lists through `astUtils.equalTokens`. That is
O(cases² × tokens) for a switch with no duplicates, which is the normal case.

This builds one key per test — the node type followed by the type and value of
each of its tokens — and keeps them in a `Set`. Two nodes produce the same key
exactly when the old `equal()` returned true for them, since `equal()` was
precisely "same node type and same sequence of token types and values", so the
reported duplicates are unchanged. Each test is now tokenized once instead of
once per earlier case.

All 29 existing rule tests pass unchanged. I did not add tests because the
behavior is identical and those tests already pin it; happy to add cases if
you would like the equivalence itself covered.

Measured on a switch of non-duplicate cases, rule time only (linting the same
source with the rule off subtracted, so parsing is excluded):

| cases | before | after | |
|---:|---:|---:|---:|
| 20 | 0.088 ms | 0.085 ms | 1.0x |
| 50 | 0.277 ms | 0.190 ms | 1.5x |
| 200 | 3.357 ms | 0.751 ms | 4.5x |
| 600 | 19.745 ms | 2.061 ms | 9.6x |

Being straight about the size question: a hand-written switch of a handful of
cases sees no measurable difference. The change matters for the large generated
switches — parsers, state machines, lookup tables — where the quadratic term
starts to show, and it costs nothing at small sizes.

#### Is there anything you'd like reviewers to focus on?

Whether the key is a faithful stand-in for `equal()`. It relies on `equal()`
being exactly equality of the pair (node type, token type/value sequence); if
there is a case where two nodes should compare equal despite differing on that
pair, the key needs to change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate `case` detection for more consistent results.
* **Chores**
  * Reduced internal dependency usage without changing any public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->